### PR TITLE
Add require-structure rule for markdown schema validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,16 +29,18 @@ vigiles — ESLint for AI agents. Validates that instruction files (CLAUDE.md, A
 
 ## Architecture
 
-Single-file core (`validate.mjs`). Exports: `parseClaudeMd`, `validate`, `readClaudeMd`, `validatePaths`, `loadConfig`, `validateStructure`, `resolveSchema`, `STRUCTURE_PRESETS`.
+Single-file core (`validate.mjs`). Exports: `parseClaudeMd`, `validate`, `readClaudeMd`, `validatePaths`, `loadConfig`, `validateStructure`, `resolveSchema`, `STRUCTURE_PRESETS`, `RULE_PACKS`.
 
 Rules are detected by line-by-line parsing. Two marker types: `###` headings and `- [ ]`/`- [x]` checkboxes (configurable via `.vigilesrc.json`). Each rule must have `**Enforced by:**`, `**Guidance only**`, or `<!-- vigiles-disable -->`.
 
+Two rule packs: `"recommended"` (default) and `"strict"`. Set via `"extends"` in `.vigilesrc.json`. User `"rules"` overrides are merged on top.
+
 Named validation rules (togglable in config under `rules`):
 
-- `require-annotations` (default: `true`) — every rule marker needs an enforcement annotation
-- `max-lines` (default: `500`) — caps file length; set a number for custom limit, `false` to disable
-- `require-rule-file` (default: `"auto"`) — validates referenced linter rules exist and are enabled in project config; auto-detects eslint, stylelint, ruff, clippy, pylint, rubocop. Set `"catalog-only"` to only check rule existence without config-enabled checks
-- `require-structure` (default: `false`) — validates markdown structure against schemas defined in `structures` config. Schemas can specify required/optional sections, heading rules (noSkipLevels, maxDepth), and frontmatter validation. Built-in presets: `"claude-md"`, `"skill"`
+- `require-annotations` (recommended: `true`, strict: `true`) — every rule marker needs an enforcement annotation
+- `max-lines` (recommended: `500`, strict: `300`) — caps file length; set a number for custom limit, `false` to disable
+- `require-rule-file` (recommended: `"auto"`, strict: `"auto"`) — validates referenced linter rules exist and are enabled in project config; auto-detects eslint, stylelint, ruff, clippy, pylint, rubocop. Set `"catalog-only"` to only check rule existence without config-enabled checks
+- `require-structure` (recommended: `false`, strict: `true`) — validates markdown structure via mdschema CLI. Schemas are `.mdschema.yml` files matched to files by glob. Built-in presets: `"claude-md"`, `"claude-md:strict"`, `"skill"`, `"skill:strict"`
 
 ## Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ vigiles — ESLint for AI agents. Validates that instruction files (CLAUDE.md, A
 
 ## Architecture
 
-Single-file core (`validate.mjs`). Exports: `parseClaudeMd`, `validate`, `readClaudeMd`, `validatePaths`, `loadConfig`.
+Single-file core (`validate.mjs`). Exports: `parseClaudeMd`, `validate`, `readClaudeMd`, `validatePaths`, `loadConfig`, `validateStructure`, `resolveSchema`, `STRUCTURE_PRESETS`.
 
 Rules are detected by line-by-line parsing. Two marker types: `###` headings and `- [ ]`/`- [x]` checkboxes (configurable via `.vigilesrc.json`). Each rule must have `**Enforced by:**`, `**Guidance only**`, or `<!-- vigiles-disable -->`.
 
@@ -38,6 +38,7 @@ Named validation rules (togglable in config under `rules`):
 - `require-annotations` (default: `true`) — every rule marker needs an enforcement annotation
 - `max-lines` (default: `500`) — caps file length; set a number for custom limit, `false` to disable
 - `require-rule-file` (default: `"auto"`) — validates referenced linter rules exist and are enabled in project config; auto-detects eslint, stylelint, ruff, clippy, pylint, rubocop. Set `"catalog-only"` to only check rule existence without config-enabled checks
+- `require-structure` (default: `false`) — validates markdown structure against schemas defined in `structures` config. Schemas can specify required/optional sections, heading rules (noSkipLevels, maxDepth), and frontmatter validation. Built-in presets: `"claude-md"`, `"skill"`
 
 ## Rules
 

--- a/README.md
+++ b/README.md
@@ -176,19 +176,54 @@ vigiles works with zero configuration. Optionally create a `.vigilesrc.json` to 
 
 | Option        | Default                      | Description                                                                                          |
 | ------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `extends`     | `"recommended"`              | Rule pack to use as base. `"recommended"` or `"strict"`. User overrides are merged on top.           |
 | `ruleMarkers` | `["headings", "checkboxes"]` | Which rule marker types to recognize                                                                 |
 | `linters`     | `{}`                         | Per-linter config for rule file validation                                                           |
 | `agents`      | `null` (auto-detect)         | List of agent tool names to require, or `null` to auto-detect                                        |
 | `structures`  | `[]`                         | File-to-schema mappings for structure validation. See [Structure Validation](#structure-validation). |
 
+### Rule Packs
+
+Like ESLint's shared configs, vigiles ships with two rule packs. Set `"extends"` in `.vigilesrc.json` to select one — all rules from the pack apply, and any explicit `"rules"` you set override the pack defaults.
+
+```json
+{
+  "extends": "strict"
+}
+```
+
+| Rule                  | `recommended` (default) | `strict`                              |
+| --------------------- | ----------------------- | ------------------------------------- |
+| `require-annotations` | `true`                  | `true`                                |
+| `max-lines`           | `500`                   | `300`                                 |
+| `require-rule-file`   | `"auto"`                | `"auto"`                              |
+| `require-structure`   | `false`                 | `true`                                |
+| `structures`          | `[]`                    | CLAUDE.md + SKILL.md (strict schemas) |
+
+**`recommended`** is the zero-config default — catches missing annotations and oversized files. No structure validation, no extra dependencies.
+
+**`strict`** turns everything on: tighter line limits, structure validation with the strict schema presets (heading hierarchy, required sections, frontmatter). Requires [mdschema](https://github.com/jackchuka/mdschema) for `require-structure`.
+
+You can always override individual rules on top of either pack:
+
+```json
+{
+  "extends": "strict",
+  "rules": {
+    "max-lines": 1000,
+    "require-structure": false
+  }
+}
+```
+
 ### Rules
 
-| Rule                  | Default  | Description                                                                                                                 |
-| --------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `require-annotations` | `true`   | Every rule marker must have `**Enforced by:**` or `**Guidance only**`                                                       |
-| `max-lines`           | `500`    | Maximum number of lines allowed per file. Set a number for custom limit.                                                    |
-| `require-rule-file`   | `"auto"` | Validates that referenced linter rules exist and are enabled in project config. Use `"catalog-only"` to skip config checks. |
-| `require-structure`   | `false`  | Validates markdown structure against schemas. See [Structure Validation](#structure-validation).                            |
+| Rule                  | Description                                                                                                                 |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `require-annotations` | Every rule marker must have `**Enforced by:**` or `**Guidance only**`                                                       |
+| `max-lines`           | Maximum number of lines allowed per file. Set a number for custom limit.                                                    |
+| `require-rule-file`   | Validates that referenced linter rules exist and are enabled in project config. Use `"catalog-only"` to skip config checks. |
+| `require-structure`   | Validates markdown structure against schemas. See [Structure Validation](#structure-validation).                            |
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Companion repo for [Feedback Loop Is All You Need](https://zernie.com/blog/feedb
 - [Configuration](#configuration)
 - [CLI](#cli)
 - [Organizing Rules](#organizing-rules)
+- [Structure Validation](#structure-validation)
 - [GitHub Action](#github-action)
 - [Installing Skills](#installing-skills)
 - [Maturity Levels](#maturity-levels)
@@ -173,11 +174,12 @@ vigiles works with zero configuration. Optionally create a `.vigilesrc.json` to 
 }
 ```
 
-| Option        | Default                      | Description                                                   |
-| ------------- | ---------------------------- | ------------------------------------------------------------- |
-| `ruleMarkers` | `["headings", "checkboxes"]` | Which rule marker types to recognize                          |
-| `linters`     | `{}`                         | Per-linter config for rule file validation                    |
-| `agents`      | `null` (auto-detect)         | List of agent tool names to require, or `null` to auto-detect |
+| Option        | Default                      | Description                                                                                          |
+| ------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `ruleMarkers` | `["headings", "checkboxes"]` | Which rule marker types to recognize                                                                 |
+| `linters`     | `{}`                         | Per-linter config for rule file validation                                                           |
+| `agents`      | `null` (auto-detect)         | List of agent tool names to require, or `null` to auto-detect                                        |
+| `structures`  | `[]`                         | File-to-schema mappings for structure validation. See [Structure Validation](#structure-validation). |
 
 ### Rules
 
@@ -186,6 +188,7 @@ vigiles works with zero configuration. Optionally create a `.vigilesrc.json` to 
 | `require-annotations` | `true`   | Every rule marker must have `**Enforced by:**` or `**Guidance only**`                                                       |
 | `max-lines`           | `500`    | Maximum number of lines allowed per file. Set a number for custom limit.                                                    |
 | `require-rule-file`   | `"auto"` | Validates that referenced linter rules exist and are enabled in project config. Use `"catalog-only"` to skip config checks. |
+| `require-structure`   | `false`  | Validates markdown structure against schemas. See [Structure Validation](#structure-validation).                            |
 
 ## CLI
 
@@ -229,6 +232,99 @@ packages/
 ```
 
 The `max-lines` rule (default: 500) nudges toward this pattern — oversized instruction files waste agent tokens on irrelevant rules.
+
+## Structure Validation
+
+The `require-structure` rule validates that instruction files follow a consistent markdown structure. This is especially useful for enforcing templates across teams — every CLAUDE.md has a Commands section, every SKILL.md has frontmatter with a description, etc.
+
+Enable it in `.vigilesrc.json`:
+
+```json
+{
+  "rules": { "require-structure": true },
+  "structures": [
+    { "files": "CLAUDE.md", "schema": "claude-md" },
+    { "files": "**/SKILL.md", "schema": "skill" }
+  ]
+}
+```
+
+Each entry in `structures` maps a glob pattern to a schema. The `files` glob is matched against the file path, so you can apply different schemas to different directories:
+
+```json
+{
+  "rules": { "require-structure": true },
+  "structures": [
+    { "files": "CLAUDE.md", "schema": "claude-md" },
+    {
+      "files": "packages/api/**/*.md",
+      "schema": {
+        "sections": [
+          { "heading": "## API Reference", "required": true },
+          { "heading": "## Examples", "required": false }
+        ]
+      }
+    },
+    { "files": "**/SKILL.md", "schema": "skill" }
+  ]
+}
+```
+
+### Built-in Presets
+
+| Preset        | What it checks                                                                                            |
+| ------------- | --------------------------------------------------------------------------------------------------------- |
+| `"claude-md"` | Heading levels don't skip (h1→h3), max depth 4. Optional section hints for Commands, Architecture, Rules. |
+| `"skill"`     | Requires YAML frontmatter with a `description` field. Max heading depth 4.                                |
+
+### Custom Schemas
+
+Schemas support four features:
+
+**Required/optional sections** — check that specific headings exist:
+
+```json
+{
+  "sections": [
+    {
+      "heading": "## Commands",
+      "required": true,
+      "description": "Build/test/lint commands"
+    },
+    { "heading": "## Architecture", "required": true },
+    { "heading": "## Principles", "required": false }
+  ]
+}
+```
+
+Heading patterns support trailing wildcards: `"## *"` matches any `##` heading.
+
+**Heading rules** — enforce heading hierarchy:
+
+```json
+{
+  "headingRules": {
+    "noSkipLevels": true,
+    "maxDepth": 3
+  }
+}
+```
+
+`noSkipLevels` errors if you jump from `#` to `###` without a `##`. `maxDepth` caps the deepest heading level allowed.
+
+**Frontmatter validation** — require YAML frontmatter and specific fields:
+
+```json
+{
+  "requireFrontmatter": true,
+  "frontmatterFields": [
+    { "name": "name", "required": false },
+    { "name": "description", "required": true }
+  ]
+}
+```
+
+All features can be combined in a single schema.
 
 ## GitHub Action
 

--- a/README.md
+++ b/README.md
@@ -235,9 +235,21 @@ The `max-lines` rule (default: 500) nudges toward this pattern — oversized ins
 
 ## Structure Validation
 
-The `require-structure` rule validates that instruction files follow a consistent markdown structure. This is especially useful for enforcing templates across teams — every CLAUDE.md has a Commands section, every SKILL.md has frontmatter with a description, etc.
+### Why
 
-Enable it in `.vigilesrc.json`:
+LLM agents treat every instruction file as novel — they'll add a `## Guidelines` section to one CLAUDE.md and `## Conventions` to another, skip heading levels, forget frontmatter on skills, and gradually drift each file into a unique snowflake. Across a team or monorepo this compounds: no two files follow the same template, making them harder for both humans and agents to navigate.
+
+Structure validation enforces a consistent markdown template. Every CLAUDE.md gets the same sections. Every SKILL.md has frontmatter. Heading hierarchy stays clean. The agent gets deterministic feedback when it creates or edits instruction files — not a human code review two days later.
+
+### Setup
+
+Requires [mdschema](https://github.com/jackchuka/mdschema) (optional dependency — vigiles works without it, but this rule is skipped):
+
+```bash
+npm install @jackchuka/mdschema
+```
+
+Enable in `.vigilesrc.json`:
 
 ```json
 {
@@ -249,7 +261,11 @@ Enable it in `.vigilesrc.json`:
 }
 ```
 
-Each entry in `structures` maps a glob pattern to a schema. The `files` glob is matched against the file path, so you can apply different schemas to different directories:
+Each entry maps a glob pattern to a schema. Schemas can be a built-in preset name or a path to a custom `.mdschema.yml` file.
+
+### Glob-Based File Matching
+
+Different schemas for different directories:
 
 ```json
 {
@@ -257,13 +273,8 @@ Each entry in `structures` maps a glob pattern to a schema. The `files` glob is 
   "structures": [
     { "files": "CLAUDE.md", "schema": "claude-md" },
     {
-      "files": "packages/api/**/*.md",
-      "schema": {
-        "sections": [
-          { "heading": "## API Reference", "required": true },
-          { "heading": "## Examples", "required": false }
-        ]
-      }
+      "files": "packages/api/**/CLAUDE.md",
+      "schema": "./schemas/api-claude.yml"
     },
     { "files": "**/SKILL.md", "schema": "skill" }
   ]
@@ -272,59 +283,46 @@ Each entry in `structures` maps a glob pattern to a schema. The `files` glob is 
 
 ### Built-in Presets
 
-| Preset        | What it checks                                                                                            |
-| ------------- | --------------------------------------------------------------------------------------------------------- |
-| `"claude-md"` | Heading levels don't skip (h1→h3), max depth 4. Optional section hints for Commands, Architecture, Rules. |
-| `"skill"`     | Requires YAML frontmatter with a `description` field. Max heading depth 4.                                |
+| Preset        | What it checks                                                                |
+| ------------- | ----------------------------------------------------------------------------- |
+| `"claude-md"` | Heading levels don't skip (h1 to h3), max depth 4. Freeform sections allowed. |
+| `"skill"`     | Requires YAML frontmatter with a `description` field. Max heading depth 4.    |
+
+Preset schemas are bundled in `schemas/`. You can copy and customize them.
 
 ### Custom Schemas
 
-Schemas support four features:
+Create a `.mdschema.yml` file with the full [mdschema syntax](https://github.com/jackchuka/mdschema):
 
-**Required/optional sections** — check that specific headings exist:
+```yaml
+# schemas/api-claude.yml
+structure:
+  - heading:
+      pattern: "# .+"
+    allow_additional: true
+    children:
+      - heading: "## Commands"
+      - heading: "## Architecture"
+      - heading: "## API Conventions"
+        optional: true
 
-```json
-{
-  "sections": [
-    {
-      "heading": "## Commands",
-      "required": true,
-      "description": "Build/test/lint commands"
-    },
-    { "heading": "## Architecture", "required": true },
-    { "heading": "## Principles", "required": false }
-  ]
-}
+heading_rules:
+  no_skip_levels: true
+  max_depth: 4
+
+frontmatter:
+  fields:
+    - name: "description"
+      required: true
 ```
 
-Heading patterns support trailing wildcards: `"## *"` matches any `##` heading.
+mdschema supports required/optional sections, regex heading patterns, nested children, section count constraints (`min`/`max`), `allow_additional` for unlisted subsections, frontmatter field validation, word count rules, required text/code blocks per section, and link validation. See the [mdschema README](https://github.com/jackchuka/mdschema) for the full schema format.
 
-**Heading rules** — enforce heading hierarchy:
+You can also derive a schema from an existing file:
 
-```json
-{
-  "headingRules": {
-    "noSkipLevels": true,
-    "maxDepth": 3
-  }
-}
+```bash
+npx @jackchuka/mdschema derive CLAUDE.md -o schemas/claude-md.yml
 ```
-
-`noSkipLevels` errors if you jump from `#` to `###` without a `##`. `maxDepth` caps the deepest heading level allowed.
-
-**Frontmatter validation** — require YAML frontmatter and specific fields:
-
-```json
-{
-  "requireFrontmatter": true,
-  "frontmatterFields": [
-    { "name": "name", "required": false },
-    { "name": "description", "required": true }
-  ]
-}
-```
-
-All features can be combined in a single schema.
 
 ## GitHub Action
 

--- a/action.mjs
+++ b/action.mjs
@@ -82,6 +82,7 @@ const { fileResults, valid } = validatePaths(paths, {
   ruleMarkers,
   rules,
   linters,
+  structures: config.structures,
 });
 
 let totalEnforced = 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "vigiles",
       "dependencies": {
         "cosmiconfig": "^9.0.1",
-        "glob": "^13.0.6"
+        "glob": "^13.0.6",
+        "minimatch": "^10.0.1"
       },
       "bin": {
         "vigiles": "validate.mjs"
@@ -16,6 +17,9 @@
       "devDependencies": {
         "eslint": "^10.1.0",
         "prettier": "^3.8.1"
+      },
+      "optionalDependencies": {
+        "@jackchuka/mdschema": "^0.12.8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -198,6 +202,124 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jackchuka/mdschema": {
+      "version": "0.12.8",
+      "resolved": "https://registry.npmjs.org/@jackchuka/mdschema/-/mdschema-0.12.8.tgz",
+      "integrity": "sha512-mnmkGeg453N9SGX3xYPafFzAerwhPyAFO1/B5ISTXh/78YlkFUES7aEmbrJYTg+WTuK4hqDOxqNSrN1VN9q7qw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "mdschema": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "@jackchuka/mdschema-darwin-arm64": "0.12.8",
+        "@jackchuka/mdschema-darwin-x64": "0.12.8",
+        "@jackchuka/mdschema-linux-arm64": "0.12.8",
+        "@jackchuka/mdschema-linux-x64": "0.12.8",
+        "@jackchuka/mdschema-windows-arm64": "0.12.8",
+        "@jackchuka/mdschema-windows-x64": "0.12.8"
+      }
+    },
+    "node_modules/@jackchuka/mdschema-darwin-arm64": {
+      "version": "0.12.8",
+      "resolved": "https://registry.npmjs.org/@jackchuka/mdschema-darwin-arm64/-/mdschema-darwin-arm64-0.12.8.tgz",
+      "integrity": "sha512-f3GJrMWl0nf91vDuCr7ckevkVX5nr55pSkCYRNGKZPcqr15/977RJuM9z7tVZJQ+2AdlIvL5IYkv11mFfPyBYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "mdschema": "bin/mdschema"
+      }
+    },
+    "node_modules/@jackchuka/mdschema-darwin-x64": {
+      "version": "0.12.8",
+      "resolved": "https://registry.npmjs.org/@jackchuka/mdschema-darwin-x64/-/mdschema-darwin-x64-0.12.8.tgz",
+      "integrity": "sha512-Ia/z/iuY9AX8tlg0cBxcRHEONv8Jm3SjvqNltDT17RG7lRD+JMIVH6JU0Zp5iDtYpdNIlPDY3Vn0iWvaNXqrIQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "mdschema": "bin/mdschema"
+      }
+    },
+    "node_modules/@jackchuka/mdschema-linux-arm64": {
+      "version": "0.12.8",
+      "resolved": "https://registry.npmjs.org/@jackchuka/mdschema-linux-arm64/-/mdschema-linux-arm64-0.12.8.tgz",
+      "integrity": "sha512-QFuhOYX9gmZWAQAZMxCURadqLyVAMEone/Vwd/GoWcRJrluAjL3v0BBwNZKCYbVIA+kM4XLk2Y4UNqixzYBS2Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "mdschema": "bin/mdschema"
+      }
+    },
+    "node_modules/@jackchuka/mdschema-linux-x64": {
+      "version": "0.12.8",
+      "resolved": "https://registry.npmjs.org/@jackchuka/mdschema-linux-x64/-/mdschema-linux-x64-0.12.8.tgz",
+      "integrity": "sha512-41o1XAcJlrR+1capwAf3/E04Dp8awI3iLDd5hXZKbiGYZb389KSD48MUg+ni3kygvFuJe6RoVUeugPhs01xXWg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "mdschema": "bin/mdschema"
+      }
+    },
+    "node_modules/@jackchuka/mdschema-windows-arm64": {
+      "version": "0.12.8",
+      "resolved": "https://registry.npmjs.org/@jackchuka/mdschema-windows-arm64/-/mdschema-windows-arm64-0.12.8.tgz",
+      "integrity": "sha512-MUzV8i9rzzrhKHeQofjUbmqgalUTm6u8iWAj2ZwrzcsXIb1YqOH/DT4QeKE9Fhys5TxT5iiA27Co8S1pgTlOag==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "mdschema": "bin/mdschema.exe"
+      }
+    },
+    "node_modules/@jackchuka/mdschema-windows-x64": {
+      "version": "0.12.8",
+      "resolved": "https://registry.npmjs.org/@jackchuka/mdschema-windows-x64/-/mdschema-windows-x64-0.12.8.tgz",
+      "integrity": "sha512-UiPe+QRq6oS3hsBC0aOZwgGhHw20tdvnoIFjpkHYsW48T9KgneGD0H233Tsst/Uo/s1nuHHriggnao04PhXxLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "mdschema": "bin/mdschema.exe"
       }
     },
     "node_modules/@types/esrecurse": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
   },
   "dependencies": {
     "cosmiconfig": "^9.0.1",
-    "glob": "^13.0.6"
+    "glob": "^13.0.6",
+    "minimatch": "^10.0.1"
+  },
+  "optionalDependencies": {
+    "@jackchuka/mdschema": "^0.12.8"
   }
 }

--- a/research-feature-ideas.md
+++ b/research-feature-ideas.md
@@ -368,3 +368,66 @@ Also optionally enforces `**Why:**` explanations: `{ "requireWhy": true }`
 | 10  | **Instruction Diffs**  | Migration safety                     | Enforcement removed in PRs, nobody notices                |
 | 11  | **Dependency Graph**   | Build DAG / import graph             | Cross-references to deleted instruction files             |
 | 12  | **Typo Detection**     | Type checking / strict mode          | Near-miss annotations silently ignored                    |
+
+---
+
+## Research: Code Clone Detection & Deterministic Similarity Techniques
+
+Collected April 2026 during investigation of [this Mastodon thread](https://neuromatch.social/@jonny/116328694967192899) about LLM code inconsistency — the same task implemented 3 different ways (set membership, regex, string methods).
+
+### Clone Type Taxonomy
+
+| Type       | What it catches                              | Deterministic?                       | Example                           |
+| ---------- | -------------------------------------------- | ------------------------------------ | --------------------------------- |
+| **Type-1** | Exact clones (modulo whitespace/comments)    | Yes                                  | Copy-paste with reformatting      |
+| **Type-2** | Renamed identifiers/literals                 | Yes                                  | Same logic, different var names   |
+| **Type-3** | Near-miss (added/deleted statements)         | Yes (with fixed threshold)           | Structural modifications          |
+| **Type-4** | Semantically equivalent, textually different | **No** (undecidable, Rice's theorem) | `set.has(x)` vs `/regex/.test(x)` |
+
+Type-4 is the core complaint from the post. It's provably undecidable in the general case.
+
+### Practical Tools
+
+#### Token-Based (Type-1/2) — Fast, CI-ready
+
+- **[PMD CPD](https://pmd.github.io/pmd/pmd_userdocs_cpd.html)** — Token stream matching, 31 languages. GitLab CI integration, Maven plugin. More comprehensive than jscpd for 3+ duplications.
+- **[jscpd](https://github.com/kucherenko/jscpd)** — Rabin-Karp hash fingerprinting, 150+ languages. ~1.4s for 100 files. npm package, Codacy/GitHub Actions integration.
+- **[SourcererCC](https://arxiv.org/abs/1512.06448)** — Token-based inverted index. Scales to 250 MLOC on 12GB RAM, 86% precision. Research tool, not CI-native. Twice as fast as CCFinderX at largest input sizes.
+
+#### AST Tree Edit Distance (Type-3) — Promising
+
+- **[similarity-ts](https://github.com/mizchi/similarity)** — Rust-based, uses Bloom filter + APTED tree edit distance. Built specifically for detecting LLM-generated structural duplicates. <1s for 60K LOC. ~50x speedup from Bloom filter (5x) + multithreading (4x) combined. TypeScript/JS only.
+- **[APTED](https://github.com/DatabaseGroup/apted)** — State-of-the-art optimal tree edit distance. O(n²) worst case. Requires pre-filtering for practical use (n functions = n(n-1)/2 comparisons).
+- **[tree-sitter](https://tree-sitter.github.io/tree-sitter/)** — GLR parser used by similarity-ts and academic tools for AST generation across languages.
+
+#### PDG / Graph-Based (Type-3/4) — Academic
+
+- **CCGraph** (ASE 2020) — PDG + approximate graph matching. Catches non-contiguous clones but graph isomorphism is NP-complete.
+- **Scorpio** — PDG subgraph isomorphism. Academic prototype.
+- **[HideNoSeek](https://github.com/aurore54f/hidenoseek)** — Static data flow analysis for JS syntactic clones.
+
+#### Locality-Sensitive Hashing
+
+Hash code features into buckets where similar items collide. Probabilistic but tunable false-positive rate. Used as pre-filter in tools like SourcererCC.
+
+### Key Insight
+
+For CI today: jscpd/PMD CPD for copy-paste (seconds), similarity-ts for structural near-misses (sub-second, JS/TS only), custom lint rules for known patterns. Type-4 detection (semantically identical, textually different) remains unsolved in production.
+
+### Markdown Structure Validation Tools
+
+- **[mdschema](https://github.com/jackchuka/mdschema)** — Declarative YAML schema for markdown structure. Go binary with npm wrapper. Supports required/optional sections, regex heading patterns, nested children, count constraints, frontmatter validation, word counts, code block requirements, link validation. **Integrated into vigiles as `require-structure` rule.**
+- **[markdown-validator](https://github.com/mattbriggs/markdown-validator)** — Declarative rules for Hugo/DocFX-style markdown.
+- **[markdownlint](https://github.com/DavidAnson/markdownlint)** — Formatting rules (no skipped levels, consistent lists) but not structural schemas.
+- **[Vale](https://vale.sh)** — Prose linter with YAML rule collections. Focuses on writing style, not document structure.
+
+### AI in CI Research
+
+The "LLM reviews PRs in CI" approach hasn't worked due to non-determinism. What works:
+
+- **Semgrep** — AI helps _write_ custom rules, but rules run deterministically.
+- **SonarQube** — Added LLM explanations of findings, detection stays rule-based.
+- **[Factory.ai](https://factory.ai/news/using-linters-to-direct-agents)** — Linters direct agents, not the reverse.
+- **Hybrid SAST + LLM post-processing** — 91% false positive reduction vs standalone Semgrep.
+
+Pattern: **LLM proposes, deterministic tool disposes.** The CI gate stays deterministic.

--- a/schemas/claude-md-strict.yml
+++ b/schemas/claude-md-strict.yml
@@ -1,0 +1,18 @@
+# Strict schema for CLAUDE.md — enforces consistent template structure.
+# See https://github.com/jackchuka/mdschema for full syntax
+
+structure:
+  - heading:
+      pattern: "# .+"
+    optional: true
+    allow_additional: true
+    children:
+      - heading: "## Commands"
+      - heading: "## Architecture"
+        optional: true
+      - heading: "## Rules"
+        optional: true
+
+heading_rules:
+  no_skip_levels: true
+  max_depth: 4

--- a/schemas/claude-md.yml
+++ b/schemas/claude-md.yml
@@ -1,26 +1,6 @@
-# Schema for CLAUDE.md instruction files
+# Default schema for CLAUDE.md — lenient, catches obviously broken structure.
+# Use "claude-md:strict" for full template enforcement.
 # See https://github.com/jackchuka/mdschema for full syntax
 
-structure:
-  - heading:
-      pattern: "# .+"
-    optional: true
-    allow_additional: true
-    children:
-      - heading:
-          pattern: "## .+"
-        optional: true
-        allow_additional: true
-        count:
-          min: 0
-        children:
-          - heading:
-              pattern: "### .+"
-            optional: true
-            allow_additional: true
-            count:
-              min: 0
-
 heading_rules:
-  no_skip_levels: true
-  max_depth: 4
+  max_depth: 6

--- a/schemas/claude-md.yml
+++ b/schemas/claude-md.yml
@@ -1,0 +1,26 @@
+# Schema for CLAUDE.md instruction files
+# See https://github.com/jackchuka/mdschema for full syntax
+
+structure:
+  - heading:
+      pattern: "# .+"
+    optional: true
+    allow_additional: true
+    children:
+      - heading:
+          pattern: "## .+"
+        optional: true
+        allow_additional: true
+        count:
+          min: 0
+        children:
+          - heading:
+              pattern: "### .+"
+            optional: true
+            allow_additional: true
+            count:
+              min: 0
+
+heading_rules:
+  no_skip_levels: true
+  max_depth: 4

--- a/schemas/skill-strict.yml
+++ b/schemas/skill-strict.yml
@@ -1,0 +1,12 @@
+# Strict schema for SKILL.md — enforces frontmatter fields and heading depth.
+# See https://github.com/jackchuka/mdschema for full syntax
+
+frontmatter:
+  fields:
+    - name: "description"
+      required: true
+    - name: "name"
+      required: false
+
+heading_rules:
+  max_depth: 4

--- a/schemas/skill.yml
+++ b/schemas/skill.yml
@@ -1,10 +1,5 @@
-# Schema for SKILL.md files (Claude Code skills)
+# Default schema for SKILL.md — lenient, just checks frontmatter exists.
+# Use "skill:strict" for full template enforcement.
 # See https://github.com/jackchuka/mdschema for full syntax
 
-frontmatter:
-  fields:
-    - name: "description"
-      required: true
-
-heading_rules:
-  max_depth: 4
+frontmatter: {}

--- a/schemas/skill.yml
+++ b/schemas/skill.yml
@@ -1,0 +1,10 @@
+# Schema for SKILL.md files (Claude Code skills)
+# See https://github.com/jackchuka/mdschema for full syntax
+
+frontmatter:
+  fields:
+    - name: "description"
+      required: true
+
+heading_rules:
+  max_depth: 4

--- a/validate.mjs
+++ b/validate.mjs
@@ -15,20 +15,43 @@ const RULE_HEADER_RE = /^###\s+(.+)$/;
 const CHECKBOX_RE = /^- \[([ xX])\]\s+(.+)$/;
 
 const VALID_MARKERS = ["headings", "checkboxes"];
-const DEFAULT_RULES = {
-  "require-annotations": true,
-  "max-lines": 500,
-  "require-rule-file": "auto",
-  "require-structure": false,
-};
 const SAFE_RULE_NAME_RE = /^[a-zA-Z0-9_\-/.:#]+$/;
 
 // Built-in schema presets (bundled .yml files in schemas/)
 const SCHEMAS_DIR = new URL("./schemas/", import.meta.url).pathname;
 export const STRUCTURE_PRESETS = {
   "claude-md": resolve(SCHEMAS_DIR, "claude-md.yml"),
+  "claude-md:strict": resolve(SCHEMAS_DIR, "claude-md-strict.yml"),
   skill: resolve(SCHEMAS_DIR, "skill.yml"),
+  "skill:strict": resolve(SCHEMAS_DIR, "skill-strict.yml"),
 };
+
+// Rule packs — like eslint's "recommended" / "strict" configs
+export const RULE_PACKS = {
+  recommended: {
+    rules: {
+      "require-annotations": true,
+      "max-lines": 500,
+      "require-rule-file": "auto",
+      "require-structure": false,
+    },
+    structures: [],
+  },
+  strict: {
+    rules: {
+      "require-annotations": true,
+      "max-lines": 300,
+      "require-rule-file": "auto",
+      "require-structure": true,
+    },
+    structures: [
+      { files: "CLAUDE.md", schema: "claude-md:strict" },
+      { files: "**/SKILL.md", schema: "skill:strict" },
+    ],
+  },
+};
+
+const DEFAULT_RULES = RULE_PACKS.recommended.rules;
 
 // Resolve the mdschema binary path (optional dependency)
 function findMdschema() {
@@ -132,11 +155,12 @@ const AGENT_TOOLS = [
 ];
 
 const DEFAULT_CONFIG = {
+  extends: "recommended",
   ruleMarkers: ["headings", "checkboxes"],
   rules: DEFAULT_RULES,
   linters: {},
   agents: null, // null = auto-detect; array = explicit list of tool names
-  structures: [], // array of { files: "<glob>", schema: <object|preset-name> }
+  structures: [], // array of { files: "<glob>", schema: <preset-name|path> }
 };
 
 function extractLinterName(enforcedBy) {
@@ -554,13 +578,24 @@ export function loadConfig() {
     const result = explorer.search();
     if (!result || !result.config) return DEFAULT_CONFIG;
 
+    // Resolve rule pack base
+    const packName = result.config.extends || "recommended";
+    const pack = RULE_PACKS[packName];
+    if (!pack) {
+      console.warn(`Unknown rule pack: "${packName}". Using "recommended".`);
+    }
+    const basePack = pack || RULE_PACKS.recommended;
+
+    // User config overrides the pack
     const config = {
       ...DEFAULT_CONFIG,
       ...result.config,
-      rules: { ...DEFAULT_RULES, ...result.config.rules },
+      rules: { ...basePack.rules, ...result.config.rules },
       linters: { ...result.config.linters },
       agents: result.config.agents !== undefined ? result.config.agents : null,
-      structures: resolveStructures(result.config.structures),
+      structures: resolveStructures(
+        result.config.structures || basePack.structures,
+      ),
     };
 
     if (

--- a/validate.mjs
+++ b/validate.mjs
@@ -6,6 +6,7 @@ import { resolve, dirname } from "node:path";
 import { execSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { cosmiconfigSync } from "cosmiconfig";
+import { minimatch } from "minimatch";
 
 const ENFORCED_BY_RE = /\*\*Enforced by:\*\*/;
 const GUIDANCE_RE = /\*\*Guidance only\*\*/;
@@ -18,8 +19,186 @@ const DEFAULT_RULES = {
   "require-annotations": true,
   "max-lines": 500,
   "require-rule-file": "auto",
+  "require-structure": false,
 };
 const SAFE_RULE_NAME_RE = /^[a-zA-Z0-9_\-/.:#]+$/;
+
+const HEADING_RE = /^(#{1,6})\s+(.+)$/;
+
+// Built-in structure presets
+export const STRUCTURE_PRESETS = {
+  "claude-md": {
+    sections: [
+      { heading: "# *", required: false },
+      {
+        heading: "## Commands",
+        required: false,
+        description: "Build/test/lint commands",
+      },
+      {
+        heading: "## Architecture",
+        required: false,
+        description: "Project structure overview",
+      },
+      {
+        heading: "## Rules",
+        required: false,
+        description: "Coding rules with enforcement annotations",
+      },
+    ],
+    headingRules: { noSkipLevels: true, maxDepth: 4 },
+  },
+  skill: {
+    sections: [
+      {
+        heading: "## *",
+        required: false,
+        description: "Skills use freeform ## sections",
+      },
+    ],
+    requireFrontmatter: true,
+    frontmatterFields: [
+      { name: "name", required: false },
+      { name: "description", required: true },
+    ],
+    headingRules: { noSkipLevels: false, maxDepth: 4 },
+  },
+};
+
+/**
+ * Parse all headings from markdown content.
+ * Returns [{ level, title, line }]
+ */
+function parseHeadings(content) {
+  const lines = content.split("\n");
+  const headings = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(HEADING_RE);
+    if (m) {
+      headings.push({ level: m[1].length, title: m[2].trim(), line: i + 1 });
+    }
+  }
+  return headings;
+}
+
+/**
+ * Check if a heading title matches a section spec.
+ * Supports literal match and trailing wildcard ("## *" matches any ## heading).
+ */
+function headingMatches(title, spec) {
+  // spec is the heading value from a section definition, e.g. "## Commands" or "## *"
+  // strip the leading #s to get just the title part
+  const specTitle = spec.replace(/^#+\s*/, "");
+  if (specTitle === "*") return true;
+  if (specTitle.endsWith("*")) {
+    return title.startsWith(specTitle.slice(0, -1));
+  }
+  return title === specTitle;
+}
+
+function specLevel(spec) {
+  const m = spec.match(/^(#+)/);
+  return m ? m[1].length : 0;
+}
+
+/**
+ * Parse YAML frontmatter from markdown content.
+ * Returns { fields: { key: value }, endLine } or null if no frontmatter.
+ */
+function parseFrontmatter(content) {
+  const lines = content.split("\n");
+  if (lines[0] !== "---") return null;
+  const fields = {};
+  let endLine = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i] === "---") {
+      endLine = i + 1;
+      break;
+    }
+    const m = lines[i].match(/^(\w[\w-]*):\s*(.*)/);
+    if (m) {
+      fields[m[1]] = m[2].trim();
+    }
+  }
+  if (endLine === -1) return null;
+  return { fields, endLine };
+}
+
+/**
+ * Validate markdown content against a structure schema.
+ * Returns an array of error objects { rule, message, line }.
+ */
+export function validateStructure(content, schema) {
+  const errors = [];
+  const headings = parseHeadings(content);
+
+  // Check frontmatter
+  if (schema.requireFrontmatter) {
+    const fm = parseFrontmatter(content);
+    if (!fm) {
+      errors.push({
+        rule: "require-structure",
+        message:
+          "Missing YAML frontmatter (expected --- delimited block at top of file)",
+        line: 1,
+      });
+    } else if (schema.frontmatterFields) {
+      for (const field of schema.frontmatterFields) {
+        if (field.required && !(field.name in fm.fields)) {
+          errors.push({
+            rule: "require-structure",
+            message: `Frontmatter missing required field "${field.name}"`,
+            line: 1,
+          });
+        }
+      }
+    }
+  }
+
+  // Check heading rules
+  if (schema.headingRules) {
+    const { noSkipLevels, maxDepth } = schema.headingRules;
+    let prevLevel = 0;
+    for (const h of headings) {
+      if (maxDepth && h.level > maxDepth) {
+        errors.push({
+          rule: "require-structure",
+          message: `Line ${h.line}: heading "${"#".repeat(h.level)} ${h.title}" exceeds max depth ${maxDepth}`,
+          line: h.line,
+        });
+      }
+      if (noSkipLevels && prevLevel > 0 && h.level > prevLevel + 1) {
+        errors.push({
+          rule: "require-structure",
+          message: `Line ${h.line}: heading level skips from h${prevLevel} to h${h.level} ("${h.title}")`,
+          line: h.line,
+        });
+      }
+      prevLevel = h.level;
+    }
+  }
+
+  // Check required sections
+  if (schema.sections) {
+    for (const section of schema.sections) {
+      if (!section.required) continue;
+      const level = specLevel(section.heading);
+      const specTitle = section.heading.replace(/^#+\s*/, "");
+      const found = headings.some(
+        (h) => h.level === level && headingMatches(h.title, section.heading),
+      );
+      if (!found) {
+        errors.push({
+          rule: "require-structure",
+          message: `Missing required section "${section.heading}"${section.description ? ` (${section.description})` : ""}`,
+          line: 1,
+        });
+      }
+    }
+  }
+
+  return errors;
+}
 
 // AI coding tools: presence indicators and required instruction files
 const AGENT_TOOLS = [
@@ -61,6 +240,7 @@ const DEFAULT_CONFIG = {
   rules: DEFAULT_RULES,
   linters: {},
   agents: null, // null = auto-detect; array = explicit list of tool names
+  structures: [], // array of { files: "<glob>", schema: <object|preset-name> }
 };
 
 function extractLinterName(enforcedBy) {
@@ -436,6 +616,32 @@ export function discoverInstructionFiles(cwd = process.cwd(), agents = null) {
   return { detected, files, missing };
 }
 
+/**
+ * Resolve a schema value: if it's a string, look up the preset; otherwise return as-is.
+ */
+export function resolveSchema(schema) {
+  if (typeof schema === "string") {
+    const preset = STRUCTURE_PRESETS[schema];
+    if (!preset) {
+      console.warn(`Unknown structure preset: "${schema}". Skipping.`);
+      return null;
+    }
+    return preset;
+  }
+  return schema;
+}
+
+function resolveStructures(raw) {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((entry) => {
+      const schema = resolveSchema(entry.schema);
+      if (!schema) return null;
+      return { files: entry.files, schema };
+    })
+    .filter(Boolean);
+}
+
 export function loadConfig() {
   try {
     const explorer = cosmiconfigSync("vigiles", {
@@ -451,6 +657,7 @@ export function loadConfig() {
       rules: { ...DEFAULT_RULES, ...result.config.rules },
       linters: { ...result.config.linters },
       agents: result.config.agents !== undefined ? result.config.agents : null,
+      structures: resolveStructures(result.config.structures),
     };
 
     if (
@@ -532,7 +739,14 @@ export function parseClaudeMd(content, { ruleMarkers } = {}) {
 
 export function validate(
   content,
-  { ruleMarkers, rules: rulesConfig, basePath, linters: lintersConfig } = {},
+  {
+    ruleMarkers,
+    rules: rulesConfig,
+    basePath,
+    linters: lintersConfig,
+    structures,
+    filePath,
+  } = {},
 ) {
   const activeRules = rulesConfig || DEFAULT_RULES;
   const parsedRules = parseClaudeMd(content, { ruleMarkers });
@@ -571,6 +785,21 @@ export function validate(
         message: `File has ${lineCount} lines, exceeding the limit of ${limit}. Consider splitting into subdirectory files — see https://github.com/zernie/vigiles#organizing-rules`,
         line: lineCount,
       });
+    }
+  }
+
+  // --- require-structure: validate markdown structure against schemas ---
+  if (activeRules["require-structure"] !== false && structures && filePath) {
+    for (const entry of structures) {
+      // Match filePath against the glob pattern (test both full path and basename)
+      const basename = filePath.split("/").pop();
+      if (
+        minimatch(filePath, entry.files, { matchBase: true }) ||
+        minimatch(basename, entry.files)
+      ) {
+        const structErrors = validateStructure(content, entry.schema);
+        errors.push(...structErrors);
+      }
     }
   }
 
@@ -822,6 +1051,7 @@ export function validatePaths(
     ruleMarkers,
     rules: rulesConfig,
     linters: lintersConfig,
+    structures,
   } = {},
 ) {
   const fileResults = [];
@@ -853,6 +1083,8 @@ export function validatePaths(
       rules: rulesConfig,
       basePath: dirname(resolve(filePath)),
       linters: lintersConfig,
+      structures,
+      filePath,
     });
     if (!result.valid) allValid = false;
     fileResults.push({ path: filePath, skipped: false, reason: null, result });
@@ -930,6 +1162,7 @@ if (
     ruleMarkers,
     rules: config.rules,
     linters: config.linters,
+    structures: config.structures,
   });
 
   for (const { path: filePath, skipped, reason, result } of fileResults) {

--- a/validate.mjs
+++ b/validate.mjs
@@ -23,181 +23,77 @@ const DEFAULT_RULES = {
 };
 const SAFE_RULE_NAME_RE = /^[a-zA-Z0-9_\-/.:#]+$/;
 
-const HEADING_RE = /^(#{1,6})\s+(.+)$/;
-
-// Built-in structure presets
+// Built-in schema presets (bundled .yml files in schemas/)
+const SCHEMAS_DIR = new URL("./schemas/", import.meta.url).pathname;
 export const STRUCTURE_PRESETS = {
-  "claude-md": {
-    sections: [
-      { heading: "# *", required: false },
-      {
-        heading: "## Commands",
-        required: false,
-        description: "Build/test/lint commands",
-      },
-      {
-        heading: "## Architecture",
-        required: false,
-        description: "Project structure overview",
-      },
-      {
-        heading: "## Rules",
-        required: false,
-        description: "Coding rules with enforcement annotations",
-      },
-    ],
-    headingRules: { noSkipLevels: true, maxDepth: 4 },
-  },
-  skill: {
-    sections: [
-      {
-        heading: "## *",
-        required: false,
-        description: "Skills use freeform ## sections",
-      },
-    ],
-    requireFrontmatter: true,
-    frontmatterFields: [
-      { name: "name", required: false },
-      { name: "description", required: true },
-    ],
-    headingRules: { noSkipLevels: false, maxDepth: 4 },
-  },
+  "claude-md": resolve(SCHEMAS_DIR, "claude-md.yml"),
+  skill: resolve(SCHEMAS_DIR, "skill.yml"),
 };
 
-/**
- * Parse all headings from markdown content.
- * Returns [{ level, title, line }]
- */
-function parseHeadings(content) {
-  const lines = content.split("\n");
-  const headings = [];
-  for (let i = 0; i < lines.length; i++) {
-    const m = lines[i].match(HEADING_RE);
-    if (m) {
-      headings.push({ level: m[1].length, title: m[2].trim(), line: i + 1 });
-    }
+// Resolve the mdschema binary path (optional dependency)
+function findMdschema() {
+  try {
+    const req = createRequire(resolve(process.cwd(), "package.json"));
+    const { getBinaryPath } = req("@jackchuka/mdschema/lib/platform");
+    const bin = getBinaryPath();
+    if (existsSync(bin)) return bin;
+  } catch {
+    // not installed via npm
   }
-  return headings;
+  // Try PATH
+  try {
+    execSync("which mdschema", { stdio: "ignore" });
+    return "mdschema";
+  } catch {
+    return null;
+  }
 }
 
-/**
- * Check if a heading title matches a section spec.
- * Supports literal match and trailing wildcard ("## *" matches any ## heading).
- */
-function headingMatches(title, spec) {
-  // spec is the heading value from a section definition, e.g. "## Commands" or "## *"
-  // strip the leading #s to get just the title part
-  const specTitle = spec.replace(/^#+\s*/, "");
-  if (specTitle === "*") return true;
-  if (specTitle.endsWith("*")) {
-    return title.startsWith(specTitle.slice(0, -1));
+let _mdschemaPath;
+function getMdschema() {
+  if (_mdschemaPath === undefined) {
+    _mdschemaPath = findMdschema();
   }
-  return title === specTitle;
+  return _mdschemaPath;
 }
 
-function specLevel(spec) {
-  const m = spec.match(/^(#+)/);
-  return m ? m[1].length : 0;
-}
+// Parse mdschema text output into error objects
+// Format: "  ✗ LINE:COL [RULE] MESSAGE"
+const MDSCHEMA_ERROR_RE = /^\s*✗\s+(\d+):(\d+)\s+\[([^\]]+)\]\s+(.+)$/;
 
 /**
- * Parse YAML frontmatter from markdown content.
- * Returns { fields: { key: value }, endLine } or null if no frontmatter.
+ * Validate a markdown file against an mdschema YAML schema.
+ * @param {string} filePath - path to the markdown file
+ * @param {string} schemaPath - path to the .mdschema.yml file
+ * @returns {{ errors: Array<{rule: string, message: string, line: number}>, available: boolean }}
  */
-function parseFrontmatter(content) {
-  const lines = content.split("\n");
-  if (lines[0] !== "---") return null;
-  const fields = {};
-  let endLine = -1;
-  for (let i = 1; i < lines.length; i++) {
-    if (lines[i] === "---") {
-      endLine = i + 1;
-      break;
-    }
-    const m = lines[i].match(/^(\w[\w-]*):\s*(.*)/);
-    if (m) {
-      fields[m[1]] = m[2].trim();
-    }
+export function validateStructure(filePath, schemaPath) {
+  const bin = getMdschema();
+  if (!bin) {
+    return { errors: [], available: false };
   }
-  if (endLine === -1) return null;
-  return { fields, endLine };
-}
-
-/**
- * Validate markdown content against a structure schema.
- * Returns an array of error objects { rule, message, line }.
- */
-export function validateStructure(content, schema) {
-  const errors = [];
-  const headings = parseHeadings(content);
-
-  // Check frontmatter
-  if (schema.requireFrontmatter) {
-    const fm = parseFrontmatter(content);
-    if (!fm) {
-      errors.push({
-        rule: "require-structure",
-        message:
-          "Missing YAML frontmatter (expected --- delimited block at top of file)",
-        line: 1,
-      });
-    } else if (schema.frontmatterFields) {
-      for (const field of schema.frontmatterFields) {
-        if (field.required && !(field.name in fm.fields)) {
-          errors.push({
-            rule: "require-structure",
-            message: `Frontmatter missing required field "${field.name}"`,
-            line: 1,
-          });
-        }
-      }
-    }
-  }
-
-  // Check heading rules
-  if (schema.headingRules) {
-    const { noSkipLevels, maxDepth } = schema.headingRules;
-    let prevLevel = 0;
-    for (const h of headings) {
-      if (maxDepth && h.level > maxDepth) {
+  try {
+    execSync(`${bin} check --schema ${schemaPath} ${filePath}`, {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 15000,
+    });
+    return { errors: [], available: true };
+  } catch (e) {
+    const output = (e.stdout || "") + (e.stderr || "");
+    const errors = [];
+    for (const line of output.split("\n")) {
+      const m = line.match(MDSCHEMA_ERROR_RE);
+      if (m) {
         errors.push({
           rule: "require-structure",
-          message: `Line ${h.line}: heading "${"#".repeat(h.level)} ${h.title}" exceeds max depth ${maxDepth}`,
-          line: h.line,
-        });
-      }
-      if (noSkipLevels && prevLevel > 0 && h.level > prevLevel + 1) {
-        errors.push({
-          rule: "require-structure",
-          message: `Line ${h.line}: heading level skips from h${prevLevel} to h${h.level} ("${h.title}")`,
-          line: h.line,
-        });
-      }
-      prevLevel = h.level;
-    }
-  }
-
-  // Check required sections
-  if (schema.sections) {
-    for (const section of schema.sections) {
-      if (!section.required) continue;
-      const level = specLevel(section.heading);
-      const specTitle = section.heading.replace(/^#+\s*/, "");
-      const found = headings.some(
-        (h) => h.level === level && headingMatches(h.title, section.heading),
-      );
-      if (!found) {
-        errors.push({
-          rule: "require-structure",
-          message: `Missing required section "${section.heading}"${section.description ? ` (${section.description})` : ""}`,
-          line: 1,
+          message: `[${m[3]}] ${m[4]}`,
+          line: parseInt(m[1], 10),
         });
       }
     }
+    return { errors, available: true };
   }
-
-  return errors;
 }
 
 // AI coding tools: presence indicators and required instruction files
@@ -617,18 +513,25 @@ export function discoverInstructionFiles(cwd = process.cwd(), agents = null) {
 }
 
 /**
- * Resolve a schema value: if it's a string, look up the preset; otherwise return as-is.
+ * Resolve a schema value to a file path.
+ * - If it's a preset name ("claude-md", "skill"), return the bundled .yml path.
+ * - If it's a file path string, resolve it relative to cwd.
+ * - Otherwise return null.
  */
 export function resolveSchema(schema) {
-  if (typeof schema === "string") {
-    const preset = STRUCTURE_PRESETS[schema];
-    if (!preset) {
-      console.warn(`Unknown structure preset: "${schema}". Skipping.`);
-      return null;
-    }
-    return preset;
+  if (typeof schema !== "string") {
+    console.warn(
+      `Invalid schema value: expected a preset name or file path string. Skipping.`,
+    );
+    return null;
   }
-  return schema;
+  const preset = STRUCTURE_PRESETS[schema];
+  if (preset) return preset;
+  // Treat as file path
+  const resolved = resolve(schema);
+  if (existsSync(resolved)) return resolved;
+  console.warn(`Schema not found: "${schema}". Skipping.`);
+  return null;
 }
 
 function resolveStructures(raw) {
@@ -788,7 +691,7 @@ export function validate(
     }
   }
 
-  // --- require-structure: validate markdown structure against schemas ---
+  // --- require-structure: validate markdown structure against schemas (via mdschema CLI) ---
   if (activeRules["require-structure"] !== false && structures && filePath) {
     for (const entry of structures) {
       // Match filePath against the glob pattern (test both full path and basename)
@@ -797,7 +700,19 @@ export function validate(
         minimatch(filePath, entry.files, { matchBase: true }) ||
         minimatch(basename, entry.files)
       ) {
-        const structErrors = validateStructure(content, entry.schema);
+        const { errors: structErrors, available } = validateStructure(
+          resolve(filePath),
+          entry.schema,
+        );
+        if (!available) {
+          errors.push({
+            rule: "require-structure",
+            message:
+              "mdschema is not installed. Install with: npm install @jackchuka/mdschema",
+            line: 1,
+          });
+          break; // Only warn once
+        }
         errors.push(...structErrors);
       }
     }

--- a/validate.test.mjs
+++ b/validate.test.mjs
@@ -20,6 +20,7 @@ import {
   validateStructure,
   resolveSchema,
   STRUCTURE_PRESETS,
+  RULE_PACKS,
 } from "./validate.mjs";
 
 describe("parseClaudeMd", () => {
@@ -324,6 +325,46 @@ describe("loadConfig", () => {
     assert.deepEqual(config.ruleMarkers, ["headings", "checkboxes"]);
     process.chdir(originalCwd);
     rmSync(configDir, { recursive: true, force: true });
+  });
+
+  it("should apply strict rule pack via extends", () => {
+    const configDir = mkdtempSync(join(tmpdir(), "vigiles-strict-"));
+    writeFileSync(
+      join(configDir, ".vigilesrc.json"),
+      JSON.stringify({ extends: "strict" }),
+    );
+    process.chdir(configDir);
+    const config = loadConfig();
+    assert.equal(config.rules["max-lines"], 300);
+    assert.equal(config.rules["require-structure"], true);
+    assert.ok(config.structures.length > 0);
+    process.chdir(originalCwd);
+    rmSync(configDir, { recursive: true, force: true });
+  });
+
+  it("should allow user overrides on top of strict pack", () => {
+    const configDir = mkdtempSync(join(tmpdir(), "vigiles-override-"));
+    writeFileSync(
+      join(configDir, ".vigilesrc.json"),
+      JSON.stringify({
+        extends: "strict",
+        rules: { "max-lines": 1000, "require-structure": false },
+      }),
+    );
+    process.chdir(configDir);
+    const config = loadConfig();
+    assert.equal(config.rules["max-lines"], 1000);
+    assert.equal(config.rules["require-structure"], false);
+    assert.equal(config.rules["require-annotations"], true); // from pack
+    process.chdir(originalCwd);
+    rmSync(configDir, { recursive: true, force: true });
+  });
+
+  it("should default to recommended when extends is omitted", () => {
+    process.chdir(tmpDir);
+    const config = loadConfig();
+    assert.equal(config.rules["max-lines"], 500);
+    assert.equal(config.rules["require-structure"], false);
   });
 
   it("should fall back to defaults for invalid ruleMarkers", () => {

--- a/validate.test.mjs
+++ b/validate.test.mjs
@@ -1571,165 +1571,159 @@ describe("discoverInstructionFiles", () => {
   });
 });
 
-describe("validateStructure", () => {
-  it("should pass when no required sections and content is valid", () => {
-    const errors = validateStructure("# Hello\n\nSome text.\n", {
-      sections: [],
-    });
-    assert.equal(errors.length, 0);
+describe("validateStructure (mdschema CLI)", () => {
+  let tmpDir;
+
+  before(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "vigiles-struct-"));
   });
 
-  it("should error on missing required section", () => {
-    const schema = {
-      sections: [
-        { heading: "## Commands", required: true },
-        { heading: "## Rules", required: true },
-      ],
-    };
-    const content = "# My Project\n\n## Commands\n\nnpm test\n";
-    const errors = validateStructure(content, schema);
-    assert.equal(errors.length, 1);
-    assert.ok(errors[0].message.includes("## Rules"));
+  after(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("should pass when all required sections present", () => {
-    const schema = {
-      sections: [
-        { heading: "## Commands", required: true },
-        { heading: "## Rules", required: true },
-      ],
-    };
-    const content =
-      "# My Project\n\n## Commands\n\nnpm test\n\n## Rules\n\n### No console\n";
-    const errors = validateStructure(content, schema);
-    assert.equal(errors.length, 0);
-  });
+  function writeSchema(name, content) {
+    const p = join(tmpDir, name);
+    writeFileSync(p, content);
+    return p;
+  }
 
-  it("should skip optional sections without error", () => {
-    const schema = {
-      sections: [
-        { heading: "## Commands", required: true },
-        { heading: "## Architecture", required: false },
-      ],
-    };
-    const content = "# Project\n\n## Commands\n\nnpm test\n";
-    const errors = validateStructure(content, schema);
+  function writeMd(name, content) {
+    const p = join(tmpDir, name);
+    writeFileSync(p, content);
+    return p;
+  }
+
+  it("should pass valid file against schema", () => {
+    const schema = writeSchema(
+      "s1.yml",
+      "heading_rules:\n  no_skip_levels: true\n  max_depth: 3\n",
+    );
+    const md = writeMd("t1.md", "# Title\n\n## Section\n\n### Sub\n");
+    const { errors, available } = validateStructure(md, schema);
+    if (!available) return; // skip if mdschema not installed
     assert.equal(errors.length, 0);
   });
 
   it("should detect skipped heading levels", () => {
-    const schema = { headingRules: { noSkipLevels: true } };
-    const content = "# Title\n\n### Skipped h2\n\nSome text.\n";
-    const errors = validateStructure(content, schema);
-    assert.equal(errors.length, 1);
-    assert.ok(errors[0].message.includes("skips from h1 to h3"));
-  });
-
-  it("should not error on valid heading levels", () => {
-    const schema = { headingRules: { noSkipLevels: true } };
-    const content = "# Title\n\n## Section\n\n### Subsection\n";
-    const errors = validateStructure(content, schema);
-    assert.equal(errors.length, 0);
+    const schema = writeSchema(
+      "s2.yml",
+      "heading_rules:\n  no_skip_levels: true\n",
+    );
+    const md = writeMd("t2.md", "# Title\n\n### Skipped h2\n");
+    const { errors, available } = validateStructure(md, schema);
+    if (!available) return;
+    assert.ok(errors.length > 0);
+    assert.ok(errors.some((e) => e.rule === "require-structure"));
   });
 
   it("should detect headings exceeding max depth", () => {
-    const schema = { headingRules: { maxDepth: 3 } };
-    const content = "# Title\n\n## Section\n\n### Sub\n\n#### Too deep\n";
-    const errors = validateStructure(content, schema);
-    assert.equal(errors.length, 1);
-    assert.ok(errors[0].message.includes("exceeds max depth 3"));
+    const schema = writeSchema("s3.yml", "heading_rules:\n  max_depth: 3\n");
+    const md = writeMd(
+      "t3.md",
+      "# Title\n\n## Section\n\n### Sub\n\n#### Too deep\n",
+    );
+    const { errors, available } = validateStructure(md, schema);
+    if (!available) return;
+    assert.ok(errors.length > 0);
   });
 
   it("should require frontmatter when specified", () => {
-    const schema = { requireFrontmatter: true };
-    const content = "# No frontmatter\n\nJust text.\n";
-    const errors = validateStructure(content, schema);
-    assert.equal(errors.length, 1);
-    assert.ok(errors[0].message.includes("Missing YAML frontmatter"));
+    const schema = writeSchema(
+      "s4.yml",
+      'frontmatter:\n  fields:\n    - name: "description"\n      required: true\n',
+    );
+    const md = writeMd("t4.md", "# No frontmatter\n\nJust text.\n");
+    const { errors, available } = validateStructure(md, schema);
+    if (!available) return;
+    assert.ok(errors.length > 0);
+    assert.ok(errors.some((e) => e.message.includes("frontmatter")));
   });
 
-  it("should pass when frontmatter is present", () => {
-    const schema = { requireFrontmatter: true };
-    const content = "---\nname: my-skill\n---\n\n# Skill\n";
-    const errors = validateStructure(content, schema);
+  it("should pass when frontmatter has required fields", () => {
+    const schema = writeSchema(
+      "s5.yml",
+      'frontmatter:\n  fields:\n    - name: "description"\n      required: true\n',
+    );
+    const md = writeMd("t5.md", "---\ndescription: hello\n---\n\n# Skill\n");
+    const { errors, available } = validateStructure(md, schema);
+    if (!available) return;
     assert.equal(errors.length, 0);
   });
 
-  it("should validate required frontmatter fields", () => {
-    const schema = {
-      requireFrontmatter: true,
-      frontmatterFields: [
-        { name: "name", required: false },
-        { name: "description", required: true },
-      ],
-    };
-    const content = "---\nname: test\n---\n\n# Test\n";
-    const errors = validateStructure(content, schema);
-    assert.equal(errors.length, 1);
-    assert.ok(errors[0].message.includes("description"));
+  it("should error on missing required section", () => {
+    const schema = writeSchema(
+      "s6.yml",
+      'structure:\n  - heading:\n      pattern: "# .+"\n    allow_additional: true\n    children:\n      - heading: "## Commands"\n',
+    );
+    const md = writeMd("t6.md", "# Project\n\n## Other\n\nNo commands.\n");
+    const { errors, available } = validateStructure(md, schema);
+    if (!available) return;
+    assert.ok(errors.length > 0);
+    assert.ok(errors.some((e) => e.message.includes("Commands")));
   });
 
-  it("should pass when all required frontmatter fields present", () => {
-    const schema = {
-      requireFrontmatter: true,
-      frontmatterFields: [
-        { name: "name", required: true },
-        { name: "description", required: true },
-      ],
-    };
-    const content =
-      "---\nname: test\ndescription: A test skill\n---\n\n# Test\n";
-    const errors = validateStructure(content, schema);
+  it("should pass when required section is present", () => {
+    const schema = writeSchema(
+      "s7.yml",
+      'structure:\n  - heading:\n      pattern: "# .+"\n    allow_additional: true\n    children:\n      - heading: "## Commands"\n',
+    );
+    const md = writeMd("t7.md", "# Project\n\n## Commands\n\nnpm test\n");
+    const { errors, available } = validateStructure(md, schema);
+    if (!available) return;
     assert.equal(errors.length, 0);
   });
 
-  it("should match wildcard heading patterns", () => {
-    const schema = {
-      sections: [{ heading: "## *", required: true }],
-    };
-    const content = "# Title\n\n## Anything\n\nText.\n";
-    const errors = validateStructure(content, schema);
-    assert.equal(errors.length, 0);
-  });
-
-  it("should fail wildcard when no headings at that level exist", () => {
-    const schema = {
-      sections: [{ heading: "## *", required: true }],
-    };
-    const content = "# Title\n\nJust text, no h2 sections.\n";
-    const errors = validateStructure(content, schema);
-    assert.equal(errors.length, 1);
+  it("should parse line numbers from mdschema output", () => {
+    const schema = writeSchema(
+      "s8.yml",
+      "heading_rules:\n  no_skip_levels: true\n",
+    );
+    const md = writeMd("t8.md", "# Title\n\n### Skipped\n");
+    const { errors, available } = validateStructure(md, schema);
+    if (!available) return;
+    assert.ok(errors.length > 0);
+    assert.ok(errors[0].line > 0);
   });
 });
 
 describe("resolveSchema", () => {
-  it("should resolve 'claude-md' preset", () => {
+  it("should resolve 'claude-md' preset to a file path", () => {
     const schema = resolveSchema("claude-md");
     assert.ok(schema);
-    assert.ok(schema.headingRules);
-    assert.equal(schema.headingRules.noSkipLevels, true);
+    assert.ok(typeof schema === "string");
+    assert.ok(schema.endsWith("claude-md.yml"));
   });
 
-  it("should resolve 'skill' preset", () => {
+  it("should resolve 'skill' preset to a file path", () => {
     const schema = resolveSchema("skill");
     assert.ok(schema);
-    assert.equal(schema.requireFrontmatter, true);
-    assert.ok(schema.frontmatterFields.some((f) => f.name === "description"));
+    assert.ok(typeof schema === "string");
+    assert.ok(schema.endsWith("skill.yml"));
   });
 
-  it("should return null for unknown preset", () => {
+  it("should return null for unknown preset/missing file", () => {
     const schema = resolveSchema("nonexistent");
     assert.equal(schema, null);
   });
 
-  it("should pass through object schemas unchanged", () => {
-    const custom = { sections: [{ heading: "## Foo", required: true }] };
-    const schema = resolveSchema(custom);
-    assert.deepEqual(schema, custom);
+  it("should return null for non-string schemas", () => {
+    const schema = resolveSchema({ sections: [] });
+    assert.equal(schema, null);
   });
 });
 
 describe("require-structure via validate()", () => {
+  let tmpDir;
+
+  before(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "vigiles-vstruct-"));
+  });
+
+  after(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
   it("should not check structure when rule is disabled (default)", () => {
     const result = validate("# Title\n", {
       rules: { "require-annotations": false, "require-rule-file": false },
@@ -1738,16 +1732,15 @@ describe("require-structure via validate()", () => {
   });
 
   it("should check structure when enabled and file matches", () => {
-    const structures = [
-      {
-        files: "CLAUDE.md",
-        schema: {
-          sections: [{ heading: "## Commands", required: true }],
-        },
-      },
-    ];
-    const content = "# Project\n\nNo commands section here.\n";
-    const result = validate(content, {
+    const schemaPath = join(tmpDir, "req-cmd.yml");
+    writeFileSync(
+      schemaPath,
+      'structure:\n  - heading:\n      pattern: "# .+"\n    allow_additional: true\n    children:\n      - heading: "## Commands"\n',
+    );
+    const mdPath = join(tmpDir, "CLAUDE.md");
+    writeFileSync(mdPath, "# Project\n\nNo commands section here.\n");
+    const structures = [{ files: "CLAUDE.md", schema: schemaPath }];
+    const result = validate("# Project\n\nNo commands section here.\n", {
       rules: {
         "require-annotations": false,
         "max-lines": false,
@@ -1755,26 +1748,28 @@ describe("require-structure via validate()", () => {
         "require-structure": true,
       },
       structures,
-      filePath: "CLAUDE.md",
+      filePath: mdPath,
     });
+    // Either fails with structure error or warns about mdschema not installed
+    if (result.errors.some((e) => e.message.includes("mdschema is not"))) {
+      return; // mdschema not installed, skip
+    }
     assert.equal(result.valid, false);
     assert.ok(
       result.errors.some(
-        (e) =>
-          e.rule === "require-structure" && e.message.includes("## Commands"),
+        (e) => e.rule === "require-structure" && e.message.includes("Commands"),
       ),
     );
   });
 
   it("should not check structure when file does not match glob", () => {
-    const structures = [
-      {
-        files: "SKILL.md",
-        schema: { requireFrontmatter: true },
-      },
-    ];
-    const content = "# Project\n\nNo frontmatter.\n";
-    const result = validate(content, {
+    const schemaPath = join(tmpDir, "fm.yml");
+    writeFileSync(
+      schemaPath,
+      'frontmatter:\n  fields:\n    - name: "description"\n      required: true\n',
+    );
+    const structures = [{ files: "SKILL.md", schema: schemaPath }];
+    const result = validate("# Project\n\nNo frontmatter.\n", {
       rules: {
         "require-annotations": false,
         "max-lines": false,
@@ -1787,47 +1782,31 @@ describe("require-structure via validate()", () => {
     assert.equal(result.valid, true);
   });
 
-  it("should match glob patterns like **/SKILL.md", () => {
+  it("should use bundled skill preset against real skill files", () => {
     const structures = [
-      {
-        files: "**/SKILL.md",
-        schema: { requireFrontmatter: true },
-      },
+      { files: "**/SKILL.md", schema: STRUCTURE_PRESETS["skill"] },
     ];
-    const content = "# No frontmatter skill\n";
-    const result = validate(content, {
-      rules: {
-        "require-annotations": false,
-        "max-lines": false,
-        "require-rule-file": false,
-        "require-structure": true,
-      },
-      structures,
-      filePath: "skills/my-skill/SKILL.md",
-    });
-    assert.equal(result.valid, false);
-    assert.ok(result.errors.some((e) => e.message.includes("frontmatter")));
-  });
-
-  it("should use preset schemas via string reference", () => {
-    const structures = [
+    const mdPath = join(tmpDir, "SKILL.md");
+    writeFileSync(
+      mdPath,
+      "---\nname: test\ndescription: A test\n---\n\n# Test Skill\n",
+    );
+    const result = validate(
+      "---\nname: test\ndescription: A test\n---\n\n# Test Skill\n",
       {
-        files: "**/SKILL.md",
-        schema: STRUCTURE_PRESETS["skill"],
+        rules: {
+          "require-annotations": false,
+          "max-lines": false,
+          "require-rule-file": false,
+          "require-structure": true,
+        },
+        structures,
+        filePath: mdPath,
       },
-    ];
-    const content =
-      "---\nname: test\ndescription: A test\n---\n\n# Test Skill\n";
-    const result = validate(content, {
-      rules: {
-        "require-annotations": false,
-        "max-lines": false,
-        "require-rule-file": false,
-        "require-structure": true,
-      },
-      structures,
-      filePath: "skills/test/SKILL.md",
-    });
+    );
+    if (result.errors.some((e) => e.message.includes("mdschema is not"))) {
+      return;
+    }
     assert.equal(result.valid, true);
   });
 });

--- a/validate.test.mjs
+++ b/validate.test.mjs
@@ -17,6 +17,9 @@ import {
   expandGlobs,
   discoverInstructionFiles,
   loadConfig,
+  validateStructure,
+  resolveSchema,
+  STRUCTURE_PRESETS,
 } from "./validate.mjs";
 
 describe("parseClaudeMd", () => {
@@ -306,6 +309,7 @@ describe("loadConfig", () => {
       "require-annotations": true,
       "max-lines": 500,
       "require-rule-file": "auto",
+      "require-structure": false,
     });
   });
 
@@ -1564,5 +1568,266 @@ describe("discoverInstructionFiles", () => {
     // Cursor detected but .cursorrules missing
     assert.ok(result.missing.some((m) => m.tool === "Cursor"));
     rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("validateStructure", () => {
+  it("should pass when no required sections and content is valid", () => {
+    const errors = validateStructure("# Hello\n\nSome text.\n", {
+      sections: [],
+    });
+    assert.equal(errors.length, 0);
+  });
+
+  it("should error on missing required section", () => {
+    const schema = {
+      sections: [
+        { heading: "## Commands", required: true },
+        { heading: "## Rules", required: true },
+      ],
+    };
+    const content = "# My Project\n\n## Commands\n\nnpm test\n";
+    const errors = validateStructure(content, schema);
+    assert.equal(errors.length, 1);
+    assert.ok(errors[0].message.includes("## Rules"));
+  });
+
+  it("should pass when all required sections present", () => {
+    const schema = {
+      sections: [
+        { heading: "## Commands", required: true },
+        { heading: "## Rules", required: true },
+      ],
+    };
+    const content =
+      "# My Project\n\n## Commands\n\nnpm test\n\n## Rules\n\n### No console\n";
+    const errors = validateStructure(content, schema);
+    assert.equal(errors.length, 0);
+  });
+
+  it("should skip optional sections without error", () => {
+    const schema = {
+      sections: [
+        { heading: "## Commands", required: true },
+        { heading: "## Architecture", required: false },
+      ],
+    };
+    const content = "# Project\n\n## Commands\n\nnpm test\n";
+    const errors = validateStructure(content, schema);
+    assert.equal(errors.length, 0);
+  });
+
+  it("should detect skipped heading levels", () => {
+    const schema = { headingRules: { noSkipLevels: true } };
+    const content = "# Title\n\n### Skipped h2\n\nSome text.\n";
+    const errors = validateStructure(content, schema);
+    assert.equal(errors.length, 1);
+    assert.ok(errors[0].message.includes("skips from h1 to h3"));
+  });
+
+  it("should not error on valid heading levels", () => {
+    const schema = { headingRules: { noSkipLevels: true } };
+    const content = "# Title\n\n## Section\n\n### Subsection\n";
+    const errors = validateStructure(content, schema);
+    assert.equal(errors.length, 0);
+  });
+
+  it("should detect headings exceeding max depth", () => {
+    const schema = { headingRules: { maxDepth: 3 } };
+    const content = "# Title\n\n## Section\n\n### Sub\n\n#### Too deep\n";
+    const errors = validateStructure(content, schema);
+    assert.equal(errors.length, 1);
+    assert.ok(errors[0].message.includes("exceeds max depth 3"));
+  });
+
+  it("should require frontmatter when specified", () => {
+    const schema = { requireFrontmatter: true };
+    const content = "# No frontmatter\n\nJust text.\n";
+    const errors = validateStructure(content, schema);
+    assert.equal(errors.length, 1);
+    assert.ok(errors[0].message.includes("Missing YAML frontmatter"));
+  });
+
+  it("should pass when frontmatter is present", () => {
+    const schema = { requireFrontmatter: true };
+    const content = "---\nname: my-skill\n---\n\n# Skill\n";
+    const errors = validateStructure(content, schema);
+    assert.equal(errors.length, 0);
+  });
+
+  it("should validate required frontmatter fields", () => {
+    const schema = {
+      requireFrontmatter: true,
+      frontmatterFields: [
+        { name: "name", required: false },
+        { name: "description", required: true },
+      ],
+    };
+    const content = "---\nname: test\n---\n\n# Test\n";
+    const errors = validateStructure(content, schema);
+    assert.equal(errors.length, 1);
+    assert.ok(errors[0].message.includes("description"));
+  });
+
+  it("should pass when all required frontmatter fields present", () => {
+    const schema = {
+      requireFrontmatter: true,
+      frontmatterFields: [
+        { name: "name", required: true },
+        { name: "description", required: true },
+      ],
+    };
+    const content =
+      "---\nname: test\ndescription: A test skill\n---\n\n# Test\n";
+    const errors = validateStructure(content, schema);
+    assert.equal(errors.length, 0);
+  });
+
+  it("should match wildcard heading patterns", () => {
+    const schema = {
+      sections: [{ heading: "## *", required: true }],
+    };
+    const content = "# Title\n\n## Anything\n\nText.\n";
+    const errors = validateStructure(content, schema);
+    assert.equal(errors.length, 0);
+  });
+
+  it("should fail wildcard when no headings at that level exist", () => {
+    const schema = {
+      sections: [{ heading: "## *", required: true }],
+    };
+    const content = "# Title\n\nJust text, no h2 sections.\n";
+    const errors = validateStructure(content, schema);
+    assert.equal(errors.length, 1);
+  });
+});
+
+describe("resolveSchema", () => {
+  it("should resolve 'claude-md' preset", () => {
+    const schema = resolveSchema("claude-md");
+    assert.ok(schema);
+    assert.ok(schema.headingRules);
+    assert.equal(schema.headingRules.noSkipLevels, true);
+  });
+
+  it("should resolve 'skill' preset", () => {
+    const schema = resolveSchema("skill");
+    assert.ok(schema);
+    assert.equal(schema.requireFrontmatter, true);
+    assert.ok(schema.frontmatterFields.some((f) => f.name === "description"));
+  });
+
+  it("should return null for unknown preset", () => {
+    const schema = resolveSchema("nonexistent");
+    assert.equal(schema, null);
+  });
+
+  it("should pass through object schemas unchanged", () => {
+    const custom = { sections: [{ heading: "## Foo", required: true }] };
+    const schema = resolveSchema(custom);
+    assert.deepEqual(schema, custom);
+  });
+});
+
+describe("require-structure via validate()", () => {
+  it("should not check structure when rule is disabled (default)", () => {
+    const result = validate("# Title\n", {
+      rules: { "require-annotations": false, "require-rule-file": false },
+    });
+    assert.equal(result.valid, true);
+  });
+
+  it("should check structure when enabled and file matches", () => {
+    const structures = [
+      {
+        files: "CLAUDE.md",
+        schema: {
+          sections: [{ heading: "## Commands", required: true }],
+        },
+      },
+    ];
+    const content = "# Project\n\nNo commands section here.\n";
+    const result = validate(content, {
+      rules: {
+        "require-annotations": false,
+        "max-lines": false,
+        "require-rule-file": false,
+        "require-structure": true,
+      },
+      structures,
+      filePath: "CLAUDE.md",
+    });
+    assert.equal(result.valid, false);
+    assert.ok(
+      result.errors.some(
+        (e) =>
+          e.rule === "require-structure" && e.message.includes("## Commands"),
+      ),
+    );
+  });
+
+  it("should not check structure when file does not match glob", () => {
+    const structures = [
+      {
+        files: "SKILL.md",
+        schema: { requireFrontmatter: true },
+      },
+    ];
+    const content = "# Project\n\nNo frontmatter.\n";
+    const result = validate(content, {
+      rules: {
+        "require-annotations": false,
+        "max-lines": false,
+        "require-rule-file": false,
+        "require-structure": true,
+      },
+      structures,
+      filePath: "CLAUDE.md",
+    });
+    assert.equal(result.valid, true);
+  });
+
+  it("should match glob patterns like **/SKILL.md", () => {
+    const structures = [
+      {
+        files: "**/SKILL.md",
+        schema: { requireFrontmatter: true },
+      },
+    ];
+    const content = "# No frontmatter skill\n";
+    const result = validate(content, {
+      rules: {
+        "require-annotations": false,
+        "max-lines": false,
+        "require-rule-file": false,
+        "require-structure": true,
+      },
+      structures,
+      filePath: "skills/my-skill/SKILL.md",
+    });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.some((e) => e.message.includes("frontmatter")));
+  });
+
+  it("should use preset schemas via string reference", () => {
+    const structures = [
+      {
+        files: "**/SKILL.md",
+        schema: STRUCTURE_PRESETS["skill"],
+      },
+    ];
+    const content =
+      "---\nname: test\ndescription: A test\n---\n\n# Test Skill\n";
+    const result = validate(content, {
+      rules: {
+        "require-annotations": false,
+        "max-lines": false,
+        "require-rule-file": false,
+        "require-structure": true,
+      },
+      structures,
+      filePath: "skills/test/SKILL.md",
+    });
+    assert.equal(result.valid, true);
   });
 });


### PR DESCRIPTION
New configurable rule that validates markdown files against structural
schemas. Schemas can enforce required/optional sections, heading hierarchy
(noSkipLevels, maxDepth), and YAML frontmatter fields. Schemas are matched
to files via glob patterns in the `structures` config key, enabling
different schemas for CLAUDE.md vs SKILL.md vs subdirectory files.

Built-in presets: "claude-md" (heading rules, common section hints) and
"skill" (requires frontmatter with description field, per Anthropic spec).

Config example:
  {
    "rules": { "require-structure": true },
    "structures": [
      { "files": "CLAUDE.md", "schema": "claude-md" },
      { "files": "**/SKILL.md", "schema": "skill" }
    ]
  }