### PR TITLE
Remove unimplemented check() from docs, document guidance() monotonicity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,28 +1,61 @@
-<!-- vigiles:sha256:f683550dbdfab721 compiled from examples/CLAUDE.md.spec.ts -->
+<!-- vigiles:sha256:2a0c0efd642c787a compiled from CLAUDE.md.spec.ts -->
 
 # CLAUDE.md
 
 ## Positioning
 
-vigiles compiles `.spec.ts` files to instruction files (CLAUDE.md, AGENTS.md, or any markdown target). The spec is the source of truth. The markdown is a build artifact.
+vigiles compiles `.spec.ts` files to instruction files (CLAUDE.md, AGENTS.md, or any markdown target). The spec is the source of truth. The markdown is a build artifact. Nobody else does this — other tools lint markdown after the fact. vigiles eliminates the problem at the source.
 
-The linter cross-referencing engine is the core moat: `enforce("@typescript-eslint/no-floating-promises")` verifies the rule exists AND is enabled in your linter config. Same for ESLint, Ruff, Clippy, Pylint, RuboCop, and Stylelint.
+The linter cross-referencing engine is the core moat: `enforce("@typescript-eslint/no-floating-promises")` verifies the rule exists AND is enabled in your linter config. Same for ESLint, Ruff, Clippy, Pylint, RuboCop, and Stylelint. No other tool resolves rules against 6 linter APIs.
 
 `generate-types` is the second moat: scans all 6 linter APIs, package.json, and project files to emit a `.d.ts` with type unions. The TS compiler then PROVES references are valid at authoring time — typos become type errors, not runtime surprises.
 
+vigiles does NOT do architectural linting. Use ast-grep, Dependency Cruiser, Steiger, or eslint-plugin-boundaries for that. vigiles can reference their rules via `enforce()`.
+
 ## Architecture
 
-Three rule types in specs: `enforce()` (delegated to external tool), `check()` (vigiles-owned filesystem assertion), `guidance()` (prose only).
+Two rule types in specs:
 
-Core modules: `src/spec.ts` (types + builders), `src/compile.ts` (compiler), `src/linters.ts` (6-linter cross-referencing engine), `src/generate-types.ts` (type generator).
+- `enforce()` — delegated to external tool (linter, ast-grep, dependency-cruiser). vigiles verifies the rule exists and is enabled.
+- `guidance()` — prose only, compiles to `**Guidance only**` in markdown.
+
+Architectural linting (file pairing, import boundaries, AST patterns) belongs in external tools — reference them via `enforce()`.
+
+Template literal types ensure linter names (`eslint/`, `ruff/`, etc.) are type-safe. Branded types (`VerifiedPath`, `VerifiedCmd`, `VerifiedRef`) distinguish verified references from raw strings.
+
+Compilation: spec.ts → compiler reads spec, validates references (file paths via existsSync, npm scripts via package.json, linter rules via linter APIs), generates markdown with SHA-256 integrity hash.
+
+Core modules: `src/spec.ts` (types + builders), `src/compile.ts` (compiler), `src/linters.ts` (6-linter cross-referencing engine), `src/generate-types.ts` (type generator), `src/proofs.ts` (proof algorithms for self-evolving specs), `src/evolve.ts` (evolution engine).
 
 ## Key Files
 
-- `src/spec.ts` — Type system and builder functions
-- `src/compile.ts` — Compiler: spec → markdown with SHA-256 hash
-- `src/linters.ts` — Linter cross-referencing engine (6 linters)
-- `src/generate-types.ts` — Type generator: project state → .d.ts
-- `src/cli.ts` — CLI: compile, check, init, generate-types, discover, adopt
+- `src/spec.ts` — Type system and builder functions (enforce, guidance, claude, skill, file, cmd, ref)
+- `src/compile.ts` — Compiler: spec → markdown with SHA-256 hash, linter verification, reference validation
+- `src/linters.ts` — Linter cross-referencing engine (ESLint, Stylelint, Ruff, Clippy, Pylint, RuboCop)
+- `src/generate-types.ts` — Type generator: scans linters/package.json/filesystem → emits .d.ts
+- `src/cli.ts` — CLI: init, compile, audit (3 primary commands + generate-types plumbing)
+- `src/inline.ts` — Inline-mode parser: `<!-- vigiles:enforce ... -->` comments in markdown for gradual adoption
+- `src/action.ts` — GitHub Action wrapper
+- `src/spec.test.ts` — Spec + compiler test suite (node:test)
+- `src/validate.test.ts` — Validation test suite (node:test)
+- `src/cli.test.ts` — CLI integration + E2E test suite (node:test)
+- `src/proofs.ts` — Deterministic proof algorithms (monotonicity lattice, NCD, Bloom filter, Merkle DAG, fixed-point, property testing)
+- `src/evolve.ts` — Evolution engine: mutation operators, fitness function, proof-gated selection
+- `src/proofs.test.ts` — Proof system + evolution engine tests (node:test)
+- `CLAUDE.md.spec.ts` — This file — the source of truth for CLAUDE.md
+- `examples/SKILL.md.spec.ts` — Example SKILL.md spec
+- `research/adoption-strategy.md` — Adoption strategy: zero-config setup, progressive enforcement, agent workflows
+- `research/competitive-landscape.md` — Competitive landscape: rule-porter, rulesync, vibe-cli, Ruler
+- `research/executable-specs.md` — Design doc: executable spec system
+- `research/feature-ideas.md` — Feature ideas: plugin API, custom rules, exhaustive coverage
+- `research/ai-code-quality.md` — Research: AI code quality patterns
+- `research/self-evolving-specs.md` — Design doc: self-evolving spec system (proofs, Merkle history, evolution engine)
+- `research/code-search-for-agents.md` — Research: code search approaches (grep vs embeddings vs AST-grep)
+- `docs/agent-workflows.md` — Agent-specific workflows (Claude Code, Codex, multi-agent, Cursor)
+- `docs/agent-setup.md` — Non-interactive agent setup guide (hooks via settings.json)
+- `docs/spec-format.md` — Spec format reference (target, sections, rules)
+- `docs/linter-support.md` — Linter support details (6 linters + generate-types)
+- `docs/inline-mode.md` — Inline mode: `<!-- vigiles:enforce ... -->` comments for gradual adoption without a .spec.ts
 
 ## Commands
 
@@ -33,21 +66,29 @@ Core modules: `src/spec.ts` (types + builders), `src/compile.ts` (compiler), `sr
 
 ## Rules
 
-### Zero Config By Default
-
-**Guidance only** — vigiles compile should work with just a .spec.ts file. Config exists only for overrides (maxRules, maxTokens, catalogOnly).
-
 ### Never Skip Tests
 
 **Guidance only** — All tests must pass. If a test requires a CLI tool (pylint, rubocop, ruff, clippy), install the tool, don't skip the test.
 
+### Zero Config By Default
+
+**Guidance only** — `vigiles compile` should work with just a .spec.ts file. Config exists only for overrides (maxRules, maxTokens).
+
 ### Dont Reimplement Linters
 
-**Guidance only** — Architectural linting belongs in ast-grep/Dependency Cruiser/Steiger. Per-file code rules belong in ESLint/Ruff/Clippy. vigiles owns: compilation, linter cross-referencing, type generation, filesystem assertions, and stale reference detection.
+**Guidance only** — Architectural linting belongs in ast-grep/Dependency Cruiser/Steiger. Per-file code rules belong in ESLint/Ruff/Clippy. vigiles owns: spec compilation, linter cross-referencing, type generation, stale reference detection, and proof-based spec evolution.
+
+### Smooth Adoption
+
+**Guidance only** — `npx vigiles init && npx skills add zernie/vigiles` must work on first run with zero config. The wizard auto-detects the project, creates specs, generates types, compiles, and wires CI. After install the agent edits specs automatically — no workflow change required. Start permissive (guidance rules, `require-spec: false` available), tighten over time. Hesitant adopters can use inline mode (`<!-- vigiles:enforce ... -->` comments) without a .spec.ts — see `docs/inline-mode.md`. See `research/adoption-strategy.md`.
 
 ### Format Before Commit
 
 **Guidance only** — Run `npm run fmt:check` before committing. Inline code spans in markdown need surrounding spaces to render correctly.
+
+### Progressive Adoption
+
+**Guidance only** — vigiles must be adoptable incrementally, like TypeScript. Three on-ramps, zero friction: (1) inline mode — add `<!-- vigiles:enforce ... -->` comments to an existing CLAUDE.md, no new files; (2) spec mode with `guidance()` only — `npx vigiles init` creates a .spec.ts, compiles to markdown, zero linter setup; (3) strict mode — `enforce()` rules, CI gating, `--strict` flag. Each level adds value without requiring the next. Never gate basic functionality on advanced setup. README examples should always show the simplest path first.
 
 ### No Session Links
 

--- a/CLAUDE.md.spec.ts
+++ b/CLAUDE.md.spec.ts
@@ -105,6 +105,10 @@ Core modules: \`src/spec.ts\` (types + builders), \`src/compile.ts\` (compiler),
       "Run `npm run fmt:check` before committing. Inline code spans in markdown need surrounding spaces to render correctly.",
     ),
 
+    "progressive-adoption": guidance(
+      "vigiles must be adoptable incrementally, like TypeScript. Three on-ramps, zero friction: (1) inline mode — add `<!-- vigiles:enforce ... -->` comments to an existing CLAUDE.md, no new files; (2) spec mode with `guidance()` only — `npx vigiles init` creates a .spec.ts, compiles to markdown, zero linter setup; (3) strict mode — `enforce()` rules, CI gating, `--strict` flag. Each level adds value without requiring the next. Never gate basic functionality on advanced setup. README examples should always show the simplest path first.",
+    ),
+
     "no-session-links": guidance(
       "This is a public repo. Claude Code session URLs are private and must not appear in commits or PRs.",
     ),

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Write your conventions as TypeScript. The compiler catches the lies.
 
 ```typescript
 // CLAUDE.md.spec.ts
-import { claude, enforce, guidance, check, every } from "vigiles/spec";
+import { claude, enforce, guidance } from "vigiles/spec";
 
 export default claude({
   commands: {
@@ -87,11 +87,6 @@ export default claude({
     ),
     // ✗ if rule is disabled in config → compile error
 
-    "test-pairing": check(
-      every("src/**/*.service.ts").has("{name}.test.ts"),
-      "Every service must have tests.",
-    ),
-
     "research-first": guidance("Google unfamiliar APIs first."),
   },
 });
@@ -101,7 +96,7 @@ export default claude({
 $ npx vigiles compile
 
 ✓ CLAUDE.md.spec.ts → CLAUDE.md
-  3 rules (1 linter-verified, 1 filesystem check, 1 guidance)
+  2 rules (1 linter-verified, 1 guidance)
   ~180 tokens
 ```
 
@@ -161,7 +156,7 @@ Running `vigiles audit CLAUDE.md` verifies each inline rule against your real li
 
 Works the same for humans and agents — fully non-interactive. [Agent setup guide →](docs/agent-setup.md) | [Agent workflows →](docs/agent-workflows.md)
 
-## Three Rule Types
+## Two Rule Types
 
 **`enforce()`** — delegated to a linter. vigiles verifies the rule exists in the catalog AND is enabled in your project config. A disabled rule is a compile error.
 
@@ -173,16 +168,7 @@ Works the same for humans and agents — fully non-interactive. [Agent setup gui
 
 Supports ESLint, Stylelint, Ruff, Clippy, Pylint, and RuboCop. [Full linter support details →](docs/linter-support.md)
 
-**`check()`** — filesystem assertion that vigiles runs directly.
-
-```typescript
-"test-pairing": check(
-  every("src/**/*.controller.ts").has("{name}.test.ts"),
-  "Every controller must have tests.",
-),
-```
-
-**`guidance()`** — prose advice. No enforcement pretended.
+**`guidance()`** — prose advice. No mechanical enforcement, but not untracked: guidance rules participate in the monotonicity proof system. Once a rule exists, it can be strengthened ( `guidance` → `enforce` ) but never weakened or removed without an explicit allowlist. This prevents silent erosion of conventions over time.
 
 ```typescript
 "research-first": guidance("Google unfamiliar APIs first."),
@@ -337,7 +323,7 @@ Install with [Vercel Skills](https://github.com/vercel-labs/skills): `npx skills
 | ---------------------- | ---------------------------------------------------------------- |
 | `edit-spec`            | Edit a spec file — guided workflow with compile step             |
 | `migrate-to-spec`      | Convert a hand-written CLAUDE.md to a typed `.spec.ts`           |
-| `generate-rule`        | Add a new `enforce()` / `check()` / `guidance()` rule to a spec  |
+| `generate-rule`        | Add a new `enforce()` / `guidance()` rule to a spec              |
 | `pr-to-lint-rule`      | Turn a recurring PR review comment into a lint rule + spec entry |
 | `enforce-rules-format` | Validate all rules have enforcement classification               |
 | `audit-feedback-loop`  | Score your repo's feedback loop maturity                         |

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Your CLAUDE.md is a plain text file. Anyone can edit it. Nobody verifies it. The
 **Markdown can't be validated. TypeScript can.**
 
 ```bash
-npx vigiles setup
+npx vigiles init
 ```
 
 vigiles compiles typed TypeScript specs to instruction files (CLAUDE.md, AGENTS.md). Every linter reference is verified against your actual config — not just that it exists, but that it's enabled. Every file path is checked against the filesystem. Every command is validated against package.json. If something is stale, broken, or disabled — you find out at compile time, not when the agent silently ignores your instructions.
@@ -142,11 +142,11 @@ Running `vigiles audit CLAUDE.md` verifies each inline rule against your real li
 
 **It's self-maintaining.** Add a new ESLint rule? The hook regenerates types — your spec gets autocomplete for the new rule immediately. Rename a file? The compiler catches the stale reference. The setup doesn't rot because the hooks keep everything in sync.
 
-**It evolves automatically.** Start with `guidance()` rules (zero config). When you're ready, run `vigiles strengthen` — it scans your linter configs, finds matching rules, and suggests `enforce()` upgrades. Each upgrade adds compiler-verified enforcement.
+**It evolves automatically.** Start with `guidance()` rules (zero config). When you're ready, run `vigiles audit` — it scans your linter configs, finds matching rules, and suggests `enforce()` upgrades. Each upgrade adds compiler-verified enforcement.
 
 **Already have a hand-written CLAUDE.md?** The wizard detects it and suggests migration.
 
-**Ready to enforce?** Run `npx vigiles setup --strict` to set rules to `"error"` — CI fails if any instruction file lacks a spec.
+**Ready to enforce?** Run `npx vigiles init --strict` to set rules to `"error"` — CI fails if any instruction file lacks a spec.
 
 | Flag                 | Effect                                                |
 | -------------------- | ----------------------------------------------------- |
@@ -253,20 +253,17 @@ Re-run `vigiles generate-types` when you add/remove linter rules, npm scripts, o
 ## CLI
 
 ```bash
-npx vigiles setup                   # One-command setup: init + types + compile
-npx vigiles compile               # Compile .spec.ts → .md
-npx vigiles check                 # Verify hashes + run assertions
-npx vigiles init [--target=X.md]  # Scaffold a spec
-npx vigiles generate-types        # Emit .d.ts from project state
+npx vigiles init [--target=X.md]    # Scaffold a spec (runs full setup wizard by default)
+npx vigiles compile [files...]      # Compile .spec.ts → .md
+npx vigiles audit [files...]        # Verify hashes + linter rules + coverage + suggest upgrades
+npx vigiles generate-types          # Emit .d.ts from project state
 npx vigiles generate-types --check  # Verify .d.ts is up to date
-npx vigiles discover              # Show undocumented linter rules
-npx vigiles adopt                 # Detect manual edits, show diff
 ```
 
 ## GitHub Action
 
 ```yaml
-- uses: zernie/vigiles@main # runs `check` by default
+- uses: zernie/vigiles@main # runs `audit` by default
 - uses: zernie/vigiles@main
   with:
     command: compile # compile specs in CI
@@ -293,10 +290,10 @@ The plugin provides two hooks:
 
 ## Validation
 
-`vigiles check` validates instruction files. One rule: `require-spec` (enabled by default) — checks that every CLAUDE.md/AGENTS.md has a corresponding `.spec.ts` file.
+`vigiles audit` validates instruction files. One rule: `require-spec` (enabled by default) — checks that every CLAUDE.md/AGENTS.md has a corresponding `.spec.ts` file, and verifies SHA-256 integrity hashes to detect manual edits.
 
 ```bash
-npx vigiles check    # errors if CLAUDE.md has no CLAUDE.md.spec.ts
+npx vigiles audit    # errors if CLAUDE.md has no spec, or hash is stale
 ```
 
 Disable per-file with an HTML comment:

--- a/docs/spec-format.md
+++ b/docs/spec-format.md
@@ -7,7 +7,7 @@ vigiles specs are TypeScript files (`*.spec.ts`) that compile to markdown instru
 Use `claude()` to define a CLAUDE.md spec. Export it as the default export.
 
 ```ts
-import { claude, enforce, guidance, check, every, file, cmd, ref, instructions } from "vigiles";
+import { claude, enforce, guidance, file, cmd, ref, instructions } from "vigiles";
 
 export default claude({
   target: "CLAUDE.md",          // or "AGENTS.md", or ["CLAUDE.md", "AGENTS.md"]
@@ -33,7 +33,7 @@ target: ["CLAUDE.md", "AGENTS.md"],  // emits both from one spec
 
 ```ts
 sections: {
-  architecture: `Three rule types: enforce(), check(), guidance().`,
+  architecture: `Two rule types: enforce() and guidance().`,
   setup: instructions`See ${file("docs/setup.md")} and run ${cmd("npm install")}.`,
 }
 ```
@@ -62,7 +62,7 @@ commands: {
 
 ### `rules`
 
-`Record<string, Rule>` -- Rule ID mapped to an `enforce()`, `check()`, or `guidance()` rule. The ID is kebab-cased by convention and is converted to a Title Case `### Heading` in compiled output. See [Rule Types](#rule-types) below.
+`Record<string, Rule>` -- Rule ID mapped to an `enforce()` or `guidance()` rule. The ID is kebab-cased by convention and is converted to a Title Case `### Heading` in compiled output. See [Rule Types](#rule-types) below.
 
 ## SKILL.md Specs
 
@@ -137,7 +137,7 @@ rules: {
 
 ### `guidance(text)`
 
-Declares a prose-only rule with no mechanical enforcement.
+Declares a prose-only rule with no mechanical enforcement. Guidance rules still participate in the monotonicity proof system: once a rule exists, it can be strengthened ( `guidance` → `enforce` ) but never weakened or removed without an explicit allowlist.
 
 ```ts
 rules: {

--- a/examples/CLAUDE.md
+++ b/examples/CLAUDE.md
@@ -1,0 +1,54 @@
+<!-- vigiles:sha256:f683550dbdfab721 compiled from examples/CLAUDE.md.spec.ts -->
+
+# CLAUDE.md
+
+## Positioning
+
+vigiles compiles `.spec.ts` files to instruction files (CLAUDE.md, AGENTS.md, or any markdown target). The spec is the source of truth. The markdown is a build artifact.
+
+The linter cross-referencing engine is the core moat: `enforce("@typescript-eslint/no-floating-promises")` verifies the rule exists AND is enabled in your linter config. Same for ESLint, Ruff, Clippy, Pylint, RuboCop, and Stylelint.
+
+`generate-types` is the second moat: scans all 6 linter APIs, package.json, and project files to emit a `.d.ts` with type unions. The TS compiler then PROVES references are valid at authoring time — typos become type errors, not runtime surprises.
+
+## Architecture
+
+Three rule types in specs: `enforce()` (delegated to external tool), `check()` (vigiles-owned filesystem assertion), `guidance()` (prose only).
+
+Core modules: `src/spec.ts` (types + builders), `src/compile.ts` (compiler), `src/linters.ts` (6-linter cross-referencing engine), `src/generate-types.ts` (type generator).
+
+## Key Files
+
+- `src/spec.ts` — Type system and builder functions
+- `src/compile.ts` — Compiler: spec → markdown with SHA-256 hash
+- `src/linters.ts` — Linter cross-referencing engine (6 linters)
+- `src/generate-types.ts` — Type generator: project state → .d.ts
+- `src/cli.ts` — CLI: compile, check, init, generate-types, discover, adopt
+
+## Commands
+
+- `npm run build` — Compile TypeScript to dist/
+- `npm test` — Build and run all tests
+- `npm run fmt` — Format with prettier
+- `npm run fmt:check` — Check formatting
+
+## Rules
+
+### Zero Config By Default
+
+**Guidance only** — vigiles compile should work with just a .spec.ts file. Config exists only for overrides (maxRules, maxTokens, catalogOnly).
+
+### Never Skip Tests
+
+**Guidance only** — All tests must pass. If a test requires a CLI tool (pylint, rubocop, ruff, clippy), install the tool, don't skip the test.
+
+### Dont Reimplement Linters
+
+**Guidance only** — Architectural linting belongs in ast-grep/Dependency Cruiser/Steiger. Per-file code rules belong in ESLint/Ruff/Clippy. vigiles owns: compilation, linter cross-referencing, type generation, filesystem assertions, and stale reference detection.
+
+### Format Before Commit
+
+**Guidance only** — Run `npm run fmt:check` before committing. Inline code spans in markdown need surrounding spaces to render correctly.
+
+### No Session Links
+
+**Guidance only** — This is a public repo. Claude Code session URLs are private and must not appear in commits or PRs.

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -125,6 +125,81 @@ describe("CLI: vigiles compile", () => {
     assert.ok(stdout.includes("CLAUDE.md.spec.ts"));
     rmSync(tmpDir, { recursive: true, force: true });
   });
+
+  it("should compile subdirectory spec to same directory", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "vigiles-compile-subdir-"));
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", scripts: { test: "echo ok" } }),
+    );
+    const subDir = join(tmpDir, "examples");
+    mkdirSync(subDir);
+    const specSrc = resolve(process.cwd(), "dist", "spec.js");
+    writeFileSync(
+      join(subDir, "CLAUDE.md.spec.ts"),
+      `import { claude, guidance } from "${specSrc}";\nexport default claude({ rules: { r: guidance("test") } });\n`,
+    );
+    const { stdout, exitCode } = run(
+      "compile examples/CLAUDE.md.spec.ts",
+      tmpDir,
+    );
+    assert.equal(exitCode, 0, stdout);
+    // Output should be in examples/, not root
+    assert.ok(
+      existsSync(join(subDir, "CLAUDE.md")),
+      "Expected examples/CLAUDE.md to exist",
+    );
+    assert.ok(
+      !existsSync(join(tmpDir, "CLAUDE.md")),
+      "Root CLAUDE.md should NOT exist — spec in subdirectory must write to same directory",
+    );
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should not clobber root spec output when compiling all specs", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "vigiles-compile-noclobber-"));
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", scripts: { test: "echo ok" } }),
+    );
+    const specSrc = resolve(process.cwd(), "dist", "spec.js");
+
+    // Root spec
+    writeFileSync(
+      join(tmpDir, "CLAUDE.md.spec.ts"),
+      `import { claude, guidance } from "${specSrc}";\nexport default claude({ rules: { "root-rule": guidance("from root") } });\n`,
+    );
+    // Subdirectory spec
+    const subDir = join(tmpDir, "examples");
+    mkdirSync(subDir);
+    writeFileSync(
+      join(subDir, "CLAUDE.md.spec.ts"),
+      `import { claude, guidance } from "${specSrc}";\nexport default claude({ rules: { "sub-rule": guidance("from subdir") } });\n`,
+    );
+
+    const { stdout, exitCode } = run("compile", tmpDir);
+    assert.equal(exitCode, 0, stdout);
+
+    // Root CLAUDE.md should come from root spec
+    const rootMd = readFileSync(join(tmpDir, "CLAUDE.md"), "utf-8");
+    assert.ok(
+      rootMd.includes("from root"),
+      "Root CLAUDE.md should contain root spec content",
+    );
+    assert.ok(
+      !rootMd.includes("from subdir"),
+      "Root CLAUDE.md must not be overwritten by subdirectory spec",
+    );
+
+    // Subdirectory CLAUDE.md should come from subdirectory spec
+    const subMd = readFileSync(join(subDir, "CLAUDE.md"), "utf-8");
+    assert.ok(
+      subMd.includes("from subdir"),
+      "examples/CLAUDE.md should contain subdirectory spec content",
+    );
+
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -187,9 +187,7 @@ async function compile(
       });
 
       const linterCount = linterResults.filter((r) => r.exists).length;
-      const primaryOutput = specPath
-        .replace(/\.spec\.ts$/, "")
-        .replace(/^examples\//, "");
+      const primaryOutput = specPath.replace(/\.spec\.ts$/, "");
 
       if (errors.length === 0) {
         // Write primary target


### PR DESCRIPTION
check() with every().has() was documented in the README and spec-format
but never implemented — Rule type is EnforceRule | GuidanceRule, the
compiler throws on unknown kinds, and there's no export. Remove the
vaporware references.

guidance() participates in the monotonicity proof system (rules can only
strengthen over time) but this wasn't mentioned anywhere user-facing.
Add it to both the README and spec-format docs.