### PR TITLE
Fix missing spaces around inline code spans in README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,11 @@ Named validation rules (togglable in config under `rules`):
 
 ## Rules
 
+### Run `npm run fmt:check` before committing markdown changes
+
+**Enforced by:** `code-review`
+**Why:** Inline code spans in markdown need surrounding spaces to render correctly (e.g., `` `foo` or `bar` `` not `` `foo`or`bar` ``). Run `npm run fmt:check` after editing README.md or other markdown files to catch formatting issues before they reach GitHub.
+
 ### Never include session links in commits or PRs
 
 **Guidance only** — cannot be mechanically enforced

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ All rules have enforcement annotations.
 
 vigiles does two things:
 
-**1. Validates rule annotations** — every `###` heading or `- [ ]` checkbox in your instruction file must have `**Enforced by:** \`linter/rule\``or`**Guidance only**`. Near-miss typos like `**Enforced By:**` (wrong case) get a helpful "did you mean?" message.
+**1. Validates rule annotations** — every `###` heading or `- [ ]` checkbox in your instruction file must have an **Enforced by** annotation or be marked **Guidance only**. Near-miss typos like `Enforced By:` (wrong case) get a helpful "did you mean?" message.
 
 **2. Verifies linters exist and are enabled** — checks that referenced linters are actually installed and that the specific rules are enabled in your config. ESLint and Stylelint are checked via Node API. Ruff, Clippy, Pylint, and RuboCop are checked via CLI.
 


### PR DESCRIPTION
The "How It Works" section had `\`linter/rule\``or`**Guidance only**`
which rendered without spaces around "or" on GitHub. Rewrote the
sentence to avoid nested backtick escaping that confused Prettier.

Added a CLAUDE.md rule to run `npm run fmt:check` before committing
markdown changes to prevent similar formatting issues in the future.