### PR TITLE
Restructure documentation and add CLI binary support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 agent-lint contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ npx agent-lint CLAUDE.md packages/api/CLAUDE.md --follow-symlinks
 
 ### Options
 
-| Flag | Description |
-| ---- | ----------- |
+| Flag                | Description                                                                    |
+| ------------------- | ------------------------------------------------------------------------------ |
 | `--follow-symlinks` | Resolve and validate symlinked files. Without this flag, symlinks are skipped. |
 
 If no paths are provided, defaults to `CLAUDE.md`.
@@ -188,12 +188,12 @@ Exit codes: `0` on success, `1` if any rules are missing annotations.
 
 `agent-lint` works with any markdown file that follows the `###` heading + `**Enforced by:**` / `**Guidance only**` format. Here are the common instruction files by tool:
 
-| Tool | Instruction File | Example |
-| ---- | ---------------- | ------- |
-| Claude Code | `CLAUDE.md` | `npx agent-lint CLAUDE.md` |
-| OpenAI Codex | `AGENTS.md` | `npx agent-lint AGENTS.md` |
-| Cursor | `.cursorrules` | `npx agent-lint .cursorrules` |
-| Custom | any `.md` file | `npx agent-lint my-instructions.md` |
+| Tool         | Instruction File | Example                             |
+| ------------ | ---------------- | ----------------------------------- |
+| Claude Code  | `CLAUDE.md`      | `npx agent-lint CLAUDE.md`          |
+| OpenAI Codex | `AGENTS.md`      | `npx agent-lint AGENTS.md`          |
+| Cursor       | `.cursorrules`   | `npx agent-lint .cursorrules`       |
+| Custom       | any `.md` file   | `npx agent-lint my-instructions.md` |
 
 Validate multiple files across tools in a single run:
 

--- a/README.md
+++ b/README.md
@@ -115,13 +115,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: zernie/agent-lint@v1.0
+      - uses: zernie/agent-lint@main
 ```
 
 By default the action validates `CLAUDE.md`. Pass `paths` to validate other files:
 
 ```yaml
-- uses: zernie/agent-lint@v1.0
+- uses: zernie/agent-lint@main
   with:
     paths: "CLAUDE.md,AGENTS.md,.cursorrules"
 ```
@@ -129,7 +129,7 @@ By default the action validates `CLAUDE.md`. Pass `paths` to validate other file
 Multiple files (monorepo):
 
 ```yaml
-- uses: zernie/agent-lint@v1.0
+- uses: zernie/agent-lint@main
   with:
     paths: "CLAUDE.md,packages/api/CLAUDE.md,packages/web/CLAUDE.md"
 ```
@@ -137,7 +137,7 @@ Multiple files (monorepo):
 Follow symlinks (e.g. shared instruction file symlinked into subdirectories):
 
 ```yaml
-- uses: zernie/agent-lint@v1.0
+- uses: zernie/agent-lint@main
   with:
     paths: "CLAUDE.md,packages/api/CLAUDE.md"
     follow-symlinks: "true"
@@ -157,7 +157,7 @@ The action sets the following outputs, accessible via `steps.<id>.outputs.<name>
 | `valid`    | `true` if all rules have annotations     |
 
 ```yaml
-- uses: zernie/agent-lint@v1.0
+- uses: zernie/agent-lint@main
   id: lint
 - if: always()
   run: |
@@ -198,7 +198,7 @@ Exit codes: `0` on success, `1` if any rules are missing annotations.
 Validate multiple files across tools in a single run:
 
 ```yaml
-- uses: zernie/agent-lint@v1.0
+- uses: zernie/agent-lint@main
   with:
     paths: "CLAUDE.md,AGENTS.md,.cursorrules"
 ```

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ node validate.mjs AGENTS.md
 ```
 
 ```yaml
-- uses: zernie/agent-lint@v1
+- uses: zernie/agent-lint@v1.0
   with:
     paths: "AGENTS.md"
 ```
@@ -150,7 +150,7 @@ node validate.mjs .cursorrules
 ```
 
 ```yaml
-- uses: zernie/agent-lint@v1
+- uses: zernie/agent-lint@v1.0
   with:
     paths: ".cursorrules"
 ```
@@ -166,7 +166,7 @@ node validate.mjs my-instructions.md
 You can validate multiple files across tools in a single run:
 
 ```yaml
-- uses: zernie/agent-lint@v1
+- uses: zernie/agent-lint@v1.0
   with:
     paths: "CLAUDE.md,AGENTS.md,.cursorrules"
 ```
@@ -182,13 +182,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: zernie/agent-lint@v1
+      - uses: zernie/agent-lint@v1.0
 ```
 
 By default the action validates `CLAUDE.md`. Pass `paths` to validate other files:
 
 ```yaml
-- uses: zernie/agent-lint@v1
+- uses: zernie/agent-lint@v1.0
   with:
     paths: "CLAUDE.md,AGENTS.md,.cursorrules"
 ```
@@ -196,7 +196,7 @@ By default the action validates `CLAUDE.md`. Pass `paths` to validate other file
 Multiple files (monorepo):
 
 ```yaml
-- uses: zernie/agent-lint@v1
+- uses: zernie/agent-lint@v1.0
   with:
     paths: "CLAUDE.md,packages/api/CLAUDE.md,packages/web/CLAUDE.md"
 ```
@@ -204,7 +204,7 @@ Multiple files (monorepo):
 Follow symlinks (e.g. shared instruction file symlinked into subdirectories):
 
 ```yaml
-- uses: zernie/agent-lint@v1
+- uses: zernie/agent-lint@v1.0
   with:
     paths: "CLAUDE.md,packages/api/CLAUDE.md"
     follow-symlinks: "true"
@@ -224,7 +224,7 @@ The action sets the following outputs, accessible via `steps.<id>.outputs.<name>
 | `valid`    | `true` if all rules have annotations     |
 
 ```yaml
-- uses: zernie/agent-lint@v1
+- uses: zernie/agent-lint@v1.0
   id: lint
 - if: always()
   run: |

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ ESLint for AI agents — validate your instruction files, audit your feedback lo
 
 Companion repo for [Feedback Loop Is All You Need](https://zernie.com/blog/feedback-loop-is-all-you-need).
 
+## Table of Contents
+
+- [Why](#why)
+- [Quick Start](#quick-start)
+- [Instruction File Format](#instruction-file-format)
+- [GitHub Action](#github-action)
+- [CLI](#cli)
+- [Supported Tools](#supported-tools)
+- [Installing Skills](#installing-skills)
+- [Maturity Levels](#maturity-levels)
+- [License](#license)
+
 ## Why
 
 AI coding agents work best when they get deterministic feedback — linters, type checkers, CI. Without it, they drift from conventions and produce code that "works" but doesn't fit your codebase.
@@ -15,6 +27,47 @@ AI coding agents work best when they get deterministic feedback — linters, typ
 3. **Lint rule generation** — turn recurring PR review comments into automated enforcement
 
 Works with any AI agent instruction file — CLAUDE.md, AGENTS.md, .cursorrules, or your own convention.
+
+## Quick Start
+
+```bash
+# Validate your instruction file
+npx agent-lint CLAUDE.md
+```
+
+Example output when validation fails:
+
+```
+Validation Report: CLAUDE.md
+========================================
+  Total rules:    3
+  Enforced:       1
+  Guidance only:  0
+  Disabled:       0
+  Missing:        2
+========================================
+
+Rules missing enforcement annotations:
+  Line 12: "No console.log in production"
+  Line 18: "Use Tailwind spacing scale"
+
+Add **Enforced by:** `<rule>` or **Guidance only** to each rule.
+```
+
+When all rules pass:
+
+```
+Validation Report: CLAUDE.md
+========================================
+  Total rules:    3
+  Enforced:       2
+  Guidance only:  1
+  Disabled:       0
+  Missing:        0
+========================================
+
+All rules have enforcement annotations.
+```
 
 ## Instruction File Format
 
@@ -50,126 +103,6 @@ To skip validation for a specific rule, add an HTML comment below the heading:
 ```
 
 This works like `eslint-disable-next-line` — the rule is recognized but excluded from validation. Use sparingly.
-
-## Installing Skills
-
-Install skills for all your AI agents at once with [Vercel Skills](https://github.com/vercel-labs/skills):
-
-```bash
-npx skills add zernie/agent-lint
-```
-
-This auto-detects your installed agents and installs the skills for each one. Works with Claude Code, Codex, Cursor, GitHub Copilot, Windsurf, and [many more](https://skills.sh).
-
-### Available Skills
-
-**`audit-feedback-loop`** — Scans your repo and scores its feedback loop maturity:
-
-| Level | Name                 | Description                                                         |
-| ----- | -------------------- | ------------------------------------------------------------------- |
-| 0     | Vibes                | No CI, no linters, no CLAUDE.md                                     |
-| 1     | Guardrails           | CI + standard linters, no custom rules                              |
-| 2     | Architecture as Code | Custom lint rules + enforced CLAUDE.md                              |
-| 3     | The Organism         | CI + custom rules + visual tests + observability + scheduled agents |
-
-Works with any language — detects ESLint, Ruff, Clippy, golangci-lint, RuboCop, and more.
-
-**`pr-to-lint-rule`** — Takes a natural language description of a recurring PR comment and generates:
-
-- A lint rule for your language/toolchain (ESLint, Ruff, Clippy, go/analysis, etc.)
-- Test cases
-- Integration instructions
-- A CLAUDE.md annotation block
-
-Example:
-
-```
-/pr-to-lint-rule we keep telling people not to import directly from antd, use our design system barrel file instead
-```
-
-**`enforce-rules-format`** — Validates that every `###` rule in your instruction files has an `**Enforced by:**` or `**Guidance only**` annotation. Finds missing annotations, suggests fixes based on your linter config, and verifies the result passes validation.
-
-Example:
-
-```
-/enforce-rules-format
-```
-
-## Claude Code
-
-Skills installed via `npx skills add` are available as `/audit-feedback-loop`, `/pr-to-lint-rule`, and `/enforce-rules-format`.
-
-### Automatic Validation Hook
-
-When installed as a plugin, agent-lint automatically registers a PostToolUse hook that validates CLAUDE.md after every file edit. If a rule is missing its annotation, the agent gets immediate feedback and can fix the format before it reaches CI.
-
-To set this up manually instead (e.g. without the plugin), add to your project's `.claude/settings.json`:
-
-```json
-{
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Edit|Write",
-        "command": "node validate.mjs CLAUDE.md"
-      }
-    ]
-  }
-}
-```
-
-Alternatively, install via the Claude Code plugin system:
-
-```
-/plugin marketplace add zernie/agent-lint
-/plugin install agent-lint@agent-lint
-```
-
-Or manually copy skills into your project's `.claude/skills/` directory.
-
-## OpenAI Codex
-
-Codex uses `AGENTS.md` for agent instructions. Use the same enforcement annotation format, then validate:
-
-```bash
-node validate.mjs AGENTS.md
-```
-
-```yaml
-- uses: zernie/agent-lint@v1.0
-  with:
-    paths: "AGENTS.md"
-```
-
-## Cursor
-
-Cursor uses `.cursorrules` for agent instructions. Use the same enforcement annotation format, then validate:
-
-```bash
-node validate.mjs .cursorrules
-```
-
-```yaml
-- uses: zernie/agent-lint@v1.0
-  with:
-    paths: ".cursorrules"
-```
-
-## Other Tools
-
-`agent-lint` works with any markdown file that follows the `###` heading + `**Enforced by:**` / `**Guidance only**` format. Pass any file path to the CLI or GitHub Action:
-
-```bash
-node validate.mjs my-instructions.md
-```
-
-You can validate multiple files across tools in a single run:
-
-```yaml
-- uses: zernie/agent-lint@v1.0
-  with:
-    paths: "CLAUDE.md,AGENTS.md,.cursorrules"
-```
 
 ## GitHub Action
 
@@ -236,31 +169,126 @@ The action sets the following outputs, accessible via `steps.<id>.outputs.<name>
 ## CLI
 
 ```bash
-node validate.mjs CLAUDE.md
-node validate.mjs AGENTS.md .cursorrules
-node validate.mjs CLAUDE.md packages/api/CLAUDE.md --follow-symlinks
+npx agent-lint CLAUDE.md
+npx agent-lint AGENTS.md .cursorrules
+npx agent-lint CLAUDE.md packages/api/CLAUDE.md --follow-symlinks
+```
+
+### Options
+
+| Flag | Description |
+| ---- | ----------- |
+| `--follow-symlinks` | Resolve and validate symlinked files. Without this flag, symlinks are skipped. |
+
+If no paths are provided, defaults to `CLAUDE.md`.
+
+Exit codes: `0` on success, `1` if any rules are missing annotations.
+
+## Supported Tools
+
+`agent-lint` works with any markdown file that follows the `###` heading + `**Enforced by:**` / `**Guidance only**` format. Here are the common instruction files by tool:
+
+| Tool | Instruction File | Example |
+| ---- | ---------------- | ------- |
+| Claude Code | `CLAUDE.md` | `npx agent-lint CLAUDE.md` |
+| OpenAI Codex | `AGENTS.md` | `npx agent-lint AGENTS.md` |
+| Cursor | `.cursorrules` | `npx agent-lint .cursorrules` |
+| Custom | any `.md` file | `npx agent-lint my-instructions.md` |
+
+Validate multiple files across tools in a single run:
+
+```yaml
+- uses: zernie/agent-lint@v1.0
+  with:
+    paths: "CLAUDE.md,AGENTS.md,.cursorrules"
+```
+
+### Claude Code Integration
+
+Skills installed via `npx skills add` are available as `/audit-feedback-loop`, `/pr-to-lint-rule`, and `/enforce-rules-format`.
+
+#### Automatic Validation Hook
+
+When installed as a plugin, agent-lint automatically registers a PostToolUse hook that validates CLAUDE.md after every file edit. If a rule is missing its annotation, the agent gets immediate feedback and can fix the format before it reaches CI.
+
+To set this up manually instead (e.g. without the plugin), add to your project's `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "command": "npx agent-lint CLAUDE.md"
+      }
+    ]
+  }
+}
+```
+
+Alternatively, install via the Claude Code plugin system:
+
+```
+/plugin marketplace add zernie/agent-lint
+/plugin install agent-lint@agent-lint
+```
+
+Or manually copy skills into your project's `.claude/skills/` directory.
+
+## Installing Skills
+
+Install skills for all your AI agents at once with [Vercel Skills](https://github.com/vercel-labs/skills):
+
+```bash
+npx skills add zernie/agent-lint
+```
+
+This auto-detects your installed agents and installs the skills for each one. Works with Claude Code, Codex, Cursor, GitHub Copilot, Windsurf, and [many more](https://skills.sh).
+
+### Available Skills
+
+**`audit-feedback-loop`** — Scans your repo and scores its feedback loop maturity (see [Maturity Levels](#maturity-levels)). Works with any language — detects ESLint, Ruff, Clippy, golangci-lint, RuboCop, and more.
+
+**`pr-to-lint-rule`** — Takes a natural language description of a recurring PR comment and generates:
+
+- A lint rule for your language/toolchain (ESLint, Ruff, Clippy, go/analysis, etc.)
+- Test cases
+- Integration instructions
+- A CLAUDE.md annotation block
+
+Example:
+
+```
+/pr-to-lint-rule we keep telling people not to import directly from antd, use our design system barrel file instead
+```
+
+**`enforce-rules-format`** — Validates that every `###` rule in your instruction files has an `**Enforced by:**` or `**Guidance only**` annotation. Finds missing annotations, suggests fixes based on your linter config, and verifies the result passes validation.
+
+Example:
+
+```
+/enforce-rules-format
 ```
 
 ## Maturity Levels
 
 From the [article](https://zernie.com/blog/feedback-loop-is-all-you-need) — the four levels of feedback loop maturity:
 
-### Level 0: Vibes
+| Level | Name                 | Description                                                         |
+| ----- | -------------------- | ------------------------------------------------------------------- |
+| 0     | Vibes                | No CI, no linters, no CLAUDE.md                                     |
+| 1     | Guardrails           | CI + standard linters, no custom rules                              |
+| 2     | Architecture as Code | Custom lint rules + enforced CLAUDE.md                              |
+| 3     | The Organism         | CI + custom rules + visual tests + observability + scheduled agents |
 
-The agent writes code, you eyeball it. No automated checks.
+**Level 0: Vibes** — The agent writes code, you eyeball it. No automated checks.
 
-### Level 1: Guardrails
+**Level 1: Guardrails** — Standard CI — default linter rules, type checking, basic tests. The agent gets red/green signals but can't learn your conventions.
 
-Standard CI — default linter rules, type checking, basic tests. The agent gets red/green signals but can't learn your conventions.
+**Level 2: Architecture as Code** — Custom lint rules encode your team's decisions. CLAUDE.md rules reference actual enforcement. The agent understands _why_ things are done a certain way.
 
-### Level 2: Architecture as Code
-
-Custom lint rules encode your team's decisions. CLAUDE.md rules reference actual enforcement. The agent understands _why_ things are done a certain way.
-
-### Level 3: The Organism
-
-Everything is instrumented. Visual regression tests catch UI drift. Observability SDKs flag runtime issues. Scheduled agents monitor and maintain. The codebase evolves with feedback at every layer.
+**Level 3: The Organism** — Everything is instrumented. Visual regression tests catch UI drift. Observability SDKs flag runtime issues. Scheduled agents monitor and maintain. The codebase evolves with feedback at every layer.
 
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "agent-lint",
   "private": true,
+  "bin": {
+    "agent-lint": "./validate.mjs"
+  },
   "scripts": {
     "test": "node --test validate.test.mjs",
     "fmt": "prettier --write .",

--- a/validate.mjs
+++ b/validate.mjs
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { readFileSync, lstatSync } from "node:fs";
 
 const ENFORCED_BY_RE = /\*\*Enforced by:\*\*/;
@@ -175,7 +177,8 @@ function printResult(filePath, result) {
 if (
   process.argv[1] &&
   (process.argv[1].endsWith("validate.mjs") ||
-    process.argv[1].endsWith("validate"))
+    process.argv[1].endsWith("validate") ||
+    process.argv[1].endsWith("agent-lint"))
 ) {
   const args = process.argv.slice(2);
   const followSymlinks = args.includes("--follow-symlinks");


### PR DESCRIPTION
## Summary
This PR reorganizes the README with a table of contents, adds comprehensive documentation for Quick Start, GitHub Actions, and CLI usage, and makes `agent-lint` executable as a CLI tool via npm.

## Key Changes

- **Added Table of Contents** to README for better navigation
- **Added Quick Start section** with example validation output for both passing and failing cases
- **Reorganized documentation structure**:
  - Moved GitHub Action section earlier in the document
  - Created dedicated CLI section with usage examples and options
  - Created Supported Tools section consolidating tool-specific instructions
  - Moved Installing Skills section after Supported Tools
  - Reformatted Maturity Levels as a table with expanded descriptions
- **Made `agent-lint` executable as a CLI binary**:
  - Added shebang (`#!/usr/bin/env node`) to `validate.mjs`
  - Added `bin` field to `package.json` pointing to `validate.mjs`
  - Updated CLI entry point detection to recognize `agent-lint` command
- **Added MIT LICENSE file** with standard copyright and permissions
- **Updated documentation examples** to use `npx agent-lint` instead of `node validate.mjs`

## Implementation Details

The CLI binary support allows users to run `npx agent-lint CLAUDE.md` directly without needing to reference the underlying script file. The shebang and package.json bin configuration enable this standard npm package behavior.

The documentation restructuring improves discoverability by front-loading practical usage examples (Quick Start) before diving into tool-specific integrations, while maintaining comprehensive reference material.

https://claude.ai/code/session_019vutbMWLsGXzQ7SC2ygwXT