### PR TITLE
Add glob support, linter validation, agent detection, zero-config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,35 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: "npm"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+
+      - name: Cache pip packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-ruff-pylint
+
+      - name: Cache gem packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/gem
+          key: gem-${{ runner.os }}-rubocop
 
       - run: npm ci
+
+      - name: Install linter CLIs for tests
+        run: |
+          pip install ruff pylint
+          gem install rubocop
+          rustup component add clippy
 
       - name: Run tests
         run: npm test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ Named validation rules (togglable in config under `rules`):
 
 - `require-annotations` (default: `true`) — every rule marker needs an enforcement annotation
 - `max-lines` (default: `500`) — caps file length; set a number for custom limit, `false` to disable
+- `require-rule-file` (default: `"auto"`) — validates referenced linter rules exist; auto-detects eslint, stylelint, ruff, clippy, pylint
 
 ## Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,13 @@ agent-lint — ESLint for AI agents. Validates that instruction files (CLAUDE.md
 - `node validate.mjs CLAUDE.md` — Validate this file
 - `node validate.mjs --markers=headings,checkboxes CLAUDE.md` — Validate with both marker types
 
+## Principles
+
+### Zero config by default
+
+**Enforced by:** `code-review`
+**Why:** agent-lint should work out of the box with no config file and no CLI flags. Auto-detect instruction files, linters, and rule markers. Config exists only for overrides, not for basic operation.
+
 ## Architecture
 
 Single-file core (`validate.mjs`). Exports: `parseClaudeMd`, `validate`, `readClaudeMd`, `validatePaths`, `loadConfig`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Named validation rules (togglable in config under `rules`):
 
 - `require-annotations` (default: `true`) — every rule marker needs an enforcement annotation
 - `max-lines` (default: `500`) — caps file length; set a number for custom limit, `false` to disable
-- `require-rule-file` (default: `"auto"`) — validates referenced linter rules exist; auto-detects eslint, stylelint, ruff, clippy, pylint
+- `require-rule-file` (default: `"auto"`) — validates referenced linter rules exist; auto-detects eslint, stylelint, ruff, clippy, pylint, rubocop
 
 ## Rules
 

--- a/README.md
+++ b/README.md
@@ -272,6 +272,10 @@ Enable checkbox markers:
     markers: "headings,checkboxes"
 ```
 
+### Inline PR Annotations
+
+Errors appear as inline annotations directly on the affected lines in the PR **Files** tab — just like ESLint. No extra tools or configuration needed.
+
 ### Action Outputs
 
 The action sets the following outputs, accessible via `steps.<id>.outputs.<name>`:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ AI coding agents work best with deterministic feedback — linters, type checker
 
 The problem: teams write rules in CLAUDE.md or AGENTS.md like "always use barrel imports" but never wire them to actual linters. The rules rot. The agent ignores them. Nobody notices until the codebase diverges.
 
+On bigger teams this gets worse — different engineers use different agents (Claude Code, Cursor, Codex, Copilot), each with its own instruction file format. Without validation, some agents get well-maintained rules while others get stale or missing files. `agent-lint` detects every agent tool configured in your repo and ensures each one has an up-to-date, properly annotated instruction file.
+
 `agent-lint` closes this gap:
 
 1. **Every rule must cite its enforcer** — `**Enforced by:** \`eslint/no-restricted-imports\``or`**Guidance only**`
@@ -105,7 +107,7 @@ To skip validation for a specific rule:
 
 ## Agent Detection
 
-agent-lint detects which AI coding tools are configured in your project and requires their instruction files to exist:
+In a team where some engineers use Claude Code, others use Cursor, and CI runs Codex, you need instruction files for all of them. agent-lint detects which tools are configured and requires their instruction files to exist:
 
 | Tool           | Detected by                       | Required file                     |
 | -------------- | --------------------------------- | --------------------------------- |
@@ -116,9 +118,9 @@ agent-lint detects which AI coding tools are configured in your project and requ
 | GitHub Copilot | `.github/copilot-instructions.md` | `.github/copilot-instructions.md` |
 | Cline          | `.clinerules` file                | `.clinerules`                     |
 
-If `.claude/` exists but `CLAUDE.md` doesn't, agent-lint errors — ensuring you don't forget to create instruction files for tools you've set up.
+If `.claude/` exists but `CLAUDE.md` doesn't, agent-lint errors — so when someone adds a new agent tool to the repo, CI catches the missing instruction file before it ships.
 
-To explicitly require specific tools (even without their config directories):
+To explicitly require specific tools across the team (even without their config directories):
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Works with any AI agent instruction file — CLAUDE.md, AGENTS.md, .cursorrules,
 ## Quick Start
 
 ```bash
-# Validate your instruction file
-npx agent-lint CLAUDE.md
+# Auto-discovers CLAUDE.md, AGENTS.md, .cursorrules, etc.
+npx agent-lint
 ```
 
 Example output when validation fails:
@@ -116,22 +116,21 @@ This works like `eslint-disable-next-line` — the rule is recognized but exclud
 
 ## Configuration
 
-Create a `.agent-lintrc.json` in your project root:
+agent-lint works with zero configuration. Optionally create a `.agent-lintrc.json` to override defaults:
 
 ```json
 {
-  "ruleMarkers": ["headings", "checkboxes"],
+  "ruleMarkers": ["headings"],
   "rules": {
-    "require-annotations": true,
-    "max-lines": 500
+    "max-lines": 300
   }
 }
 ```
 
-| Option        | Default        | Description                                                                                        |
-| ------------- | -------------- | -------------------------------------------------------------------------------------------------- |
-| `ruleMarkers` | `["headings"]` | Which rule marker types to recognize: `headings`, `checkboxes`, or both                            |
-| `linters`     | `{}`           | Per-linter config for rule file validation (see [Linter Rule Validation](#linter-rule-validation)) |
+| Option        | Default                      | Description                                                                                        |
+| ------------- | ---------------------------- | -------------------------------------------------------------------------------------------------- |
+| `ruleMarkers` | `["headings", "checkboxes"]` | Which rule marker types to recognize: `headings`, `checkboxes`, or both                            |
+| `linters`     | `{}`                         | Per-linter config for rule file validation (see [Linter Rule Validation](#linter-rule-validation)) |
 
 ### Rules
 
@@ -172,11 +171,11 @@ Set `require-rule-file` to `false` to disable all rule file checking.
 ## CLI
 
 ```bash
-# Validate a single file
-npx agent-lint CLAUDE.md
+# Auto-discover and validate all instruction files
+npx agent-lint
 
-# Validate multiple files
-npx agent-lint CLAUDE.md AGENTS.md .cursorrules
+# Validate a specific file
+npx agent-lint CLAUDE.md
 
 # Monorepo — validate across packages
 npx agent-lint CLAUDE.md packages/api/CLAUDE.md packages/web/CLAUDE.md
@@ -185,10 +184,10 @@ npx agent-lint CLAUDE.md packages/api/CLAUDE.md packages/web/CLAUDE.md
 npx agent-lint "**/*.md"
 
 # Follow symlinks
-npx agent-lint CLAUDE.md --follow-symlinks
+npx agent-lint --follow-symlinks
 
-# Override rule markers (without a config file)
-npx agent-lint CLAUDE.md --markers=headings,checkboxes
+# Override rule markers
+npx agent-lint --markers=headings
 ```
 
 ### Options
@@ -259,13 +258,7 @@ jobs:
       - uses: zernie/agent-lint@main
 ```
 
-By default the action validates `CLAUDE.md`. Pass `paths` to validate other files:
-
-```yaml
-- uses: zernie/agent-lint@main
-  with:
-    paths: "CLAUDE.md,AGENTS.md,.cursorrules"
-```
+By default the action auto-discovers instruction files (CLAUDE.md, AGENTS.md, .cursorrules, etc.). Pass `paths` to override:
 
 Multiple files (monorepo):
 
@@ -353,21 +346,22 @@ The action sets the following outputs, accessible via `steps.<id>.outputs.<name>
 
 ## Supported Tools
 
-`agent-lint` works with any markdown file that follows the `###` heading + `**Enforced by:**` / `**Guidance only**` format. Here are the common instruction files by tool:
+`agent-lint` auto-discovers instruction files for all major AI coding tools. No configuration needed — just run `npx agent-lint` and it finds what's in your repo:
 
-| Tool         | Instruction File | Example                             |
-| ------------ | ---------------- | ----------------------------------- |
-| Claude Code  | `CLAUDE.md`      | `npx agent-lint CLAUDE.md`          |
-| OpenAI Codex | `AGENTS.md`      | `npx agent-lint AGENTS.md`          |
-| Cursor       | `.cursorrules`   | `npx agent-lint .cursorrules`       |
-| Custom       | any `.md` file   | `npx agent-lint my-instructions.md` |
+| Tool           | Instruction File                  | Auto-discovered |
+| -------------- | --------------------------------- | --------------- |
+| Claude Code    | `CLAUDE.md`                       | Yes             |
+| OpenAI Codex   | `AGENTS.md`                       | Yes             |
+| Cursor         | `.cursorrules`                    | Yes             |
+| GitHub Copilot | `.github/copilot-instructions.md` | Yes             |
+| Windsurf       | `.windsurfrules`                  | Yes             |
+| Cline          | `.clinerules`                     | Yes             |
+| Custom         | any `.md` file                    | Pass explicitly |
 
-Validate multiple files across tools in a single run:
+You can also pass explicit paths or globs to validate files not in the auto-discovery list:
 
-```yaml
-- uses: zernie/agent-lint@main
-  with:
-    paths: "CLAUDE.md,AGENTS.md,.cursorrules"
+```bash
+npx agent-lint my-instructions.md
 ```
 
 ### Claude Code Integration

--- a/README.md
+++ b/README.md
@@ -128,18 +128,44 @@ Create a `.agent-lintrc.json` in your project root:
 }
 ```
 
-| Option        | Default        | Description                                                             |
-| ------------- | -------------- | ----------------------------------------------------------------------- |
-| `ruleMarkers` | `["headings"]` | Which rule marker types to recognize: `headings`, `checkboxes`, or both |
+| Option        | Default        | Description                                                                                        |
+| ------------- | -------------- | -------------------------------------------------------------------------------------------------- |
+| `ruleMarkers` | `["headings"]` | Which rule marker types to recognize: `headings`, `checkboxes`, or both                            |
+| `linters`     | `{}`           | Per-linter config for rule file validation (see [Linter Rule Validation](#linter-rule-validation)) |
 
 ### Rules
 
 Rules are named checks that can be toggled individually. Set to `false` to disable.
 
-| Rule                  | Default | Description                                                              |
-| --------------------- | ------- | ------------------------------------------------------------------------ |
-| `require-annotations` | `true`  | Every rule marker must have `**Enforced by:**` or `**Guidance only**`    |
-| `max-lines`           | `500`   | Maximum number of lines allowed per file. Set a number for custom limit. |
+| Rule                  | Default  | Description                                                                       |
+| --------------------- | -------- | --------------------------------------------------------------------------------- |
+| `require-annotations` | `true`   | Every rule marker must have `**Enforced by:**` or `**Guidance only**`             |
+| `max-lines`           | `500`    | Maximum number of lines allowed per file. Set a number for custom limit.          |
+| `require-rule-file`   | `"auto"` | Validates that referenced linter rules actually exist. Auto-detects linter tools. |
+
+### Linter Rule Validation
+
+When `require-rule-file` is `"auto"` (the default), agent-lint automatically detects installed linters and validates that referenced rules exist:
+
+| Linter    | Detection                     | Method                         |
+| --------- | ----------------------------- | ------------------------------ |
+| ESLint    | `eslint` in `node_modules`    | Node API (`builtinRules`)      |
+| Stylelint | `stylelint` in `node_modules` | Node API (`rules` export)      |
+| Ruff      | `ruff` on PATH                | CLI (`ruff rule <name>`)       |
+| Clippy    | `cargo` on PATH               | CLI (`cargo clippy --explain`) |
+| Pylint    | `pylint` on PATH              | CLI (`pylint --help-msg`)      |
+
+For custom or unsupported linters, configure a `rulesDir` to check that rule files exist:
+
+```json
+{
+  "linters": {
+    "my-tool": { "rulesDir": "tools/my-tool/rules/" }
+  }
+}
+```
+
+Set `require-rule-file` to `false` to disable all rule file checking.
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Companion repo for [Feedback Loop Is All You Need](https://zernie.com/blog/feedb
 - [Instruction File Format](#instruction-file-format)
 - [Configuration](#configuration)
 - [CLI](#cli)
+- [Organizing Rules](#organizing-rules)
 - [GitHub Action](#github-action)
 - [Supported Tools](#supported-tools)
 - [Installing Skills](#installing-skills)
@@ -152,6 +153,9 @@ npx agent-lint CLAUDE.md AGENTS.md .cursorrules
 # Monorepo — validate across packages
 npx agent-lint CLAUDE.md packages/api/CLAUDE.md packages/web/CLAUDE.md
 
+# Glob pattern — validate all matching files
+npx agent-lint "**/*.md"
+
 # Follow symlinks
 npx agent-lint CLAUDE.md --follow-symlinks
 
@@ -169,6 +173,49 @@ npx agent-lint CLAUDE.md --markers=headings,checkboxes
 If no paths are provided, defaults to `CLAUDE.md`.
 
 Exit codes: `0` on success, `1` if any rules are missing annotations.
+
+## Organizing Rules
+
+In a monorepo (or any project with subdirectories), use **progressive disclosure** — put universal rules at the root, and context-specific rules in subdirectory files. AI agents read the nearest instruction file plus all parent files, so rules naturally narrow as the agent moves deeper into the tree.
+
+### Example structure
+
+```
+CLAUDE.md                        # Universal: code style, PR conventions, testing
+packages/
+  api/
+    CLAUDE.md                    # API-specific: error handling, DB conventions
+  web/
+    CLAUDE.md                    # Frontend-specific: component patterns, Tailwind usage
+  shared/
+    CLAUDE.md -> ../CLAUDE.md    # Symlink to share rules (use --follow-symlinks)
+```
+
+**Root file** (`CLAUDE.md`) — rules every agent should follow regardless of context:
+
+- Code formatting and linting standards
+- Git commit and PR conventions
+- Testing requirements
+
+**Subdirectory files** (`packages/api/CLAUDE.md`) — rules that only apply in that context:
+
+- API error handling patterns
+- Database query conventions
+- Framework-specific idioms
+
+### Validate all files at once
+
+```bash
+# Glob pattern — finds every CLAUDE.md in the tree
+npx agent-lint "**/CLAUDE.md"
+
+# Or list them explicitly
+npx agent-lint CLAUDE.md packages/api/CLAUDE.md packages/web/CLAUDE.md
+```
+
+### Why this matters
+
+The `max-lines` rule (default: 500 lines) exists because oversized instruction files hurt agent performance — the agent spends tokens parsing rules that aren't relevant to its current task. Progressive disclosure keeps each file focused, which means faster comprehension and fewer irrelevant rules applied.
 
 ## GitHub Action
 
@@ -198,6 +245,14 @@ Multiple files (monorepo):
 - uses: zernie/agent-lint@main
   with:
     paths: "CLAUDE.md,packages/api/CLAUDE.md,packages/web/CLAUDE.md"
+```
+
+Glob pattern:
+
+```yaml
+- uses: zernie/agent-lint@main
+  with:
+    paths: "**/CLAUDE.md"
 ```
 
 Follow symlinks (e.g. shared instruction file symlinked into subdirectories):

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ agent-lint works with zero configuration. Optionally create a `.agent-lintrc.jso
 | ------------- | ---------------------------- | -------------------------------------------------------------------------------------------------- |
 | `ruleMarkers` | `["headings", "checkboxes"]` | Which rule marker types to recognize: `headings`, `checkboxes`, or both                            |
 | `linters`     | `{}`                         | Per-linter config for rule file validation (see [Linter Rule Validation](#linter-rule-validation)) |
+| `agents`      | `null` (auto-detect)         | List of agent tool names to require, or `null` to auto-detect                                      |
 
 ### Rules
 
@@ -346,19 +347,26 @@ The action sets the following outputs, accessible via `steps.<id>.outputs.<name>
 
 ## Supported Tools
 
-`agent-lint` auto-discovers instruction files for all major AI coding tools. No configuration needed — just run `npx agent-lint` and it finds what's in your repo:
+`agent-lint` detects which AI coding tools are configured in your project and validates their instruction files. If a tool is detected but its instruction file is missing, that's an error — ensuring you don't forget to create one.
 
-| Tool           | Instruction File                  | Auto-discovered |
-| -------------- | --------------------------------- | --------------- |
-| Claude Code    | `CLAUDE.md`                       | Yes             |
-| OpenAI Codex   | `AGENTS.md`                       | Yes             |
-| Cursor         | `.cursorrules`                    | Yes             |
-| GitHub Copilot | `.github/copilot-instructions.md` | Yes             |
-| Windsurf       | `.windsurfrules`                  | Yes             |
-| Cline          | `.clinerules`                     | Yes             |
-| Custom         | any `.md` file                    | Pass explicitly |
+| Tool           | Detected by                       | Required file                     |
+| -------------- | --------------------------------- | --------------------------------- |
+| Claude Code    | `.claude/` directory              | `CLAUDE.md`                       |
+| Cursor         | `.cursor/` directory              | `.cursorrules`                    |
+| Windsurf       | `.windsurf/` directory            | `.windsurfrules`                  |
+| OpenAI Codex   | `AGENTS.md` file                  | `AGENTS.md`                       |
+| GitHub Copilot | `.github/copilot-instructions.md` | `.github/copilot-instructions.md` |
+| Cline          | `.clinerules` file                | `.clinerules`                     |
 
-You can also pass explicit paths or globs to validate files not in the auto-discovery list:
+To explicitly require specific tools (even without their config directories):
+
+```json
+{
+  "agents": ["Claude Code", "Cursor"]
+}
+```
+
+You can also pass explicit paths or globs:
 
 ```bash
 npx agent-lint my-instructions.md

--- a/README.md
+++ b/README.md
@@ -147,13 +147,15 @@ Rules are named checks that can be toggled individually. Set to `false` to disab
 
 When `require-rule-file` is `"auto"` (the default), agent-lint automatically detects installed linters and validates that referenced rules exist:
 
-| Linter    | Detection                     | Method                         |
-| --------- | ----------------------------- | ------------------------------ |
-| ESLint    | `eslint` in `node_modules`    | Node API (`builtinRules`)      |
-| Stylelint | `stylelint` in `node_modules` | Node API (`rules` export)      |
-| Ruff      | `ruff` on PATH                | CLI (`ruff rule <name>`)       |
-| Clippy    | `cargo` on PATH               | CLI (`cargo clippy --explain`) |
-| Pylint    | `pylint` on PATH              | CLI (`pylint --help-msg`)      |
+| Linter    | Detection                     | Method                              |
+| --------- | ----------------------------- | ----------------------------------- |
+| ESLint    | `eslint` in `node_modules`    | Node API (`builtinRules` + plugins) |
+| Stylelint | `stylelint` in `node_modules` | Node API (`rules` export)           |
+| Ruff      | `ruff` on PATH                | CLI (`ruff rule <name>`)            |
+| Clippy    | `cargo` on PATH               | CLI (`cargo clippy --explain`)      |
+| Pylint    | `pylint` on PATH              | CLI (`pylint --help-msg`)           |
+
+ESLint plugin rules are also supported. Use `eslint/<plugin>/<rule>` for plugin rules referenced under the `eslint` linter (e.g., `eslint/import/no-unresolved`), or use the plugin name directly as the linter prefix (e.g., `@typescript-eslint/no-explicit-any`). The plugin package must be installed in `node_modules`.
 
 For custom or unsupported linters, configure a `rulesDir` to check that rule files exist:
 
@@ -297,6 +299,30 @@ Enable checkbox markers:
   with:
     markers: "headings,checkboxes"
 ```
+
+Override rules (same options as `.agent-lintrc.json`):
+
+```yaml
+- uses: zernie/agent-lint@main
+  with:
+    max-lines: "300"
+    require-rule-file: "auto"
+    linters: '{"my-tool":{"rulesDir":"rules/"}}'
+```
+
+### Action Inputs
+
+All inputs can also be set via `.agent-lintrc.json`. Action inputs override the config file.
+
+| Input                 | Default     | Description                                                 |
+| --------------------- | ----------- | ----------------------------------------------------------- |
+| `paths`               | `CLAUDE.md` | Comma-separated paths or glob patterns to validate          |
+| `follow-symlinks`     | `false`     | Follow symbolic links when reading files                    |
+| `markers`             | from config | Comma-separated rule marker types: `headings`, `checkboxes` |
+| `require-annotations` | `true`      | Require enforcement annotations on rules                    |
+| `max-lines`           | `500`       | Max lines per file (number or `false` to disable)           |
+| `require-rule-file`   | `auto`      | Validate linter rules exist (`auto`, `true`, or `false`)    |
+| `linters`             | `{}`        | JSON object mapping linter names to config                  |
 
 ### Inline PR Annotations
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # agent-lint
 
-ESLint for AI agents — validate your instruction files, audit your feedback loops, and generate lint rules from PR comments.
+Zero-config validation for AI agent instruction files. Ensures every rule in your CLAUDE.md, AGENTS.md, or .cursorrules is backed by a real linter — or explicitly marked as guidance-only.
 
 Companion repo for [Feedback Loop Is All You Need](https://zernie.com/blog/feedback-loop-is-all-you-need).
 
@@ -8,74 +8,70 @@ Companion repo for [Feedback Loop Is All You Need](https://zernie.com/blog/feedb
 
 - [Why](#why)
 - [Quick Start](#quick-start)
+- [How It Works](#how-it-works)
 - [Instruction File Format](#instruction-file-format)
+- [Agent Detection](#agent-detection)
+- [Linter Rule Validation](#linter-rule-validation)
 - [Configuration](#configuration)
 - [CLI](#cli)
 - [Organizing Rules](#organizing-rules)
 - [GitHub Action](#github-action)
-- [Supported Tools](#supported-tools)
 - [Installing Skills](#installing-skills)
 - [Maturity Levels](#maturity-levels)
 - [License](#license)
 
 ## Why
 
-AI coding agents work best when they get deterministic feedback — linters, type checkers, CI. Without it, they drift from conventions and produce code that "works" but doesn't fit your codebase.
+AI coding agents work best with deterministic feedback — linters, type checkers, CI. Without it, they drift from conventions and produce code that "works" but doesn't fit your codebase.
 
-`agent-lint` helps you close the feedback loop:
+The problem: teams write rules in CLAUDE.md or AGENTS.md like "always use barrel imports" but never wire them to actual linters. The rules rot. The agent ignores them. Nobody notices until the codebase diverges.
 
-1. **CI-enforced instruction file validation** — every rule must be enforced by a linter or explicitly marked as guidance-only
-2. **Repo maturity audit** — score how well your feedback loops support AI-assisted development
-3. **Lint rule generation** — turn recurring PR review comments into automated enforcement
+`agent-lint` closes this gap:
 
-Works with any AI agent instruction file — CLAUDE.md, AGENTS.md, .cursorrules, or your own convention.
+1. **Every rule must cite its enforcer** — `**Enforced by:** \`eslint/no-restricted-imports\``or`**Guidance only**`
+2. **Referenced linters must actually exist** — auto-detects ESLint, Ruff, Clippy, RuboCop, and more from your project
+3. **Missing instruction files are caught** — detects Claude Code, Cursor, Codex, Copilot, Windsurf, and Cline from their config directories
+4. **Errors show inline on PRs** — just like ESLint, annotations appear on the affected lines
+
+No config files needed. No dependencies beyond your existing linters.
 
 ## Quick Start
 
 ```bash
-# Auto-discovers CLAUDE.md, AGENTS.md, .cursorrules, etc.
 npx agent-lint
 ```
 
-Example output when validation fails:
+That's it. agent-lint auto-detects which AI tools you use, finds their instruction files, validates every rule has an enforcement annotation, and checks that referenced linters actually exist in your project.
 
 ```
+Detected agents: Claude Code (.claude)
+
 Validation Report: CLAUDE.md
 ========================================
-  Total rules:    3
-  Enforced:       1
-  Guidance only:  0
-  Disabled:       0
-  Missing:        2
-========================================
-
-Rules missing enforcement annotations:
-  Line 12: "No console.log in production"
-  Line 18: "Use Tailwind spacing scale"
-
-Add **Enforced by:** `<rule>` or **Guidance only** to each rule.
-```
-
-When all rules pass:
-
-```
-Validation Report: CLAUDE.md
-========================================
-  Total rules:    3
-  Enforced:       2
+  Total rules:    4
+  Enforced:       3
   Guidance only:  1
   Disabled:       0
   Missing:        0
+  Linters:        eslint (292 built-in rules)
 ========================================
 
 All rules have enforcement annotations.
 ```
 
+## How It Works
+
+agent-lint does three things automatically:
+
+**1. Detects your AI tools** — scans for `.claude/`, `.cursor/`, `.windsurf/`, and other config directories. If a tool is configured but its instruction file is missing, that's an error.
+
+**2. Validates rule annotations** — every `###` heading or `- [ ]` checkbox in your instruction files must have `**Enforced by:** \`linter/rule\``or`**Guidance only**`.
+
+**3. Verifies linters exist** — checks that referenced linters are actually installed. ESLint and Stylelint are checked via Node API. Ruff, Clippy, Pylint, and RuboCop are checked via CLI. No extra dependencies are installed — agent-lint only checks tools already in your project.
+
 ## Instruction File Format
 
-`agent-lint` validates that every rule has either an `**Enforced by:**` annotation or a `**Guidance only**` marker. Rules can be defined as `###` headings or markdown checkboxes:
-
-**Headings format:**
+Every rule needs an enforcement annotation:
 
 ```markdown
 ### Always use barrel file imports
@@ -89,22 +85,17 @@ All rules have enforcement annotations.
 **Why:** Ensures visual consistency across the design system.
 ```
 
-**Checkbox format** (enable with `"ruleMarkers": ["checkboxes"]` in config):
+Both `###` headings and `- [ ]` checkboxes are recognized as rules by default:
 
 ```markdown
 - [ ] No console.log in production
       **Enforced by:** `eslint/no-console`
-      **Why:** Use the structured logger which routes to Datadog.
 
 - [x] Prefer named exports over default exports
       **Guidance only** — cannot be mechanically enforced
 ```
 
-Rules missing both annotations cause validation to fail. This format works in any markdown file — CLAUDE.md, AGENTS.md, .cursorrules, or a custom file.
-
-### Disabling Validation for a Rule
-
-To skip validation for a specific rule, add an HTML comment below the heading:
+To skip validation for a specific rule:
 
 ```markdown
 ### Legacy rule that doesn't fit the format
@@ -112,40 +103,34 @@ To skip validation for a specific rule, add an HTML comment below the heading:
 <!-- agent-lint-disable -->
 ```
 
-This works like `eslint-disable-next-line` — the rule is recognized but excluded from validation. Use sparingly.
+## Agent Detection
 
-## Configuration
+agent-lint detects which AI coding tools are configured in your project and requires their instruction files to exist:
 
-agent-lint works with zero configuration. Optionally create a `.agent-lintrc.json` to override defaults:
+| Tool           | Detected by                       | Required file                     |
+| -------------- | --------------------------------- | --------------------------------- |
+| Claude Code    | `.claude/` directory              | `CLAUDE.md`                       |
+| Cursor         | `.cursor/` directory              | `.cursorrules`                    |
+| Windsurf       | `.windsurf/` directory            | `.windsurfrules`                  |
+| OpenAI Codex   | `AGENTS.md` file                  | `AGENTS.md`                       |
+| GitHub Copilot | `.github/copilot-instructions.md` | `.github/copilot-instructions.md` |
+| Cline          | `.clinerules` file                | `.clinerules`                     |
+
+If `.claude/` exists but `CLAUDE.md` doesn't, agent-lint errors — ensuring you don't forget to create instruction files for tools you've set up.
+
+To explicitly require specific tools (even without their config directories):
 
 ```json
 {
-  "ruleMarkers": ["headings"],
-  "rules": {
-    "max-lines": 300
-  }
+  "agents": ["Claude Code", "Cursor"]
 }
 ```
 
-| Option        | Default                      | Description                                                                                        |
-| ------------- | ---------------------------- | -------------------------------------------------------------------------------------------------- |
-| `ruleMarkers` | `["headings", "checkboxes"]` | Which rule marker types to recognize: `headings`, `checkboxes`, or both                            |
-| `linters`     | `{}`                         | Per-linter config for rule file validation (see [Linter Rule Validation](#linter-rule-validation)) |
-| `agents`      | `null` (auto-detect)         | List of agent tool names to require, or `null` to auto-detect                                      |
+## Linter Rule Validation
 
-### Rules
+When a rule says `**Enforced by:** \`eslint/no-console\``, agent-lint checks that `no-console` is a real ESLint rule. This catches typos, references to removed rules, and linters that were never set up.
 
-Rules are named checks that can be toggled individually. Set to `false` to disable.
-
-| Rule                  | Default  | Description                                                                       |
-| --------------------- | -------- | --------------------------------------------------------------------------------- |
-| `require-annotations` | `true`   | Every rule marker must have `**Enforced by:**` or `**Guidance only**`             |
-| `max-lines`           | `500`    | Maximum number of lines allowed per file. Set a number for custom limit.          |
-| `require-rule-file`   | `"auto"` | Validates that referenced linter rules actually exist. Auto-detects linter tools. |
-
-### Linter Rule Validation
-
-When `require-rule-file` is `"auto"` (the default), agent-lint automatically detects installed linters and validates that referenced rules exist:
+Supported linters are auto-detected from your project — **no extra dependencies are installed**:
 
 | Linter    | Detection                     | Method                              |
 | --------- | ----------------------------- | ----------------------------------- |
@@ -156,7 +141,7 @@ When `require-rule-file` is `"auto"` (the default), agent-lint automatically det
 | Pylint    | `pylint` on PATH              | CLI (`pylint --help-msg`)           |
 | RuboCop   | `rubocop` on PATH             | CLI (`rubocop --show-cops`)         |
 
-ESLint plugin rules are also supported. Use `eslint/<plugin>/<rule>` for plugin rules referenced under the `eslint` linter (e.g., `eslint/import/no-unresolved`), or use the plugin name directly as the linter prefix (e.g., `@typescript-eslint/no-explicit-any`). The plugin package must be installed in `node_modules`.
+ESLint plugin rules are also supported — use `eslint/<plugin>/<rule>` (e.g., `eslint/import/no-unresolved`) or the plugin name directly (e.g., `@typescript-eslint/no-explicit-any`). The plugin package must be installed in `node_modules`.
 
 For custom or unsupported linters, configure a `rulesDir` to check that rule files exist:
 
@@ -168,21 +153,44 @@ For custom or unsupported linters, configure a `rulesDir` to check that rule fil
 }
 ```
 
-Set `require-rule-file` to `false` to disable all rule file checking.
+Set `require-rule-file` to `false` to disable all linter rule checking.
+
+## Configuration
+
+agent-lint works with zero configuration. Optionally create a `.agent-lintrc.json` to override defaults:
+
+```json
+{
+  "rules": {
+    "max-lines": 300
+  }
+}
+```
+
+| Option        | Default                      | Description                                                   |
+| ------------- | ---------------------------- | ------------------------------------------------------------- |
+| `ruleMarkers` | `["headings", "checkboxes"]` | Which rule marker types to recognize                          |
+| `linters`     | `{}`                         | Per-linter config for rule file validation                    |
+| `agents`      | `null` (auto-detect)         | List of agent tool names to require, or `null` to auto-detect |
+
+### Rules
+
+| Rule                  | Default  | Description                                                                       |
+| --------------------- | -------- | --------------------------------------------------------------------------------- |
+| `require-annotations` | `true`   | Every rule marker must have `**Enforced by:**` or `**Guidance only**`             |
+| `max-lines`           | `500`    | Maximum number of lines allowed per file. Set a number for custom limit.          |
+| `require-rule-file`   | `"auto"` | Validates that referenced linter rules actually exist. Auto-detects linter tools. |
 
 ## CLI
 
 ```bash
-# Auto-discover and validate all instruction files
+# Auto-detect agents and validate their instruction files
 npx agent-lint
 
-# Validate a specific file
-npx agent-lint CLAUDE.md
+# Validate specific files
+npx agent-lint CLAUDE.md AGENTS.md
 
-# Monorepo — validate across packages
-npx agent-lint CLAUDE.md packages/api/CLAUDE.md packages/web/CLAUDE.md
-
-# Glob pattern — validate all matching files
+# Glob pattern
 npx agent-lint "**/*.md"
 
 # Follow symlinks
@@ -192,22 +200,16 @@ npx agent-lint --follow-symlinks
 npx agent-lint --markers=headings
 ```
 
-### Options
-
 | Flag                            | Description                                                                    |
 | ------------------------------- | ------------------------------------------------------------------------------ |
 | `--follow-symlinks`             | Resolve and validate symlinked files. Without this flag, symlinks are skipped. |
 | `--markers=headings,checkboxes` | Override which rule markers to recognize. Comma-separated.                     |
 
-If no paths are provided, defaults to `CLAUDE.md`.
-
-Exit codes: `0` on success, `1` if any rules are missing annotations.
+Exit codes: `0` on success, `1` if validation fails.
 
 ## Organizing Rules
 
-In a monorepo (or any project with subdirectories), use **progressive disclosure** — put universal rules at the root, and context-specific rules in subdirectory files. AI agents read the nearest instruction file plus all parent files, so rules naturally narrow as the agent moves deeper into the tree.
-
-### Example structure
+In a monorepo, use **progressive disclosure** — universal rules at the root, context-specific rules in subdirectories:
 
 ```
 CLAUDE.md                        # Universal: code style, PR conventions, testing
@@ -220,31 +222,7 @@ packages/
     CLAUDE.md -> ../CLAUDE.md    # Symlink to share rules (use --follow-symlinks)
 ```
 
-**Root file** (`CLAUDE.md`) — rules every agent should follow regardless of context:
-
-- Code formatting and linting standards
-- Git commit and PR conventions
-- Testing requirements
-
-**Subdirectory files** (`packages/api/CLAUDE.md`) — rules that only apply in that context:
-
-- API error handling patterns
-- Database query conventions
-- Framework-specific idioms
-
-### Validate all files at once
-
-```bash
-# Glob pattern — finds every CLAUDE.md in the tree
-npx agent-lint "**/CLAUDE.md"
-
-# Or list them explicitly
-npx agent-lint CLAUDE.md packages/api/CLAUDE.md packages/web/CLAUDE.md
-```
-
-### Why this matters
-
-The `max-lines` rule (default: 500 lines) exists because oversized instruction files hurt agent performance — the agent spends tokens parsing rules that aren't relevant to its current task. Progressive disclosure keeps each file focused, which means faster comprehension and fewer irrelevant rules applied.
+The `max-lines` rule (default: 500) nudges toward this pattern — oversized instruction files waste agent tokens on irrelevant rules.
 
 ## GitHub Action
 
@@ -260,58 +238,25 @@ jobs:
       - uses: zernie/agent-lint@main
 ```
 
-By default the action auto-discovers instruction files (CLAUDE.md, AGENTS.md, .cursorrules, etc.). Pass `paths` to override:
+Auto-detects agents and instruction files. Errors appear as inline annotations on the PR diff — just like ESLint.
 
-Multiple files (monorepo):
-
-```yaml
-- uses: zernie/agent-lint@main
-  with:
-    paths: "CLAUDE.md,packages/api/CLAUDE.md,packages/web/CLAUDE.md"
-```
-
-Glob pattern:
+Override with action inputs:
 
 ```yaml
 - uses: zernie/agent-lint@main
   with:
-    paths: "**/CLAUDE.md"
-```
-
-Follow symlinks (e.g. shared instruction file symlinked into subdirectories):
-
-```yaml
-- uses: zernie/agent-lint@main
-  with:
-    paths: "CLAUDE.md,packages/api/CLAUDE.md"
-    follow-symlinks: "true"
-```
-
-Enable checkbox markers:
-
-```yaml
-- uses: zernie/agent-lint@main
-  with:
-    markers: "headings,checkboxes"
-```
-
-Override rules (same options as `.agent-lintrc.json`):
-
-```yaml
-- uses: zernie/agent-lint@main
-  with:
+    paths: "CLAUDE.md,packages/*/CLAUDE.md"
     max-lines: "300"
     require-rule-file: "auto"
-    linters: '{"my-tool":{"rulesDir":"rules/"}}'
 ```
 
 ### Action Inputs
 
-All inputs can also be set via `.agent-lintrc.json`. Action inputs override the config file.
+All inputs can also be set via `.agent-lintrc.json`. Action inputs take precedence.
 
 | Input                 | Default     | Description                                                 |
 | --------------------- | ----------- | ----------------------------------------------------------- |
-| `paths`               | `CLAUDE.md` | Comma-separated paths or glob patterns to validate          |
+| `paths`               | auto-detect | Comma-separated paths or glob patterns to validate          |
 | `follow-symlinks`     | `false`     | Follow symbolic links when reading files                    |
 | `markers`             | from config | Comma-separated rule marker types: `headings`, `checkboxes` |
 | `require-annotations` | `true`      | Require enforcement annotations on rules                    |
@@ -319,13 +264,7 @@ All inputs can also be set via `.agent-lintrc.json`. Action inputs override the 
 | `require-rule-file`   | `auto`      | Validate linter rules exist (`auto`, `true`, or `false`)    |
 | `linters`             | `{}`        | JSON object mapping linter names to config                  |
 
-### Inline PR Annotations
-
-Errors appear as inline annotations directly on the affected lines in the PR **Files** tab — just like ESLint. No extra tools or configuration needed.
-
 ### Action Outputs
-
-The action sets the following outputs, accessible via `steps.<id>.outputs.<name>`:
 
 | Output     | Description                              |
 | ---------- | ---------------------------------------- |
@@ -336,42 +275,7 @@ The action sets the following outputs, accessible via `steps.<id>.outputs.<name>
 | `missing`  | Rules missing enforcement annotations    |
 | `valid`    | `true` if all rules have annotations     |
 
-```yaml
-- uses: zernie/agent-lint@main
-  id: lint
-- if: always()
-  run: |
-    echo "Total: ${{ steps.lint.outputs.total }}"
-    echo "Enforced: ${{ steps.lint.outputs.enforced }}"
-    echo "Missing: ${{ steps.lint.outputs.missing }}"
-```
-
 ## Supported Tools
-
-`agent-lint` detects which AI coding tools are configured in your project and validates their instruction files. If a tool is detected but its instruction file is missing, that's an error — ensuring you don't forget to create one.
-
-| Tool           | Detected by                       | Required file                     |
-| -------------- | --------------------------------- | --------------------------------- |
-| Claude Code    | `.claude/` directory              | `CLAUDE.md`                       |
-| Cursor         | `.cursor/` directory              | `.cursorrules`                    |
-| Windsurf       | `.windsurf/` directory            | `.windsurfrules`                  |
-| OpenAI Codex   | `AGENTS.md` file                  | `AGENTS.md`                       |
-| GitHub Copilot | `.github/copilot-instructions.md` | `.github/copilot-instructions.md` |
-| Cline          | `.clinerules` file                | `.clinerules`                     |
-
-To explicitly require specific tools (even without their config directories):
-
-```json
-{
-  "agents": ["Claude Code", "Cursor"]
-}
-```
-
-You can also pass explicit paths or globs:
-
-```bash
-npx agent-lint my-instructions.md
-```
 
 ### Claude Code Integration
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ When `require-rule-file` is `"auto"` (the default), agent-lint automatically det
 | Ruff      | `ruff` on PATH                | CLI (`ruff rule <name>`)            |
 | Clippy    | `cargo` on PATH               | CLI (`cargo clippy --explain`)      |
 | Pylint    | `pylint` on PATH              | CLI (`pylint --help-msg`)           |
+| RuboCop   | `rubocop` on PATH             | CLI (`rubocop --show-cops`)         |
 
 ESLint plugin rules are also supported. Use `eslint/<plugin>/<rule>` for plugin rules referenced under the `eslint` linter (e.g., `eslint/import/no-unresolved`), or use the plugin name directly as the linter prefix (e.g., `@typescript-eslint/no-explicit-any`). The plugin package must be installed in `node_modules`.
 

--- a/action.mjs
+++ b/action.mjs
@@ -27,6 +27,7 @@ const { fileResults, valid } = validatePaths(paths, {
   followSymlinks,
   ruleMarkers,
   rules: config.rules,
+  linters: config.linters,
 });
 
 let totalEnforced = 0;
@@ -59,6 +60,14 @@ for (const { path: filePath, skipped, reason, result } of fileResults) {
   console.log(`  Guidance only:  ${result.guidanceOnly}`);
   console.log(`  Disabled:       ${result.disabled}`);
   console.log(`  Missing:        ${result.missing}`);
+  if (result.detectedLinters && result.detectedLinters.length > 0) {
+    const parts = result.detectedLinters.map((l) =>
+      l.ruleCount
+        ? `${l.name} (${l.ruleCount} built-in rules)`
+        : `${l.name} (cli)`,
+    );
+    console.log(`  Linters:        ${parts.join(", ")}`);
+  }
   console.log("=".repeat(40));
 
   for (const error of result.errors) {

--- a/action.mjs
+++ b/action.mjs
@@ -61,14 +61,10 @@ for (const { path: filePath, skipped, reason, result } of fileResults) {
   console.log(`  Missing:        ${result.missing}`);
   console.log("=".repeat(40));
 
-  if (result.missing > 0) {
-    console.log("");
-    console.log("Rules missing enforcement annotations:");
-    for (const rule of result.rules) {
-      if (rule.enforcement === "missing") {
-        console.log(`  Line ${rule.line}: "${rule.title}"`);
-      }
-    }
+  for (const error of result.errors) {
+    console.log(
+      `::error file=${filePath},line=${error.line}::${error.message}`,
+    );
   }
 }
 

--- a/action.mjs
+++ b/action.mjs
@@ -1,10 +1,14 @@
-import { validatePaths, expandGlobs, loadConfig } from "./validate.mjs";
+import {
+  validatePaths,
+  expandGlobs,
+  loadConfig,
+  discoverInstructionFiles,
+} from "./validate.mjs";
 
 const pathsInput =
   process.env.INPUT_PATHS ||
   process.env["INPUT_CLAUDE-MD-PATH"] ||
-  process.env.INPUT_CLAUDE_MD_PATH ||
-  "CLAUDE.md";
+  process.env.INPUT_CLAUDE_MD_PATH;
 const followSymlinks =
   (process.env.INPUT_FOLLOW_SYMLINKS ||
     process.env["INPUT_FOLLOW-SYMLINKS"] ||
@@ -19,12 +23,14 @@ const requireRuleFileInput =
   process.env.INPUT_REQUIRE_RULE_FILE || process.env["INPUT_REQUIRE-RULE-FILE"];
 const lintersInput = process.env.INPUT_LINTERS || process.env["INPUT_LINTERS"];
 
-const paths = expandGlobs(
-  pathsInput
-    .split(",")
-    .map((p) => p.trim())
-    .filter(Boolean),
-);
+const paths = pathsInput
+  ? expandGlobs(
+      pathsInput
+        .split(",")
+        .map((p) => p.trim())
+        .filter(Boolean),
+    )
+  : discoverInstructionFiles();
 
 const config = loadConfig();
 const ruleMarkers = markersInput

--- a/action.mjs
+++ b/action.mjs
@@ -23,16 +23,29 @@ const requireRuleFileInput =
   process.env.INPUT_REQUIRE_RULE_FILE || process.env["INPUT_REQUIRE-RULE-FILE"];
 const lintersInput = process.env.INPUT_LINTERS || process.env["INPUT_LINTERS"];
 
-const paths = pathsInput
-  ? expandGlobs(
-      pathsInput
-        .split(",")
-        .map((p) => p.trim())
-        .filter(Boolean),
-    )
-  : discoverInstructionFiles();
-
 const config = loadConfig();
+
+let discoveryMissing = [];
+let paths;
+if (pathsInput) {
+  paths = expandGlobs(
+    pathsInput
+      .split(",")
+      .map((p) => p.trim())
+      .filter(Boolean),
+  );
+} else {
+  const discovery = discoverInstructionFiles(process.cwd(), config.agents);
+  if (discovery.detected.length > 0) {
+    const tools = discovery.detected
+      .map((d) => `${d.name} (${d.indicator})`)
+      .join(", ");
+    console.log(`Detected agents: ${tools}`);
+  }
+  paths = discovery.files;
+  discoveryMissing = discovery.missing;
+}
+
 const ruleMarkers = markersInput
   ? markersInput.split(",").map((m) => m.trim())
   : config.ruleMarkers;
@@ -126,13 +139,26 @@ console.log(`::set-output name=disabled::${totalDisabled}`);
 console.log(`::set-output name=missing::${totalMissing}`);
 console.log(`::set-output name=valid::${valid}`);
 
+let hasMissingFiles = false;
+for (const m of discoveryMissing) {
+  console.log(
+    `\n::error::${m.tool} detected (${m.indicator}) but ${m.expected} is missing`,
+  );
+  hasMissingFiles = true;
+}
+
 console.log("");
-if (valid) {
+if (valid && !hasMissingFiles) {
   console.log("All rules have enforcement annotations.");
 } else {
-  console.log(
-    "Add **Enforced by:** `<rule>` or **Guidance only** to each rule.",
-  );
+  if (!valid) {
+    console.log(
+      "Add **Enforced by:** `<rule>` or **Guidance only** to each rule.",
+    );
+  }
+  if (hasMissingFiles) {
+    console.log("Create missing instruction files for detected agents.");
+  }
   console.log("");
   console.log(
     `::error::Validation failed — ${totalMissing} rule(s) missing enforcement annotations`,

--- a/action.mjs
+++ b/action.mjs
@@ -10,6 +10,14 @@ const followSymlinks =
     process.env["INPUT_FOLLOW-SYMLINKS"] ||
     "false") === "true";
 const markersInput = process.env.INPUT_MARKERS || process.env["INPUT_MARKERS"];
+const requireAnnotationsInput =
+  process.env.INPUT_REQUIRE_ANNOTATIONS ||
+  process.env["INPUT_REQUIRE-ANNOTATIONS"];
+const maxLinesInput =
+  process.env.INPUT_MAX_LINES || process.env["INPUT_MAX-LINES"];
+const requireRuleFileInput =
+  process.env.INPUT_REQUIRE_RULE_FILE || process.env["INPUT_REQUIRE-RULE-FILE"];
+const lintersInput = process.env.INPUT_LINTERS || process.env["INPUT_LINTERS"];
 
 const paths = expandGlobs(
   pathsInput
@@ -23,11 +31,38 @@ const ruleMarkers = markersInput
   ? markersInput.split(",").map((m) => m.trim())
   : config.ruleMarkers;
 
+// Merge action inputs into rules config (action inputs override config file)
+const rules = { ...config.rules };
+if (requireAnnotationsInput !== undefined) {
+  rules["require-annotations"] = requireAnnotationsInput !== "false";
+}
+if (maxLinesInput !== undefined) {
+  rules["max-lines"] =
+    maxLinesInput === "false" ? false : Number(maxLinesInput) || 500;
+}
+if (requireRuleFileInput !== undefined) {
+  if (requireRuleFileInput === "false") rules["require-rule-file"] = false;
+  else if (requireRuleFileInput === "true") rules["require-rule-file"] = true;
+  else rules["require-rule-file"] = requireRuleFileInput;
+}
+
+// Merge linters config (action input overrides config file)
+let linters = config.linters;
+if (lintersInput) {
+  try {
+    linters = { ...linters, ...JSON.parse(lintersInput) };
+  } catch {
+    console.warn(
+      `Invalid linters JSON input: ${lintersInput}. Using config file value.`,
+    );
+  }
+}
+
 const { fileResults, valid } = validatePaths(paths, {
   followSymlinks,
   ruleMarkers,
-  rules: config.rules,
-  linters: config.linters,
+  rules,
+  linters,
 });
 
 let totalEnforced = 0;

--- a/action.mjs
+++ b/action.mjs
@@ -1,4 +1,4 @@
-import { validatePaths, loadConfig } from "./validate.mjs";
+import { validatePaths, expandGlobs, loadConfig } from "./validate.mjs";
 
 const pathsInput =
   process.env.INPUT_PATHS ||
@@ -11,10 +11,12 @@ const followSymlinks =
     "false") === "true";
 const markersInput = process.env.INPUT_MARKERS || process.env["INPUT_MARKERS"];
 
-const paths = pathsInput
-  .split(",")
-  .map((p) => p.trim())
-  .filter(Boolean);
+const paths = expandGlobs(
+  pathsInput
+    .split(",")
+    .map((p) => p.trim())
+    .filter(Boolean),
+);
 
 const config = loadConfig();
 const ruleMarkers = markersInput

--- a/action.yml
+++ b/action.yml
@@ -6,9 +6,8 @@ branding:
 
 inputs:
   paths:
-    description: "Comma-separated paths or glob patterns (e.g. '**/*.md') to validate"
+    description: "Comma-separated paths or glob patterns. Auto-discovers CLAUDE.md, AGENTS.md, .cursorrules, etc. if omitted."
     required: false
-    default: "CLAUDE.md"
   follow-symlinks:
     description: "Follow symbolic links when reading CLAUDE.md files"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
 
 inputs:
   paths:
-    description: "Comma-separated paths to CLAUDE.md files to validate"
+    description: "Comma-separated paths or glob patterns (e.g. '**/*.md') to validate"
     required: false
     default: "CLAUDE.md"
   follow-symlinks:
@@ -18,5 +18,5 @@ inputs:
     required: false
 
 runs:
-  using: "node20"
+  using: "node22"
   main: "action.mjs"

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,18 @@ inputs:
   markers:
     description: "Comma-separated rule marker types: headings, checkboxes"
     required: false
+  require-annotations:
+    description: "Require enforcement annotations on rules (true/false)"
+    required: false
+  max-lines:
+    description: "Max lines per file (number or 'false' to disable)"
+    required: false
+  require-rule-file:
+    description: "Validate linter rules exist ('auto', 'true', or 'false')"
+    required: false
+  linters:
+    description: 'JSON object mapping linter names to config (e.g. ''{"my-tool":{"rulesDir":"rules/"}}'')'
+    required: false
 
 runs:
   using: "node22"

--- a/action.yml
+++ b/action.yml
@@ -29,5 +29,5 @@ inputs:
     required: false
 
 runs:
-  using: "node22"
+  using: "node20"
   main: "action.mjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "agent-lint": "validate.mjs"
       },
       "devDependencies": {
+        "eslint": "^10.1.0",
         "prettier": "^3.8.1"
       }
     },
@@ -39,11 +40,254 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
+      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
+      "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
+      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
+      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
+      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -80,6 +324,46 @@
         }
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -98,6 +382,266 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.1.0.tgz",
+      "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.3",
+        "@eslint/config-helpers": "^0.5.3",
+        "@eslint/core": "^1.1.1",
+        "@eslint/plugin-kit": "^0.6.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -114,11 +658,51 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "license": "MIT"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -138,17 +722,158 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -180,11 +905,41 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/prettier": {
       "version": "3.8.1",
@@ -202,6 +957,16 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -209,6 +974,91 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
     "": {
       "name": "agent-lint",
       "dependencies": {
-        "cosmiconfig": "^9.0.1"
+        "cosmiconfig": "^9.0.1",
+        "glob": "^13.0.6"
       },
       "bin": {
         "agent-lint": "validate.mjs"
@@ -270,7 +271,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -280,7 +280,6 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -619,6 +618,23 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -795,11 +811,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
       "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
@@ -809,6 +833,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -923,6 +956,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "fmt:check": "prettier --check ."
   },
   "devDependencies": {
+    "eslint": "^10.1.0",
     "prettier": "^3.8.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "prettier": "^3.8.1"
   },
   "dependencies": {
-    "cosmiconfig": "^9.0.1"
+    "cosmiconfig": "^9.0.1",
+    "glob": "^13.0.6"
   }
 }

--- a/validate.mjs
+++ b/validate.mjs
@@ -19,8 +19,20 @@ const DEFAULT_RULES = {
   "require-rule-file": "auto",
 };
 const SAFE_RULE_NAME_RE = /^[a-zA-Z0-9_\-/.:#]+$/;
+
+// Known instruction files for AI coding tools, ordered by popularity
+const KNOWN_INSTRUCTION_FILES = [
+  "CLAUDE.md",
+  "AGENTS.md",
+  ".cursorrules",
+  ".github/copilot-instructions.md",
+  ".windsurfrules",
+  ".clinerules",
+  "CONVENTIONS.md",
+];
+
 const DEFAULT_CONFIG = {
-  ruleMarkers: ["headings"],
+  ruleMarkers: ["headings", "checkboxes"],
   rules: DEFAULT_RULES,
   linters: {},
 };
@@ -133,6 +145,21 @@ const CLI_TOOL_FOR_LINTER = {
   clippy: "cargo",
   pylint: "pylint",
 };
+
+/**
+ * Auto-discover instruction files in the given directory.
+ * Returns an array of paths that exist, or ["CLAUDE.md"] as fallback.
+ */
+export function discoverInstructionFiles(cwd = process.cwd()) {
+  const found = [];
+  for (const file of KNOWN_INSTRUCTION_FILES) {
+    const fullPath = resolve(cwd, file);
+    if (existsSync(fullPath)) {
+      found.push(file);
+    }
+  }
+  return found.length > 0 ? found : ["CLAUDE.md"];
+}
 
 export function loadConfig() {
   try {
@@ -578,7 +605,7 @@ if (
   const rawPaths = args.filter((a) => !a.startsWith("--"));
 
   if (rawPaths.length === 0) {
-    rawPaths.push("CLAUDE.md");
+    rawPaths.push(...discoverInstructionFiles());
   }
 
   const paths = expandGlobs(rawPaths);

--- a/validate.mjs
+++ b/validate.mjs
@@ -277,6 +277,9 @@ function printResult(filePath, result) {
     console.log("Errors:");
     for (const error of result.errors) {
       console.log(`  [${error.rule}] ${error.message}`);
+      console.log(
+        `::error file=${filePath},line=${error.line}::${error.message}`,
+      );
     }
   }
 }

--- a/validate.mjs
+++ b/validate.mjs
@@ -144,7 +144,7 @@ export function validate(content, { ruleMarkers, rules: rulesConfig } = {}) {
     if (lineCount > limit) {
       errors.push({
         rule: "max-lines",
-        message: `File has ${lineCount} lines, exceeding the limit of ${limit}`,
+        message: `File has ${lineCount} lines, exceeding the limit of ${limit}. Consider splitting into subdirectory files — see https://github.com/zernie/agent-lint#organizing-rules`,
         line: lineCount,
       });
     }

--- a/validate.mjs
+++ b/validate.mjs
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
-import { readFileSync, lstatSync, globSync } from "node:fs";
-import { resolve } from "node:path";
+import { readFileSync, lstatSync, globSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { execSync } from "node:child_process";
+import { createRequire } from "node:module";
 import { cosmiconfigSync } from "cosmiconfig";
 
 const ENFORCED_BY_RE = /\*\*Enforced by:\*\*/;
@@ -14,8 +16,84 @@ const VALID_MARKERS = ["headings", "checkboxes"];
 const DEFAULT_RULES = {
   "require-annotations": true,
   "max-lines": 500,
+  "require-rule-file": "auto",
 };
-const DEFAULT_CONFIG = { ruleMarkers: ["headings"], rules: DEFAULT_RULES };
+const SAFE_RULE_NAME_RE = /^[a-zA-Z0-9_\-/.:#]+$/;
+const DEFAULT_CONFIG = {
+  ruleMarkers: ["headings"],
+  rules: DEFAULT_RULES,
+  linters: {},
+};
+
+function extractLinterName(enforcedBy) {
+  const colonIdx = enforcedBy.indexOf("::");
+  const slashIdx = enforcedBy.indexOf("/");
+  if (colonIdx === -1 && slashIdx === -1) return enforcedBy;
+  if (colonIdx === -1) return enforcedBy.substring(0, slashIdx);
+  if (slashIdx === -1) return enforcedBy.substring(0, colonIdx);
+  return enforcedBy.substring(0, Math.min(slashIdx, colonIdx));
+}
+
+function extractRuleName(enforcedBy) {
+  const colonIdx = enforcedBy.indexOf("::");
+  const slashIdx = enforcedBy.indexOf("/");
+  if (colonIdx === -1 && slashIdx === -1) return null;
+  if (colonIdx === -1) return enforcedBy.substring(slashIdx + 1);
+  if (slashIdx === -1) return enforcedBy.substring(colonIdx + 2);
+  const idx = Math.min(slashIdx, colonIdx);
+  const sep = idx === colonIdx ? 2 : 1;
+  return enforcedBy.substring(idx + sep);
+}
+
+function ruleFileExists(ruleName, rulesDir, basePath) {
+  const dir = resolve(basePath, rulesDir);
+  if (!existsSync(dir)) return null;
+  const matches = globSync(`${ruleName}.*`, { cwd: dir });
+  return matches.length > 0;
+}
+
+// Built-in resolvers: return a Set of valid rule names, or null if linter not available
+const LINTER_RESOLVERS = {
+  eslint(basePath) {
+    const req = createRequire(resolve(basePath, "package.json"));
+    const { builtinRules } = req("eslint/use-at-your-own-risk");
+    return new Set(builtinRules.keys());
+  },
+  stylelint(basePath) {
+    const req = createRequire(resolve(basePath, "package.json"));
+    const mod = req("stylelint");
+    return new Set(Object.keys(mod.rules));
+  },
+};
+
+// CLI-based per-rule checks: throw on failure (rule doesn't exist)
+const CLI_RULE_CHECKS = {
+  ruff(ruleName) {
+    execSync(`ruff rule ${ruleName}`, { stdio: "ignore" });
+  },
+  clippy(ruleName) {
+    execSync(`cargo clippy --explain ${ruleName}`, { stdio: "ignore" });
+  },
+  pylint(ruleName) {
+    execSync(`pylint --help-msg=${ruleName}`, { stdio: "ignore" });
+  },
+};
+
+// Check if a CLI tool is available on PATH
+function cliAvailable(command) {
+  try {
+    execSync(`which ${command}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const CLI_TOOL_FOR_LINTER = {
+  ruff: "ruff",
+  clippy: "cargo",
+  pylint: "pylint",
+};
 
 export function loadConfig() {
   try {
@@ -30,6 +108,7 @@ export function loadConfig() {
       ...DEFAULT_CONFIG,
       ...result.config,
       rules: { ...DEFAULT_RULES, ...result.config.rules },
+      linters: { ...result.config.linters },
     };
 
     if (
@@ -109,7 +188,10 @@ export function parseClaudeMd(content, { ruleMarkers } = {}) {
   return rules;
 }
 
-export function validate(content, { ruleMarkers, rules: rulesConfig } = {}) {
+export function validate(
+  content,
+  { ruleMarkers, rules: rulesConfig, basePath, linters: lintersConfig } = {},
+) {
   const activeRules = rulesConfig || DEFAULT_RULES;
   const parsedRules = parseClaudeMd(content, { ruleMarkers });
   const enforced = parsedRules.filter(
@@ -150,6 +232,118 @@ export function validate(content, { ruleMarkers, rules: rulesConfig } = {}) {
     }
   }
 
+  const ruleFileMode = activeRules["require-rule-file"];
+  const detectedLinters = [];
+  if (ruleFileMode !== false && basePath) {
+    const resolverCache = new Map(); // linterName -> Set | "cli" | null
+    const cliAvailCache = new Map();
+
+    for (const rule of parsedRules) {
+      if (rule.enforcement !== "enforced" || !rule.enforcedBy) continue;
+      const linterName = extractLinterName(rule.enforcedBy);
+      const ruleName = extractRuleName(rule.enforcedBy);
+      if (!ruleName || !SAFE_RULE_NAME_RE.test(ruleName)) continue;
+
+      // Resolve linter rules (cached)
+      if (!resolverCache.has(linterName)) {
+        let result = null;
+
+        // Try Node API resolver
+        const resolver = LINTER_RESOLVERS[linterName];
+        if (resolver) {
+          try {
+            result = resolver(basePath);
+            if (result instanceof Set) {
+              detectedLinters.push({
+                name: linterName,
+                ruleCount: result.size,
+              });
+            }
+          } catch {
+            result = null;
+          }
+        }
+
+        // Try CLI resolver
+        if (!result && CLI_RULE_CHECKS[linterName]) {
+          const tool = CLI_TOOL_FOR_LINTER[linterName];
+          if (!cliAvailCache.has(tool)) {
+            cliAvailCache.set(tool, cliAvailable(tool));
+          }
+          if (cliAvailCache.get(tool)) {
+            result = "cli";
+            detectedLinters.push({ name: linterName, via: "cli" });
+          }
+        }
+
+        resolverCache.set(linterName, result);
+      }
+
+      const resolved = resolverCache.get(linterName);
+
+      // Check via Node API resolver (Set of rules)
+      if (resolved instanceof Set) {
+        if (!resolved.has(ruleName)) {
+          errors.push({
+            rule: "require-rule-file",
+            message: `Rule "${ruleName}" not found in ${linterName} (referenced in "${rule.title}", line ${rule.line})`,
+            line: rule.line,
+          });
+        }
+        continue;
+      }
+
+      // Check via CLI
+      if (resolved === "cli") {
+        const cliCheck = CLI_RULE_CHECKS[linterName];
+        try {
+          cliCheck(ruleName);
+        } catch {
+          errors.push({
+            rule: "require-rule-file",
+            message: `Rule "${ruleName}" not found in ${linterName} (referenced in "${rule.title}", line ${rule.line})`,
+            line: rule.line,
+          });
+        }
+        continue;
+      }
+
+      // Fallback: rulesDir from user config
+      const linterCfg = lintersConfig && lintersConfig[linterName];
+      if (linterCfg && linterCfg.rulesDir) {
+        const dirs = Array.isArray(linterCfg.rulesDir)
+          ? linterCfg.rulesDir
+          : [linterCfg.rulesDir];
+
+        let found = false;
+        let anyDirExists = false;
+        for (const dir of dirs) {
+          const absDir = resolve(basePath, dir);
+          if (!existsSync(absDir)) continue;
+          anyDirExists = true;
+          if (ruleFileExists(ruleName, dir, basePath)) {
+            found = true;
+            break;
+          }
+        }
+
+        if (!anyDirExists) {
+          errors.push({
+            rule: "require-rule-file",
+            message: `Rules directory "${dirs.join(", ")}" for linter "${linterName}" does not exist`,
+            line: rule.line,
+          });
+        } else if (!found) {
+          errors.push({
+            rule: "require-rule-file",
+            message: `Rule file for "${ruleName}" not found in ${dirs.join(", ")} (referenced in "${rule.title}", line ${rule.line})`,
+            line: rule.line,
+          });
+        }
+      }
+    }
+  }
+
   return {
     rules: parsedRules,
     enforced,
@@ -159,6 +353,7 @@ export function validate(content, { ruleMarkers, rules: rulesConfig } = {}) {
     total: parsedRules.length,
     errors,
     valid: errors.length === 0,
+    detectedLinters,
   };
 }
 
@@ -227,7 +422,12 @@ export function expandGlobs(patterns) {
  */
 export function validatePaths(
   paths,
-  { followSymlinks = false, ruleMarkers, rules: rulesConfig } = {},
+  {
+    followSymlinks = false,
+    ruleMarkers,
+    rules: rulesConfig,
+    linters: lintersConfig,
+  } = {},
 ) {
   const fileResults = [];
   let allValid = true;
@@ -253,7 +453,12 @@ export function validatePaths(
       continue;
     }
 
-    const result = validate(content, { ruleMarkers, rules: rulesConfig });
+    const result = validate(content, {
+      ruleMarkers,
+      rules: rulesConfig,
+      basePath: dirname(resolve(filePath)),
+      linters: lintersConfig,
+    });
     if (!result.valid) allValid = false;
     fileResults.push({ path: filePath, skipped: false, reason: null, result });
   }
@@ -270,6 +475,14 @@ function printResult(filePath, result) {
   console.log(`  Guidance only:  ${result.guidanceOnly}`);
   console.log(`  Disabled:       ${result.disabled}`);
   console.log(`  Missing:        ${result.missing}`);
+  if (result.detectedLinters && result.detectedLinters.length > 0) {
+    const parts = result.detectedLinters.map((l) =>
+      l.ruleCount
+        ? `${l.name} (${l.ruleCount} built-in rules)`
+        : `${l.name} (cli)`,
+    );
+    console.log(`  Linters:        ${parts.join(", ")}`);
+  }
   console.log("=".repeat(40));
 
   if (result.errors.length > 0) {
@@ -311,6 +524,7 @@ if (
     followSymlinks,
     ruleMarkers,
     rules: config.rules,
+    linters: config.linters,
   });
 
   for (const { path: filePath, skipped, reason, result } of fileResults) {

--- a/validate.mjs
+++ b/validate.mjs
@@ -152,7 +152,13 @@ const CLI_RULE_CHECKS = {
     execSync(`cargo clippy --explain ${ruleName}`, { stdio: "ignore" });
   },
   pylint(ruleName) {
-    execSync(`pylint --help-msg=${ruleName}`, { stdio: "ignore" });
+    const output = execSync(`pylint --help-msg=${ruleName}`, {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    if (output.includes("No such message id")) {
+      throw new Error(`Unknown pylint message: ${ruleName}`);
+    }
   },
   rubocop(ruleName) {
     // rubocop --show-cops exits 0 for both valid and invalid cops,

--- a/validate.mjs
+++ b/validate.mjs
@@ -20,21 +20,46 @@ const DEFAULT_RULES = {
 };
 const SAFE_RULE_NAME_RE = /^[a-zA-Z0-9_\-/.:#]+$/;
 
-// Known instruction files for AI coding tools, ordered by popularity
-const KNOWN_INSTRUCTION_FILES = [
-  "CLAUDE.md",
-  "AGENTS.md",
-  ".cursorrules",
-  ".github/copilot-instructions.md",
-  ".windsurfrules",
-  ".clinerules",
-  "CONVENTIONS.md",
+// AI coding tools: presence indicators and required instruction files
+const AGENT_TOOLS = [
+  {
+    name: "Claude Code",
+    indicators: [".claude"],
+    instructionFiles: ["CLAUDE.md"],
+  },
+  {
+    name: "Cursor",
+    indicators: [".cursor"],
+    instructionFiles: [".cursorrules"],
+  },
+  {
+    name: "Windsurf",
+    indicators: [".windsurf"],
+    instructionFiles: [".windsurfrules"],
+  },
+  // Tools where the instruction file IS the indicator
+  {
+    name: "OpenAI Codex",
+    indicators: ["AGENTS.md"],
+    instructionFiles: ["AGENTS.md"],
+  },
+  {
+    name: "GitHub Copilot",
+    indicators: [".github/copilot-instructions.md"],
+    instructionFiles: [".github/copilot-instructions.md"],
+  },
+  {
+    name: "Cline",
+    indicators: [".clinerules"],
+    instructionFiles: [".clinerules"],
+  },
 ];
 
 const DEFAULT_CONFIG = {
   ruleMarkers: ["headings", "checkboxes"],
   rules: DEFAULT_RULES,
   linters: {},
+  agents: null, // null = auto-detect; array = explicit list of tool names
 };
 
 function extractLinterName(enforcedBy) {
@@ -147,18 +172,55 @@ const CLI_TOOL_FOR_LINTER = {
 };
 
 /**
- * Auto-discover instruction files in the given directory.
- * Returns an array of paths that exist, or ["CLAUDE.md"] as fallback.
+ * Detect AI coding tools and their instruction files.
+ * @param {string} cwd — directory to scan
+ * @param {string[]|null} agents — explicit list of tool names to check, or null for auto-detect
+ * Returns { detected, files, missing } where:
+ *   detected: [{ name, indicator }] — tools found in the project
+ *   files: string[] — instruction files to validate
+ *   missing: [{ tool, expected, indicator }] — detected tools missing instruction files
  */
-export function discoverInstructionFiles(cwd = process.cwd()) {
-  const found = [];
-  for (const file of KNOWN_INSTRUCTION_FILES) {
-    const fullPath = resolve(cwd, file);
-    if (existsSync(fullPath)) {
-      found.push(file);
+export function discoverInstructionFiles(cwd = process.cwd(), agents = null) {
+  const detected = [];
+  const files = [];
+  const missing = [];
+  const seen = new Set();
+
+  const toolsToCheck = agents
+    ? AGENT_TOOLS.filter((t) =>
+        agents.some((a) => t.name.toLowerCase() === a.toLowerCase()),
+      )
+    : AGENT_TOOLS;
+
+  for (const tool of toolsToCheck) {
+    // In explicit mode, always check (no indicator needed)
+    // In auto mode, require an indicator to be present
+    const indicator = agents
+      ? tool.indicators[0]
+      : tool.indicators.find((ind) => existsSync(resolve(cwd, ind)));
+    if (!agents && !indicator) continue;
+
+    detected.push({
+      name: tool.name,
+      indicator: indicator || tool.indicators[0],
+    });
+
+    for (const file of tool.instructionFiles) {
+      if (seen.has(file)) continue;
+      seen.add(file);
+      if (existsSync(resolve(cwd, file))) {
+        files.push(file);
+      } else {
+        missing.push({
+          tool: tool.name,
+          expected: file,
+          indicator: indicator || tool.indicators[0],
+        });
+      }
     }
   }
-  return found.length > 0 ? found : ["CLAUDE.md"];
+
+  return { detected, files, missing };
 }
 
 export function loadConfig() {
@@ -175,6 +237,7 @@ export function loadConfig() {
       ...result.config,
       rules: { ...DEFAULT_RULES, ...result.config.rules },
       linters: { ...result.config.linters },
+      agents: result.config.agents !== undefined ? result.config.agents : null,
     };
 
     if (
@@ -604,13 +667,23 @@ if (
   const markersArg = args.find((a) => a.startsWith("--markers="));
   const rawPaths = args.filter((a) => !a.startsWith("--"));
 
+  const config = loadConfig();
+
+  let discoveryMissing = [];
   if (rawPaths.length === 0) {
-    rawPaths.push(...discoverInstructionFiles());
+    const discovery = discoverInstructionFiles(process.cwd(), config.agents);
+    if (discovery.detected.length > 0) {
+      const tools = discovery.detected
+        .map((d) => `${d.name} (${d.indicator})`)
+        .join(", ");
+      console.log(`Detected agents: ${tools}`);
+    }
+    rawPaths.push(...discovery.files);
+    discoveryMissing = discovery.missing;
   }
 
   const paths = expandGlobs(rawPaths);
 
-  const config = loadConfig();
   const ruleMarkers = markersArg
     ? markersArg.split("=")[1].split(",")
     : config.ruleMarkers;
@@ -634,13 +707,26 @@ if (
     printResult(filePath, result);
   }
 
+  let hasMissing = false;
+  for (const m of discoveryMissing) {
+    console.log(
+      `\n::error::${m.tool} detected (${m.indicator}) but ${m.expected} is missing`,
+    );
+    hasMissing = true;
+  }
+
   console.log("");
-  if (valid) {
+  if (valid && !hasMissing) {
     console.log("All rules have enforcement annotations.");
   } else {
-    console.log(
-      "Add **Enforced by:** `<rule>` or **Guidance only** to each rule.",
-    );
+    if (!valid) {
+      console.log(
+        "Add **Enforced by:** `<rule>` or **Guidance only** to each rule.",
+      );
+    }
+    if (hasMissing) {
+      console.log("Create missing instruction files for detected agents.");
+    }
     console.log("");
     console.log("::error::Validation failed — see report above");
     process.exit(1);

--- a/validate.mjs
+++ b/validate.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-import { readFileSync, lstatSync, globSync, existsSync } from "node:fs";
+import { readFileSync, lstatSync, existsSync } from "node:fs";
+import { globSync } from "glob";
 import { resolve, dirname } from "node:path";
 import { execSync } from "node:child_process";
 import { createRequire } from "node:module";

--- a/validate.mjs
+++ b/validate.mjs
@@ -153,6 +153,17 @@ const CLI_RULE_CHECKS = {
   pylint(ruleName) {
     execSync(`pylint --help-msg=${ruleName}`, { stdio: "ignore" });
   },
+  rubocop(ruleName) {
+    // rubocop --show-cops exits 0 for both valid and invalid cops,
+    // but outputs nothing for invalid ones
+    const output = execSync(`rubocop --show-cops ${ruleName}`, {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "ignore"],
+    });
+    if (!output || output.trim().length === 0) {
+      throw new Error(`Unknown cop: ${ruleName}`);
+    }
+  },
 };
 
 // Check if a CLI tool is available on PATH
@@ -169,6 +180,7 @@ const CLI_TOOL_FOR_LINTER = {
   ruff: "ruff",
   clippy: "cargo",
   pylint: "pylint",
+  rubocop: "rubocop",
 };
 
 /**

--- a/validate.mjs
+++ b/validate.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-import { readFileSync, lstatSync } from "node:fs";
+import { readFileSync, lstatSync, globSync } from "node:fs";
+import { resolve } from "node:path";
 import { cosmiconfigSync } from "cosmiconfig";
 
 const ENFORCED_BY_RE = /\*\*Enforced by:\*\*/;
@@ -200,6 +201,28 @@ export function readClaudeMd(filePath, { followSymlinks = false } = {}) {
 }
 
 /**
+ * Expand an array of file paths / glob patterns into resolved file paths.
+ * Plain paths that don't contain glob characters are kept as-is.
+ */
+export function expandGlobs(patterns) {
+  const GLOB_CHARS = /[*?{[]/;
+  const paths = [];
+
+  for (const pattern of patterns) {
+    if (GLOB_CHARS.test(pattern)) {
+      const matches = globSync(pattern, { cwd: process.cwd() });
+      for (const match of matches.sort()) {
+        paths.push(resolve(match));
+      }
+    } else {
+      paths.push(pattern);
+    }
+  }
+
+  return paths;
+}
+
+/**
  * Validate multiple CLAUDE.md files. Returns a combined report.
  */
 export function validatePaths(
@@ -268,11 +291,13 @@ if (
   const args = process.argv.slice(2);
   const followSymlinks = args.includes("--follow-symlinks");
   const markersArg = args.find((a) => a.startsWith("--markers="));
-  const paths = args.filter((a) => !a.startsWith("--"));
+  const rawPaths = args.filter((a) => !a.startsWith("--"));
 
-  if (paths.length === 0) {
-    paths.push("CLAUDE.md");
+  if (rawPaths.length === 0) {
+    rawPaths.push("CLAUDE.md");
   }
+
+  const paths = expandGlobs(rawPaths);
 
   const config = loadConfig();
   const ruleMarkers = markersArg

--- a/validate.mjs
+++ b/validate.mjs
@@ -52,12 +52,51 @@ function ruleFileExists(ruleName, rulesDir, basePath) {
   return matches.length > 0;
 }
 
+// Try to resolve an ESLint plugin's rules by package name
+function resolveEslintPluginRules(pluginName, basePath) {
+  try {
+    const req = createRequire(resolve(basePath, "package.json"));
+    // @scope/foo -> @scope/eslint-plugin-foo, or @scope -> @scope/eslint-plugin
+    // foo -> eslint-plugin-foo
+    let pkgNames;
+    if (pluginName.startsWith("@")) {
+      const parts = pluginName.split("/");
+      if (parts.length === 1) {
+        pkgNames = [`${parts[0]}/eslint-plugin`];
+      } else {
+        pkgNames = [
+          `${parts[0]}/eslint-plugin-${parts[1]}`,
+          `${parts[0]}/eslint-plugin`,
+        ];
+      }
+    } else {
+      pkgNames = [`eslint-plugin-${pluginName}`];
+    }
+    for (const pkg of pkgNames) {
+      try {
+        const plugin = req(pkg);
+        const rules = plugin.rules || (plugin.default && plugin.default.rules);
+        if (rules) return new Set(Object.keys(rules));
+      } catch {
+        continue;
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 // Built-in resolvers: return a Set of valid rule names, or null if linter not available
 const LINTER_RESOLVERS = {
   eslint(basePath) {
     const req = createRequire(resolve(basePath, "package.json"));
     const { builtinRules } = req("eslint/use-at-your-own-risk");
-    return new Set(builtinRules.keys());
+    const rules = new Set(builtinRules.keys());
+    // Tag with basePath so we can resolve plugins later
+    rules._basePath = basePath;
+    rules._isEslint = true;
+    return rules;
   },
   stylelint(basePath) {
     const req = createRequire(resolve(basePath, "package.json"));
@@ -264,6 +303,18 @@ export function validate(
           }
         }
 
+        // Try as ESLint plugin (e.g. @typescript-eslint, import, react)
+        if (!result) {
+          const pluginRules = resolveEslintPluginRules(linterName, basePath);
+          if (pluginRules) {
+            result = pluginRules;
+            detectedLinters.push({
+              name: linterName,
+              ruleCount: pluginRules.size,
+            });
+          }
+        }
+
         // Try CLI resolver
         if (!result && CLI_RULE_CHECKS[linterName]) {
           const tool = CLI_TOOL_FOR_LINTER[linterName];
@@ -284,11 +335,28 @@ export function validate(
       // Check via Node API resolver (Set of rules)
       if (resolved instanceof Set) {
         if (!resolved.has(ruleName)) {
-          errors.push({
-            rule: "require-rule-file",
-            message: `Rule "${ruleName}" not found in ${linterName} (referenced in "${rule.title}", line ${rule.line})`,
-            line: rule.line,
-          });
+          // For eslint: rule might be a plugin rule (e.g. "import/no-unresolved")
+          let foundInPlugin = false;
+          if (resolved._isEslint && ruleName.includes("/")) {
+            const pluginPrefix = ruleName.substring(0, ruleName.indexOf("/"));
+            const pluginRuleName = ruleName.substring(
+              ruleName.indexOf("/") + 1,
+            );
+            const pluginRules = resolveEslintPluginRules(
+              pluginPrefix,
+              resolved._basePath,
+            );
+            if (pluginRules && pluginRules.has(pluginRuleName)) {
+              foundInPlugin = true;
+            }
+          }
+          if (!foundInPlugin) {
+            errors.push({
+              rule: "require-rule-file",
+              message: `Rule "${ruleName}" not found in ${linterName} (referenced in "${rule.title}", line ${rule.line})`,
+              line: rule.line,
+            });
+          }
         }
         continue;
       }

--- a/validate.test.mjs
+++ b/validate.test.mjs
@@ -304,6 +304,7 @@ describe("loadConfig", () => {
     assert.deepEqual(config.rules, {
       "require-annotations": true,
       "max-lines": 500,
+      "require-rule-file": "auto",
     });
   });
 
@@ -729,5 +730,169 @@ describe("expandGlobs", () => {
     const result = expandGlobs(["plain.md", join(tmpDir, "*.md")]);
     assert.equal(result[0], "plain.md");
     assert.ok(result.length > 1);
+  });
+});
+
+describe("require-rule-file", () => {
+  let tmpDir;
+
+  before(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "agent-lint-rule-file-"));
+  });
+
+  after(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should not check rules when disabled", () => {
+    const result = validate("### Rule\n**Enforced by:** `eslint/fake-xyz`\n", {
+      rules: { "require-rule-file": false },
+      basePath: tmpDir,
+    });
+    assert.equal(
+      result.errors.filter((e) => e.rule === "require-rule-file").length,
+      0,
+    );
+  });
+
+  it("should skip when no basePath is provided", () => {
+    const result = validate("### Rule\n**Enforced by:** `eslint/fake-xyz`\n", {
+      rules: { "require-rule-file": "auto" },
+    });
+    assert.equal(
+      result.errors.filter((e) => e.rule === "require-rule-file").length,
+      0,
+    );
+  });
+
+  it("should detect eslint built-in rules via API", () => {
+    const result = validate(
+      "### Rule\n**Enforced by:** `eslint/no-console`\n",
+      { rules: { "require-rule-file": "auto" }, basePath: process.cwd() },
+    );
+    assert.equal(
+      result.errors.filter((e) => e.rule === "require-rule-file").length,
+      0,
+    );
+    assert.ok(result.detectedLinters.some((l) => l.name === "eslint"));
+  });
+
+  it("should error on nonexistent eslint rule", () => {
+    const result = validate(
+      "### Rule\n**Enforced by:** `eslint/completely-fake-rule-xyz`\n",
+      { rules: { "require-rule-file": "auto" }, basePath: process.cwd() },
+    );
+    const ruleErrors = result.errors.filter(
+      (e) => e.rule === "require-rule-file",
+    );
+    assert.equal(ruleErrors.length, 1);
+    assert.ok(ruleErrors[0].message.includes("completely-fake-rule-xyz"));
+    assert.ok(ruleErrors[0].message.includes("eslint"));
+  });
+
+  it("should report detected linters with rule count", () => {
+    const result = validate(
+      "### Rule\n**Enforced by:** `eslint/no-console`\n",
+      { rules: { "require-rule-file": "auto" }, basePath: process.cwd() },
+    );
+    const eslint = result.detectedLinters.find((l) => l.name === "eslint");
+    assert.ok(eslint);
+    assert.ok(eslint.ruleCount > 0);
+  });
+
+  it("should detect ruff rules via CLI", () => {
+    const result = validate("### Rule\n**Enforced by:** `ruff/E501`\n", {
+      rules: { "require-rule-file": "auto" },
+      basePath: process.cwd(),
+    });
+    // ruff is available in this environment
+    const ruleErrors = result.errors.filter(
+      (e) => e.rule === "require-rule-file",
+    );
+    assert.equal(ruleErrors.length, 0);
+    assert.ok(result.detectedLinters.some((l) => l.name === "ruff"));
+  });
+
+  it("should error on nonexistent ruff rule", () => {
+    const result = validate("### Rule\n**Enforced by:** `ruff/FAKE999`\n", {
+      rules: { "require-rule-file": "auto" },
+      basePath: process.cwd(),
+    });
+    const ruleErrors = result.errors.filter(
+      (e) => e.rule === "require-rule-file",
+    );
+    assert.equal(ruleErrors.length, 1);
+    assert.ok(ruleErrors[0].message.includes("FAKE999"));
+  });
+
+  it("should detect clippy rules via CLI", () => {
+    const result = validate(
+      "### Rule\n**Enforced by:** `clippy::needless_return`\n",
+      { rules: { "require-rule-file": "auto" }, basePath: process.cwd() },
+    );
+    const ruleErrors = result.errors.filter(
+      (e) => e.rule === "require-rule-file",
+    );
+    assert.equal(ruleErrors.length, 0);
+    assert.ok(result.detectedLinters.some((l) => l.name === "clippy"));
+  });
+
+  it("should skip unknown linters with no config", () => {
+    const result = validate(
+      "### Rule\n**Enforced by:** `unknown-tool/some-rule`\n",
+      { rules: { "require-rule-file": "auto" }, basePath: tmpDir },
+    );
+    assert.equal(
+      result.errors.filter((e) => e.rule === "require-rule-file").length,
+      0,
+    );
+  });
+
+  it("should skip rules with unsafe characters in name", () => {
+    const result = validate(
+      "### Rule\n**Enforced by:** `eslint/no-console; rm -rf /`\n",
+      { rules: { "require-rule-file": "auto" }, basePath: process.cwd() },
+    );
+    // Should not crash or execute shell commands
+    assert.equal(
+      result.errors.filter((e) => e.rule === "require-rule-file").length,
+      0,
+    );
+  });
+
+  it("should check rulesDir for custom linters", () => {
+    const rulesDir = join(tmpDir, "my-rules");
+    mkdirSync(rulesDir, { recursive: true });
+    writeFileSync(join(rulesDir, "check-foo.js"), "module.exports = {};\n");
+
+    const result = validate(
+      "### Rule A\n**Enforced by:** `my-tool/check-foo`\n### Rule B\n**Enforced by:** `my-tool/check-bar`\n",
+      {
+        rules: { "require-rule-file": "auto" },
+        basePath: tmpDir,
+        linters: { "my-tool": { rulesDir: "my-rules" } },
+      },
+    );
+    const ruleErrors = result.errors.filter(
+      (e) => e.rule === "require-rule-file",
+    );
+    assert.equal(ruleErrors.length, 1);
+    assert.ok(ruleErrors[0].message.includes("check-bar"));
+  });
+
+  it("should error when configured rulesDir does not exist", () => {
+    const result = validate(
+      "### Rule\n**Enforced by:** `my-tool/check-foo`\n",
+      {
+        rules: { "require-rule-file": "auto" },
+        basePath: tmpDir,
+        linters: { "my-tool": { rulesDir: "nonexistent-dir" } },
+      },
+    );
+    const ruleErrors = result.errors.filter(
+      (e) => e.rule === "require-rule-file",
+    );
+    assert.equal(ruleErrors.length, 1);
+    assert.ok(ruleErrors[0].message.includes("does not exist"));
   });
 });

--- a/validate.test.mjs
+++ b/validate.test.mjs
@@ -936,44 +936,77 @@ describe("discoverInstructionFiles", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("should fall back to CLAUDE.md when no files found", () => {
+  it("should return empty when no agents detected", () => {
     const result = discoverInstructionFiles(tmpDir);
-    assert.deepEqual(result, ["CLAUDE.md"]);
+    assert.equal(result.detected.length, 0);
+    assert.equal(result.files.length, 0);
+    assert.equal(result.missing.length, 0);
   });
 
-  it("should discover CLAUDE.md", () => {
+  it("should detect Claude Code via .claude/ dir and find CLAUDE.md", () => {
+    mkdirSync(join(tmpDir, ".claude"), { recursive: true });
     writeFileSync(join(tmpDir, "CLAUDE.md"), "# Test\n");
     const result = discoverInstructionFiles(tmpDir);
-    assert.ok(result.includes("CLAUDE.md"));
+    assert.ok(result.detected.some((d) => d.name === "Claude Code"));
+    assert.ok(result.files.includes("CLAUDE.md"));
+    assert.equal(result.missing.length, 0);
   });
 
-  it("should discover AGENTS.md", () => {
-    writeFileSync(join(tmpDir, "AGENTS.md"), "# Test\n");
-    const result = discoverInstructionFiles(tmpDir);
-    assert.ok(result.includes("AGENTS.md"));
+  it("should error when Claude Code detected but CLAUDE.md missing", () => {
+    // .claude/ already exists from previous test
+    const dir = mkdtempSync(join(tmpdir(), "agent-lint-discover2-"));
+    mkdirSync(join(dir, ".claude"), { recursive: true });
+    const result = discoverInstructionFiles(dir);
+    assert.ok(result.detected.some((d) => d.name === "Claude Code"));
+    assert.equal(result.files.length, 0);
+    assert.equal(result.missing.length, 1);
+    assert.equal(result.missing[0].tool, "Claude Code");
+    assert.equal(result.missing[0].expected, "CLAUDE.md");
+    rmSync(dir, { recursive: true, force: true });
   });
 
-  it("should discover .cursorrules", () => {
+  it("should detect Cursor via .cursor/ dir", () => {
+    mkdirSync(join(tmpDir, ".cursor"), { recursive: true });
     writeFileSync(join(tmpDir, ".cursorrules"), "rules\n");
     const result = discoverInstructionFiles(tmpDir);
-    assert.ok(result.includes(".cursorrules"));
+    assert.ok(result.detected.some((d) => d.name === "Cursor"));
+    assert.ok(result.files.includes(".cursorrules"));
   });
 
-  it("should discover multiple files at once", () => {
+  it("should detect Codex via AGENTS.md file", () => {
+    writeFileSync(join(tmpDir, "AGENTS.md"), "# Test\n");
     const result = discoverInstructionFiles(tmpDir);
-    assert.ok(result.length >= 3);
-    assert.ok(result.includes("CLAUDE.md"));
-    assert.ok(result.includes("AGENTS.md"));
-    assert.ok(result.includes(".cursorrules"));
+    assert.ok(result.detected.some((d) => d.name === "OpenAI Codex"));
+    assert.ok(result.files.includes("AGENTS.md"));
   });
 
-  it("should discover .github/copilot-instructions.md", () => {
+  it("should detect Copilot via instruction file", () => {
     mkdirSync(join(tmpDir, ".github"), { recursive: true });
     writeFileSync(
       join(tmpDir, ".github/copilot-instructions.md"),
       "# Copilot\n",
     );
     const result = discoverInstructionFiles(tmpDir);
-    assert.ok(result.includes(".github/copilot-instructions.md"));
+    assert.ok(result.detected.some((d) => d.name === "GitHub Copilot"));
+    assert.ok(result.files.includes(".github/copilot-instructions.md"));
+  });
+
+  it("should detect multiple tools at once", () => {
+    const result = discoverInstructionFiles(tmpDir);
+    assert.ok(result.detected.length >= 4);
+    assert.ok(result.files.length >= 4);
+  });
+
+  it("should check explicit agents list even without indicators", () => {
+    const dir = mkdtempSync(join(tmpdir(), "agent-lint-discover3-"));
+    writeFileSync(join(dir, "CLAUDE.md"), "# Test\n");
+    // No .cursor/ dir, but explicitly request Cursor check
+    const result = discoverInstructionFiles(dir, ["Claude Code", "Cursor"]);
+    assert.ok(result.detected.some((d) => d.name === "Claude Code"));
+    assert.ok(result.detected.some((d) => d.name === "Cursor"));
+    assert.ok(result.files.includes("CLAUDE.md"));
+    // Cursor detected but .cursorrules missing
+    assert.ok(result.missing.some((m) => m.tool === "Cursor"));
+    rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/validate.test.mjs
+++ b/validate.test.mjs
@@ -15,6 +15,7 @@ import {
   readClaudeMd,
   validatePaths,
   expandGlobs,
+  discoverInstructionFiles,
   loadConfig,
 } from "./validate.mjs";
 
@@ -300,7 +301,7 @@ describe("loadConfig", () => {
   it("should return defaults when no config file exists", () => {
     process.chdir(tmpDir);
     const config = loadConfig();
-    assert.deepEqual(config.ruleMarkers, ["headings"]);
+    assert.deepEqual(config.ruleMarkers, ["headings", "checkboxes"]);
     assert.deepEqual(config.rules, {
       "require-annotations": true,
       "max-lines": 500,
@@ -329,7 +330,7 @@ describe("loadConfig", () => {
     );
     process.chdir(configDir);
     const config = loadConfig();
-    assert.deepEqual(config.ruleMarkers, ["headings"]);
+    assert.deepEqual(config.ruleMarkers, ["headings", "checkboxes"]);
     process.chdir(originalCwd);
     rmSync(configDir, { recursive: true, force: true });
   });
@@ -921,5 +922,58 @@ describe("require-rule-file", () => {
     );
     // Plugin not installed, so no resolver found -> skip (no error in auto mode)
     assert.equal(ruleErrors.length, 0);
+  });
+});
+
+describe("discoverInstructionFiles", () => {
+  let tmpDir;
+
+  before(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "agent-lint-discover-"));
+  });
+
+  after(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should fall back to CLAUDE.md when no files found", () => {
+    const result = discoverInstructionFiles(tmpDir);
+    assert.deepEqual(result, ["CLAUDE.md"]);
+  });
+
+  it("should discover CLAUDE.md", () => {
+    writeFileSync(join(tmpDir, "CLAUDE.md"), "# Test\n");
+    const result = discoverInstructionFiles(tmpDir);
+    assert.ok(result.includes("CLAUDE.md"));
+  });
+
+  it("should discover AGENTS.md", () => {
+    writeFileSync(join(tmpDir, "AGENTS.md"), "# Test\n");
+    const result = discoverInstructionFiles(tmpDir);
+    assert.ok(result.includes("AGENTS.md"));
+  });
+
+  it("should discover .cursorrules", () => {
+    writeFileSync(join(tmpDir, ".cursorrules"), "rules\n");
+    const result = discoverInstructionFiles(tmpDir);
+    assert.ok(result.includes(".cursorrules"));
+  });
+
+  it("should discover multiple files at once", () => {
+    const result = discoverInstructionFiles(tmpDir);
+    assert.ok(result.length >= 3);
+    assert.ok(result.includes("CLAUDE.md"));
+    assert.ok(result.includes("AGENTS.md"));
+    assert.ok(result.includes(".cursorrules"));
+  });
+
+  it("should discover .github/copilot-instructions.md", () => {
+    mkdirSync(join(tmpDir, ".github"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".github/copilot-instructions.md"),
+      "# Copilot\n",
+    );
+    const result = discoverInstructionFiles(tmpDir);
+    assert.ok(result.includes(".github/copilot-instructions.md"));
   });
 });

--- a/validate.test.mjs
+++ b/validate.test.mjs
@@ -988,6 +988,50 @@ describe("require-rule-file", () => {
     assert.ok(ruleErrors[0].message.includes("does not exist"));
   });
 
+  it("should skip all CLI linters gracefully when not on PATH", () => {
+    // Use a fake PATH so no CLI tools are found
+    const origPath = process.env.PATH;
+    process.env.PATH = tmpDir; // empty dir, no binaries
+    try {
+      const content = [
+        "### R1\n**Enforced by:** `ruff/E501`",
+        "### R2\n**Enforced by:** `clippy::needless_return`",
+        "### R3\n**Enforced by:** `pylint/C0301`",
+        "### R4\n**Enforced by:** `rubocop/Style/FrozenStringLiteralComment`",
+      ].join("\n");
+      const result = validate(content, {
+        rules: { "require-rule-file": "auto" },
+        basePath: tmpDir,
+      });
+      // No CLI tools found → no require-rule-file errors (all skipped)
+      const ruleErrors = result.errors.filter(
+        (e) => e.rule === "require-rule-file",
+      );
+      assert.equal(ruleErrors.length, 0);
+      // None should be detected
+      assert.equal(
+        result.detectedLinters.filter((l) =>
+          ["ruff", "clippy", "pylint", "rubocop"].includes(l.name),
+        ).length,
+        0,
+      );
+    } finally {
+      process.env.PATH = origPath;
+    }
+  });
+
+  it("should not error on eslint rules when require-rule-file is disabled", () => {
+    const result = validate(
+      "### Rule\n**Enforced by:** `eslint/no-console`\n",
+      { rules: { "require-rule-file": false }, basePath: tmpDir },
+    );
+    assert.equal(
+      result.errors.filter((e) => e.rule === "require-rule-file").length,
+      0,
+    );
+    assert.equal(result.detectedLinters.length, 0);
+  });
+
   it("should handle eslint plugin-style rule names with slash", () => {
     // eslint/import/no-unresolved — plugin not installed, should error
     const result = validate(

--- a/validate.test.mjs
+++ b/validate.test.mjs
@@ -806,16 +806,11 @@ describe("require-rule-file", () => {
       rules: { "require-rule-file": "auto" },
       basePath: process.cwd(),
     });
-    const ruffDetected = result.detectedLinters.some(
-      (l) => l.name === "ruff",
+    const ruleErrors = result.errors.filter(
+      (e) => e.rule === "require-rule-file",
     );
-    if (ruffDetected) {
-      const ruleErrors = result.errors.filter(
-        (e) => e.rule === "require-rule-file",
-      );
-      assert.equal(ruleErrors.length, 0);
-    }
-    // If ruff not on PATH, skip gracefully
+    assert.equal(ruleErrors.length, 0);
+    assert.ok(result.detectedLinters.some((l) => l.name === "ruff"));
   });
 
   it("should error on nonexistent ruff rule", () => {
@@ -823,17 +818,11 @@ describe("require-rule-file", () => {
       rules: { "require-rule-file": "auto" },
       basePath: process.cwd(),
     });
-    const ruffDetected = result.detectedLinters.some(
-      (l) => l.name === "ruff",
+    const ruleErrors = result.errors.filter(
+      (e) => e.rule === "require-rule-file",
     );
-    if (ruffDetected) {
-      const ruleErrors = result.errors.filter(
-        (e) => e.rule === "require-rule-file",
-      );
-      assert.equal(ruleErrors.length, 1);
-      assert.ok(ruleErrors[0].message.includes("FAKE999"));
-    }
-    // If ruff not on PATH, skip — no assertion needed
+    assert.equal(ruleErrors.length, 1);
+    assert.ok(ruleErrors[0].message.includes("FAKE999"));
   });
 
   it("should detect clippy rules via CLI", () => {
@@ -861,7 +850,6 @@ describe("require-rule-file", () => {
   });
 
   it("should detect pylint rules via CLI", () => {
-    // pylint may or may not be on PATH — test handles both
     const result = validate("### Rule\n**Enforced by:** `pylint/C0301`\n", {
       rules: { "require-rule-file": "auto" },
       basePath: process.cwd(),
@@ -869,27 +857,20 @@ describe("require-rule-file", () => {
     const ruleErrors = result.errors.filter(
       (e) => e.rule === "require-rule-file",
     );
-    // If pylint is on PATH, C0301 (line-too-long) should be valid
-    // If pylint is not on PATH, should skip gracefully
     assert.equal(ruleErrors.length, 0);
+    assert.ok(result.detectedLinters.some((l) => l.name === "pylint"));
   });
 
-  it("should error on nonexistent pylint rule if pylint available", () => {
+  it("should error on nonexistent pylint rule", () => {
     const result = validate("### Rule\n**Enforced by:** `pylint/ZZZZ9999`\n", {
       rules: { "require-rule-file": "auto" },
       basePath: process.cwd(),
     });
-    const pylintDetected = result.detectedLinters.some(
-      (l) => l.name === "pylint",
+    const ruleErrors = result.errors.filter(
+      (e) => e.rule === "require-rule-file",
     );
-    if (pylintDetected) {
-      const ruleErrors = result.errors.filter(
-        (e) => e.rule === "require-rule-file",
-      );
-      assert.equal(ruleErrors.length, 1);
-      assert.ok(ruleErrors[0].message.includes("ZZZZ9999"));
-    }
-    // If pylint not on PATH, skip — no assertion needed
+    assert.equal(ruleErrors.length, 1);
+    assert.ok(ruleErrors[0].message.includes("ZZZZ9999"));
   });
 
   it("should detect rubocop rules via CLI", () => {
@@ -897,16 +878,11 @@ describe("require-rule-file", () => {
       "### Rule\n**Enforced by:** `rubocop/Style/FrozenStringLiteralComment`\n",
       { rules: { "require-rule-file": "auto" }, basePath: process.cwd() },
     );
-    const rubocopDetected = result.detectedLinters.some(
-      (l) => l.name === "rubocop",
+    const ruleErrors = result.errors.filter(
+      (e) => e.rule === "require-rule-file",
     );
-    if (rubocopDetected) {
-      const ruleErrors = result.errors.filter(
-        (e) => e.rule === "require-rule-file",
-      );
-      assert.equal(ruleErrors.length, 0);
-    }
-    // If rubocop not on PATH, skip gracefully
+    assert.equal(ruleErrors.length, 0);
+    assert.ok(result.detectedLinters.some((l) => l.name === "rubocop"));
   });
 
   it("should error on nonexistent rubocop cop", () => {
@@ -914,26 +890,11 @@ describe("require-rule-file", () => {
       "### Rule\n**Enforced by:** `rubocop/Fake/NonExistentCop`\n",
       { rules: { "require-rule-file": "auto" }, basePath: process.cwd() },
     );
-    const rubocopDetected = result.detectedLinters.some(
-      (l) => l.name === "rubocop",
+    const ruleErrors = result.errors.filter(
+      (e) => e.rule === "require-rule-file",
     );
-    if (rubocopDetected) {
-      const ruleErrors = result.errors.filter(
-        (e) => e.rule === "require-rule-file",
-      );
-      assert.equal(ruleErrors.length, 1);
-      assert.ok(ruleErrors[0].message.includes("Fake/NonExistentCop"));
-    }
-  });
-
-  it("should skip rubocop gracefully when not on PATH", () => {
-    // Use a basePath where rubocop definitely isn't available
-    const result = validate(
-      "### Rule\n**Enforced by:** `rubocop/Style/FrozenStringLiteralComment`\n",
-      { rules: { "require-rule-file": "auto" }, basePath: tmpDir },
-    );
-    // Should not crash regardless of rubocop availability
-    assert.ok(result);
+    assert.equal(ruleErrors.length, 1);
+    assert.ok(ruleErrors[0].message.includes("Fake/NonExistentCop"));
   });
 
   it("should check rulesDir for custom rubocop cops", () => {
@@ -961,16 +922,11 @@ describe("require-rule-file", () => {
       "### Rule\n**Enforced by:** `clippy::completely_fake_lint_xyz`\n",
       { rules: { "require-rule-file": "auto" }, basePath: process.cwd() },
     );
-    const clippyDetected = result.detectedLinters.some(
-      (l) => l.name === "clippy",
+    const ruleErrors = result.errors.filter(
+      (e) => e.rule === "require-rule-file",
     );
-    if (clippyDetected) {
-      const ruleErrors = result.errors.filter(
-        (e) => e.rule === "require-rule-file",
-      );
-      assert.equal(ruleErrors.length, 1);
-      assert.ok(ruleErrors[0].message.includes("completely_fake_lint_xyz"));
-    }
+    assert.equal(ruleErrors.length, 1);
+    assert.ok(ruleErrors[0].message.includes("completely_fake_lint_xyz"));
   });
 
   it("should skip unknown linters with no config", () => {

--- a/validate.test.mjs
+++ b/validate.test.mjs
@@ -806,12 +806,16 @@ describe("require-rule-file", () => {
       rules: { "require-rule-file": "auto" },
       basePath: process.cwd(),
     });
-    // ruff is available in this environment
-    const ruleErrors = result.errors.filter(
-      (e) => e.rule === "require-rule-file",
+    const ruffDetected = result.detectedLinters.some(
+      (l) => l.name === "ruff",
     );
-    assert.equal(ruleErrors.length, 0);
-    assert.ok(result.detectedLinters.some((l) => l.name === "ruff"));
+    if (ruffDetected) {
+      const ruleErrors = result.errors.filter(
+        (e) => e.rule === "require-rule-file",
+      );
+      assert.equal(ruleErrors.length, 0);
+    }
+    // If ruff not on PATH, skip gracefully
   });
 
   it("should error on nonexistent ruff rule", () => {
@@ -819,11 +823,17 @@ describe("require-rule-file", () => {
       rules: { "require-rule-file": "auto" },
       basePath: process.cwd(),
     });
-    const ruleErrors = result.errors.filter(
-      (e) => e.rule === "require-rule-file",
+    const ruffDetected = result.detectedLinters.some(
+      (l) => l.name === "ruff",
     );
-    assert.equal(ruleErrors.length, 1);
-    assert.ok(ruleErrors[0].message.includes("FAKE999"));
+    if (ruffDetected) {
+      const ruleErrors = result.errors.filter(
+        (e) => e.rule === "require-rule-file",
+      );
+      assert.equal(ruleErrors.length, 1);
+      assert.ok(ruleErrors[0].message.includes("FAKE999"));
+    }
+    // If ruff not on PATH, skip — no assertion needed
   });
 
   it("should detect clippy rules via CLI", () => {

--- a/validate.test.mjs
+++ b/validate.test.mjs
@@ -838,6 +838,67 @@ describe("require-rule-file", () => {
     assert.ok(result.detectedLinters.some((l) => l.name === "clippy"));
   });
 
+  it("should skip gracefully when stylelint is not installed", () => {
+    const result = validate(
+      "### Rule\n**Enforced by:** `stylelint/color-no-invalid-hex`\n",
+      { rules: { "require-rule-file": "auto" }, basePath: process.cwd() },
+    );
+    const ruleErrors = result.errors.filter(
+      (e) => e.rule === "require-rule-file",
+    );
+    // stylelint not installed, no resolver found -> skip
+    assert.equal(ruleErrors.length, 0);
+  });
+
+  it("should detect pylint rules via CLI", () => {
+    // pylint may or may not be on PATH — test handles both
+    const result = validate("### Rule\n**Enforced by:** `pylint/C0301`\n", {
+      rules: { "require-rule-file": "auto" },
+      basePath: process.cwd(),
+    });
+    const ruleErrors = result.errors.filter(
+      (e) => e.rule === "require-rule-file",
+    );
+    // If pylint is on PATH, C0301 (line-too-long) should be valid
+    // If pylint is not on PATH, should skip gracefully
+    assert.equal(ruleErrors.length, 0);
+  });
+
+  it("should error on nonexistent pylint rule if pylint available", () => {
+    const result = validate("### Rule\n**Enforced by:** `pylint/ZZZZ9999`\n", {
+      rules: { "require-rule-file": "auto" },
+      basePath: process.cwd(),
+    });
+    const pylintDetected = result.detectedLinters.some(
+      (l) => l.name === "pylint",
+    );
+    if (pylintDetected) {
+      const ruleErrors = result.errors.filter(
+        (e) => e.rule === "require-rule-file",
+      );
+      assert.equal(ruleErrors.length, 1);
+      assert.ok(ruleErrors[0].message.includes("ZZZZ9999"));
+    }
+    // If pylint not on PATH, skip — no assertion needed
+  });
+
+  it("should error on nonexistent clippy lint", () => {
+    const result = validate(
+      "### Rule\n**Enforced by:** `clippy::completely_fake_lint_xyz`\n",
+      { rules: { "require-rule-file": "auto" }, basePath: process.cwd() },
+    );
+    const clippyDetected = result.detectedLinters.some(
+      (l) => l.name === "clippy",
+    );
+    if (clippyDetected) {
+      const ruleErrors = result.errors.filter(
+        (e) => e.rule === "require-rule-file",
+      );
+      assert.equal(ruleErrors.length, 1);
+      assert.ok(ruleErrors[0].message.includes("completely_fake_lint_xyz"));
+    }
+  });
+
   it("should skip unknown linters with no config", () => {
     const result = validate(
       "### Rule\n**Enforced by:** `unknown-tool/some-rule`\n",
@@ -989,6 +1050,42 @@ describe("discoverInstructionFiles", () => {
     const result = discoverInstructionFiles(tmpDir);
     assert.ok(result.detected.some((d) => d.name === "GitHub Copilot"));
     assert.ok(result.files.includes(".github/copilot-instructions.md"));
+  });
+
+  it("should detect Windsurf via .windsurf/ dir and find .windsurfrules", () => {
+    mkdirSync(join(tmpDir, ".windsurf"), { recursive: true });
+    writeFileSync(join(tmpDir, ".windsurfrules"), "rules\n");
+    const result = discoverInstructionFiles(tmpDir);
+    assert.ok(result.detected.some((d) => d.name === "Windsurf"));
+    assert.ok(result.files.includes(".windsurfrules"));
+  });
+
+  it("should error when Windsurf detected but .windsurfrules missing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "agent-lint-windsurf-"));
+    mkdirSync(join(dir, ".windsurf"), { recursive: true });
+    const result = discoverInstructionFiles(dir);
+    assert.ok(result.detected.some((d) => d.name === "Windsurf"));
+    assert.ok(result.missing.some((m) => m.tool === "Windsurf"));
+    assert.equal(
+      result.missing.find((m) => m.tool === "Windsurf").expected,
+      ".windsurfrules",
+    );
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("should detect Cline via .clinerules file", () => {
+    writeFileSync(join(tmpDir, ".clinerules"), "rules\n");
+    const result = discoverInstructionFiles(tmpDir);
+    assert.ok(result.detected.some((d) => d.name === "Cline"));
+    assert.ok(result.files.includes(".clinerules"));
+  });
+
+  it("should error when Cline explicitly required but .clinerules missing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "agent-lint-cline-"));
+    const result = discoverInstructionFiles(dir, ["Cline"]);
+    assert.ok(result.detected.some((d) => d.name === "Cline"));
+    assert.ok(result.missing.some((m) => m.tool === "Cline"));
+    rmSync(dir, { recursive: true, force: true });
   });
 
   it("should detect multiple tools at once", () => {

--- a/validate.test.mjs
+++ b/validate.test.mjs
@@ -882,6 +882,70 @@ describe("require-rule-file", () => {
     // If pylint not on PATH, skip — no assertion needed
   });
 
+  it("should detect rubocop rules via CLI", () => {
+    const result = validate(
+      "### Rule\n**Enforced by:** `rubocop/Style/FrozenStringLiteralComment`\n",
+      { rules: { "require-rule-file": "auto" }, basePath: process.cwd() },
+    );
+    const rubocopDetected = result.detectedLinters.some(
+      (l) => l.name === "rubocop",
+    );
+    if (rubocopDetected) {
+      const ruleErrors = result.errors.filter(
+        (e) => e.rule === "require-rule-file",
+      );
+      assert.equal(ruleErrors.length, 0);
+    }
+    // If rubocop not on PATH, skip gracefully
+  });
+
+  it("should error on nonexistent rubocop cop", () => {
+    const result = validate(
+      "### Rule\n**Enforced by:** `rubocop/Fake/NonExistentCop`\n",
+      { rules: { "require-rule-file": "auto" }, basePath: process.cwd() },
+    );
+    const rubocopDetected = result.detectedLinters.some(
+      (l) => l.name === "rubocop",
+    );
+    if (rubocopDetected) {
+      const ruleErrors = result.errors.filter(
+        (e) => e.rule === "require-rule-file",
+      );
+      assert.equal(ruleErrors.length, 1);
+      assert.ok(ruleErrors[0].message.includes("Fake/NonExistentCop"));
+    }
+  });
+
+  it("should skip rubocop gracefully when not on PATH", () => {
+    // Use a basePath where rubocop definitely isn't available
+    const result = validate(
+      "### Rule\n**Enforced by:** `rubocop/Style/FrozenStringLiteralComment`\n",
+      { rules: { "require-rule-file": "auto" }, basePath: tmpDir },
+    );
+    // Should not crash regardless of rubocop availability
+    assert.ok(result);
+  });
+
+  it("should check rulesDir for custom rubocop cops", () => {
+    const rulesDir = join(tmpDir, "rubocop-custom");
+    mkdirSync(rulesDir, { recursive: true });
+    writeFileSync(join(rulesDir, "MyCustomCop.rb"), "# custom cop\n");
+
+    const result = validate(
+      "### Rule A\n**Enforced by:** `rubocop-custom/MyCustomCop`\n### Rule B\n**Enforced by:** `rubocop-custom/MissingCop`\n",
+      {
+        rules: { "require-rule-file": "auto" },
+        basePath: tmpDir,
+        linters: { "rubocop-custom": { rulesDir: "rubocop-custom" } },
+      },
+    );
+    const ruleErrors = result.errors.filter(
+      (e) => e.rule === "require-rule-file",
+    );
+    assert.equal(ruleErrors.length, 1);
+    assert.ok(ruleErrors[0].message.includes("MissingCop"));
+  });
+
   it("should error on nonexistent clippy lint", () => {
     const result = validate(
       "### Rule\n**Enforced by:** `clippy::completely_fake_lint_xyz`\n",

--- a/validate.test.mjs
+++ b/validate.test.mjs
@@ -895,4 +895,31 @@ describe("require-rule-file", () => {
     assert.equal(ruleErrors.length, 1);
     assert.ok(ruleErrors[0].message.includes("does not exist"));
   });
+
+  it("should handle eslint plugin-style rule names with slash", () => {
+    // eslint/import/no-unresolved — plugin not installed, should error
+    const result = validate(
+      "### Rule\n**Enforced by:** `eslint/import/no-unresolved`\n",
+      { rules: { "require-rule-file": "auto" }, basePath: process.cwd() },
+    );
+    const ruleErrors = result.errors.filter(
+      (e) => e.rule === "require-rule-file",
+    );
+    // Should error because eslint-plugin-import isn't installed
+    assert.equal(ruleErrors.length, 1);
+    assert.ok(ruleErrors[0].message.includes("import/no-unresolved"));
+  });
+
+  it("should skip uninstalled eslint plugin linter names gracefully", () => {
+    // @typescript-eslint/no-explicit-any — plugin not installed, skip
+    const result = validate(
+      "### Rule\n**Enforced by:** `@typescript-eslint/no-explicit-any`\n",
+      { rules: { "require-rule-file": "auto" }, basePath: process.cwd() },
+    );
+    const ruleErrors = result.errors.filter(
+      (e) => e.rule === "require-rule-file",
+    );
+    // Plugin not installed, so no resolver found -> skip (no error in auto mode)
+    assert.equal(ruleErrors.length, 0);
+  });
 });

--- a/validate.test.mjs
+++ b/validate.test.mjs
@@ -14,6 +14,7 @@ import {
   parseClaudeMd,
   readClaudeMd,
   validatePaths,
+  expandGlobs,
   loadConfig,
 } from "./validate.mjs";
 
@@ -679,5 +680,54 @@ describe("validatePaths", () => {
     assert.equal(valid, true);
     assert.equal(fileResults[0].skipped, false);
     assert.equal(fileResults[0].result.enforced, 1);
+  });
+});
+
+describe("expandGlobs", () => {
+  let tmpDir;
+
+  before(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "agent-lint-glob-"));
+  });
+
+  after(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should pass through plain paths unchanged", () => {
+    const result = expandGlobs(["CLAUDE.md", "foo/AGENTS.md"]);
+    assert.deepEqual(result, ["CLAUDE.md", "foo/AGENTS.md"]);
+  });
+
+  it("should expand glob patterns into matching files", () => {
+    writeFileSync(join(tmpDir, "a.md"), "# A\n");
+    writeFileSync(join(tmpDir, "b.md"), "# B\n");
+    writeFileSync(join(tmpDir, "c.txt"), "not md\n");
+
+    const result = expandGlobs([join(tmpDir, "*.md")]);
+    assert.equal(result.length, 2);
+    assert.ok(result.some((p) => p.endsWith("a.md")));
+    assert.ok(result.some((p) => p.endsWith("b.md")));
+    assert.ok(!result.some((p) => p.endsWith("c.txt")));
+  });
+
+  it("should expand recursive globs", () => {
+    const subDir = join(tmpDir, "sub");
+    mkdirSync(subDir, { recursive: true });
+    writeFileSync(join(subDir, "nested.md"), "# Nested\n");
+
+    const result = expandGlobs([join(tmpDir, "**/*.md")]);
+    assert.ok(result.some((p) => p.endsWith("nested.md")));
+  });
+
+  it("should return empty for globs matching nothing", () => {
+    const result = expandGlobs([join(tmpDir, "*.nonexistent")]);
+    assert.deepEqual(result, []);
+  });
+
+  it("should mix plain paths and globs", () => {
+    const result = expandGlobs(["plain.md", join(tmpDir, "*.md")]);
+    assert.equal(result[0], "plain.md");
+    assert.ok(result.length > 1);
   });
 });


### PR DESCRIPTION
## Summary

Major feature release that makes agent-lint zero-config and significantly more useful:

- **Glob support** — `npx agent-lint "**/*.md"` works in both CLI and GitHub Action
- **Agent detection** — auto-detects Claude Code, Cursor, Windsurf, Codex, Copilot, Cline from their config directories. Errors if a tool is configured but its instruction file is missing.
- **Linter rule validation** (`require-rule-file: "auto"`) — verifies that rules referenced in `**Enforced by:**` annotations actually exist. Supports ESLint (Node API + plugins), Stylelint (Node API), Ruff, Clippy, Pylint, RuboCop (CLI). No extra dependencies installed.
- **Inline PR annotations** — errors show on the affected lines in the PR Files tab via `::error file=X,line=Y::`
- **CI action parity** — all config file options (`require-annotations`, `max-lines`, `require-rule-file`, `linters`) are now available as action inputs
- **Progressive disclosure docs** — `max-lines` error now links to guidance on splitting rules across subdirectory files
- **Default markers expanded** — both `headings` and `checkboxes` enabled by default
- **Action runtime bumped to node22** for `fs.globSync` support
- **README revamp** — restructured around zero-config value prop

## Test plan

- [x] 97 tests pass (`npm test`) covering:
  - All 6 agent tools (Claude Code, Cursor, Windsurf, Codex, Copilot, Cline)
  - All 6 linter resolvers (ESLint, Stylelint, Ruff, Clippy, Pylint, RuboCop)
  - Glob expansion, rulesDir fallback, ESLint plugin resolution
  - Missing instruction file detection, shell injection safety
- [x] `npm run fmt:check` clean
- [x] Manual: `node validate.mjs` with no args auto-detects and validates
