### PR TITLE
Add ESLint deep-dive sub-doc for pr-to-lint-rule skill

### DIFF
--- a/CLAUDE.md.spec.ts
+++ b/CLAUDE.md.spec.ts
@@ -91,6 +91,10 @@ Core modules: \`src/spec.ts\` (types + builders), \`src/compile.ts\` (compiler),
       "RuboCop reference: gem table, node pattern DSL, auto-correct, custom cops",
     "skills/linter-docs/pylint.md":
       "Pylint reference: plugin table, astroid AST, type inference, custom checkers",
+    "skills/linter-docs/ruff.md":
+      "Ruff reference: 800+ reimplemented rules, rule selection, auto-fix, pyproject.toml config",
+    "skills/linter-docs/stylelint.md":
+      "Stylelint reference: plugin table, PostCSS AST, custom rules, CSS-in-JS, SCSS",
     "skills/strengthen/SKILL.md":
       "Strengthen skill: upgrade guidance() → enforce() by finding existing linter rules",
   },

--- a/CLAUDE.md.spec.ts
+++ b/CLAUDE.md.spec.ts
@@ -79,6 +79,8 @@ Core modules: \`src/spec.ts\` (types + builders), \`src/compile.ts\` (compiler),
     "docs/spec-format.md": "Spec format reference (target, sections, rules)",
     "docs/linter-support.md":
       "Linter support details (6 linters + generate-types)",
+    "docs/comparison.md":
+      "Before/after tables (Claude Code, Codex), determinism breakdown, flow diagram",
     "docs/freshness.md":
       "Freshness detection: strict/input-hash/output-hash modes, lock file detection, input fingerprinting",
     "docs/inline-mode.md":
@@ -127,6 +129,10 @@ Core modules: \`src/spec.ts\` (types + builders), \`src/compile.ts\` (compiler),
 
     "no-session-links": guidance(
       "This is a public repo. Claude Code session URLs are private and must not appear in commits or PRs.",
+    ),
+
+    "readme-brevity": guidance(
+      "README.md should be a concise pitch + quick start, not a reference manual. Extract detailed sections into docs/ and link with `[Details →](docs/X.md)`. Target ~300 lines max.",
     ),
   },
 });

--- a/CLAUDE.md.spec.ts
+++ b/CLAUDE.md.spec.ts
@@ -66,6 +66,8 @@ Core modules: \`src/spec.ts\` (types + builders), \`src/compile.ts\` (compiler),
       "Design doc: self-evolving spec system (proofs, Merkle history, evolution engine)",
     "research/code-search-for-agents.md":
       "Research: code search approaches (grep vs embeddings vs AST-grep)",
+    "research/doc-freshness.md":
+      "Research: input fingerprinting, TOC manifests, and stale spec detection",
     "docs/agent-workflows.md":
       "Agent-specific workflows (Claude Code, Codex, multi-agent, Cursor)",
     "docs/agent-setup.md":

--- a/CLAUDE.md.spec.ts
+++ b/CLAUDE.md.spec.ts
@@ -75,8 +75,14 @@ Core modules: \`src/spec.ts\` (types + builders), \`src/compile.ts\` (compiler),
       "Linter support details (6 linters + generate-types)",
     "docs/inline-mode.md":
       "Inline mode: `<!-- vigiles:enforce ... -->` comments for gradual adoption without a .spec.ts",
-    "skills/pr-to-lint-rule/eslint.md":
-      "ESLint deep-dive for pr-to-lint-rule skill: plugin lookup, AST selectors, type-aware rules, auto-fix, edge cases",
+    "skills/linter-docs/eslint.md":
+      "ESLint reference: plugin table, AST selectors, type-aware rules, auto-fix, edge cases",
+    "skills/linter-docs/rubocop.md":
+      "RuboCop reference: gem table, node pattern DSL, auto-correct, custom cops",
+    "skills/linter-docs/pylint.md":
+      "Pylint reference: plugin table, astroid AST, type inference, custom checkers",
+    "skills/strengthen/SKILL.md":
+      "Strengthen skill: upgrade guidance() → enforce() by finding existing linter rules",
   },
 
   commands: {

--- a/CLAUDE.md.spec.ts
+++ b/CLAUDE.md.spec.ts
@@ -75,6 +75,8 @@ Core modules: \`src/spec.ts\` (types + builders), \`src/compile.ts\` (compiler),
       "Linter support details (6 linters + generate-types)",
     "docs/inline-mode.md":
       "Inline mode: `<!-- vigiles:enforce ... -->` comments for gradual adoption without a .spec.ts",
+    "skills/pr-to-lint-rule/eslint.md":
+      "ESLint deep-dive for pr-to-lint-rule skill: plugin lookup, AST selectors, type-aware rules, auto-fix, edge cases",
   },
 
   commands: {

--- a/CLAUDE.md.spec.ts
+++ b/CLAUDE.md.spec.ts
@@ -47,6 +47,10 @@ Core modules: \`src/spec.ts\` (types + builders), \`src/compile.ts\` (compiler),
     "src/spec.test.ts": "Spec + compiler test suite (node:test)",
     "src/validate.test.ts": "Validation test suite (node:test)",
     "src/cli.test.ts": "CLI integration + E2E test suite (node:test)",
+    "src/freshness.ts":
+      "Freshness detection: lock file detection, input discovery, hash computation, staleness checks",
+    "src/freshness.test.ts":
+      "Freshness test suite: lock files (15 ecosystems), input discovery, hash computation, staleness",
     "src/proofs.ts":
       "Deterministic proof algorithms (monotonicity lattice, NCD, Bloom filter, Merkle DAG, fixed-point, property testing)",
     "src/evolve.ts":
@@ -75,6 +79,8 @@ Core modules: \`src/spec.ts\` (types + builders), \`src/compile.ts\` (compiler),
     "docs/spec-format.md": "Spec format reference (target, sections, rules)",
     "docs/linter-support.md":
       "Linter support details (6 linters + generate-types)",
+    "docs/freshness.md":
+      "Freshness detection: strict/input-hash/output-hash modes, lock file detection, input fingerprinting",
     "docs/inline-mode.md":
       "Inline mode: `<!-- vigiles:enforce ... -->` comments for gradual adoption without a .spec.ts",
     "skills/linter-docs/eslint.md":

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Running `vigiles audit CLAUDE.md` verifies each inline rule against your real li
 
 **It's self-maintaining.** Add a new ESLint rule? The hook regenerates types — your spec gets autocomplete for the new rule immediately. Rename a file? The compiler catches the stale reference. The setup doesn't rot because the hooks keep everything in sync.
 
-**It evolves automatically.** Start with `guidance()` rules (zero config). When you're ready, run `vigiles audit` — it scans your linter configs, finds matching rules, and suggests `enforce()` upgrades. Each upgrade adds compiler-verified enforcement.
+**It evolves automatically.** Start with `guidance()` rules (zero config). When you're ready, run `/strengthen` — it reads your linter configs and per-linter reference docs to find `enforce()` upgrades. Each upgrade adds compiler-verified enforcement.
 
 **Already have a hand-written CLAUDE.md?** The wizard detects it and suggests migration.
 
@@ -316,14 +316,15 @@ Or in `.vigilesrc.json`:
 
 Install with [Vercel Skills](https://github.com/vercel-labs/skills): `npx skills add zernie/vigiles`
 
-| Skill                  | What it does                                                     |
-| ---------------------- | ---------------------------------------------------------------- |
-| `edit-spec`            | Edit a spec file — guided workflow with compile step             |
-| `migrate-to-spec`      | Convert a hand-written CLAUDE.md to a typed `.spec.ts`           |
-| `generate-rule`        | Add a new `enforce()` / `guidance()` rule to a spec              |
-| `pr-to-lint-rule`      | Turn a recurring PR review comment into a lint rule + spec entry |
-| `enforce-rules-format` | Validate all rules have enforcement classification               |
-| `audit-feedback-loop`  | Score your repo's feedback loop maturity                         |
+| Skill                  | What it does                                                            |
+| ---------------------- | ----------------------------------------------------------------------- |
+| `strengthen`           | Upgrade `guidance()` → `enforce()` using linter-specific reference docs |
+| `edit-spec`            | Edit a spec file — guided workflow with compile step                    |
+| `migrate-to-spec`      | Convert a hand-written CLAUDE.md to a typed `.spec.ts`                  |
+| `generate-rule`        | Add a new `enforce()` / `guidance()` rule to a spec                     |
+| `pr-to-lint-rule`      | Turn a recurring PR review comment into a lint rule + spec entry        |
+| `enforce-rules-format` | Validate all rules have enforcement classification                      |
+| `audit-feedback-loop`  | Score your repo's feedback loop maturity                                |
 
 ## Maturity Levels
 

--- a/README.md
+++ b/README.md
@@ -62,9 +62,32 @@ The agent reads this, trusts it, and writes code based on stale claims nobody ve
 
 ## What Changes With vigiles
 
-Everything vigiles compiles and audits is **deterministic** — same input, same output, no LLM in the loop. The non-deterministic parts (authoring specs, suggesting upgrades, writing custom rules) are agent skills that run outside the compilation pipeline.
+### Claude Code
 
-[Full comparison tables (Claude Code vs Codex), determinism breakdown, and flow diagram →](docs/comparison.md)
+|                                     | Without vigiles              | With vigiles                                                   |
+| ----------------------------------- | ---------------------------- | -------------------------------------------------------------- |
+| **Instructions**                    | Hand-written CLAUDE.md       | Compiled from `.spec.ts` (build artifact)                      |
+| **Linter rule references**          | Trust-based (nobody checks)  | Verified at compile time against real config                   |
+| **File paths**                      | Rot silently when renamed    | `file()` references checked against filesystem                 |
+| **Commands**                        | Stale scripts go unnoticed   | `cmd()` references checked against package.json                |
+| **Direct edits to CLAUDE.md**       | Anyone can, nobody knows     | PreToolUse hook blocks edits, redirects to spec                |
+| **Linter config changes**           | CLAUDE.md drifts out of sync | PostToolUse hook auto-regenerates types                        |
+| **guidance → enforce upgrades**     | Manual guesswork             | `/strengthen` reads per-linter docs, suggests upgrades         |
+| **New lint rules from PR feedback** | Copy-paste from review       | `/pr-to-lint-rule` generates rule + tests + spec entry         |
+| **CI**                              | Nothing to verify            | `vigiles audit` catches hash drift, disabled rules, stale refs |
+
+### Codex / GitHub Copilot
+
+|                               | Without vigiles                  | With vigiles                                            |
+| ----------------------------- | -------------------------------- | ------------------------------------------------------- |
+| **Instructions**              | Hand-written AGENTS.md           | Compiled from `.spec.ts`                                |
+| **Linter rule references**    | Trust-based                      | Verified at compile time                                |
+| **File paths / commands**     | Rot silently                     | Checked at compile time                                 |
+| **Direct edits to AGENTS.md** | Undetected                       | CI catches hash mismatch                                |
+| **Hooks / auto-compile**      | Not available (no plugin system) | Not available — run `vigiles compile` manually or in CI |
+| **CI**                        | Nothing to verify                | Same `vigiles audit` pipeline as Claude                 |
+
+Everything vigiles compiles and audits is **deterministic** — same input, same output, no LLM in the loop. The non-deterministic parts (authoring specs, suggesting upgrades, writing custom rules) are agent skills that run outside the compilation pipeline. [Determinism breakdown and flow diagram →](docs/comparison.md)
 
 ## The Fix
 

--- a/README.md
+++ b/README.md
@@ -76,16 +76,7 @@ The agent reads this, trusts it, and writes code based on stale claims nobody ve
 | **New lint rules from PR feedback** | Copy-paste from review       | `/pr-to-lint-rule` generates rule + tests + spec entry         |
 | **CI**                              | Nothing to verify            | `vigiles audit` catches hash drift, disabled rules, stale refs |
 
-### Codex / GitHub Copilot
-
-|                               | Without vigiles                  | With vigiles                                            |
-| ----------------------------- | -------------------------------- | ------------------------------------------------------- |
-| **Instructions**              | Hand-written AGENTS.md           | Compiled from `.spec.ts`                                |
-| **Linter rule references**    | Trust-based                      | Verified at compile time                                |
-| **File paths / commands**     | Rot silently                     | Checked at compile time                                 |
-| **Direct edits to AGENTS.md** | Undetected                       | CI catches hash mismatch                                |
-| **Hooks / auto-compile**      | Not available (no plugin system) | Not available — run `vigiles compile` manually or in CI |
-| **CI**                        | Nothing to verify                | Same `vigiles audit` pipeline as Claude                 |
+Also compiles to AGENTS.md for Codex/Copilot — same verification, no hooks (they don't support them). [Full comparison →](docs/comparison.md)
 
 Everything vigiles compiles and audits is **deterministic** — same input, same output, no LLM in the loop. The non-deterministic parts (authoring specs, suggesting upgrades, writing custom rules) are agent skills that run outside the compilation pipeline. [Determinism breakdown and flow diagram →](docs/comparison.md)
 

--- a/README.md
+++ b/README.md
@@ -62,75 +62,9 @@ The agent reads this, trusts it, and writes code based on stale claims nobody ve
 
 ## What Changes With vigiles
 
-### Claude Code
+Everything vigiles compiles and audits is **deterministic** — same input, same output, no LLM in the loop. The non-deterministic parts (authoring specs, suggesting upgrades, writing custom rules) are agent skills that run outside the compilation pipeline.
 
-|                                     | Without vigiles              | With vigiles                                                   |
-| ----------------------------------- | ---------------------------- | -------------------------------------------------------------- |
-| **Instructions**                    | Hand-written CLAUDE.md       | Compiled from `.spec.ts` (build artifact)                      |
-| **Linter rule references**          | Trust-based (nobody checks)  | Verified at compile time against real config                   |
-| **File paths**                      | Rot silently when renamed    | `file()` references checked against filesystem                 |
-| **Commands**                        | Stale scripts go unnoticed   | `cmd()` references checked against package.json                |
-| **Direct edits to CLAUDE.md**       | Anyone can, nobody knows     | PreToolUse hook blocks edits, redirects to spec                |
-| **Linter config changes**           | CLAUDE.md drifts out of sync | PostToolUse hook auto-regenerates types                        |
-| **Spec edits**                      | N/A                          | PostToolUse hook auto-compiles to markdown                     |
-| **guidance → enforce upgrades**     | Manual guesswork             | `/strengthen` reads per-linter docs, suggests upgrades         |
-| **New lint rules from PR feedback** | Copy-paste from review       | `/pr-to-lint-rule` generates rule + tests + spec entry         |
-| **CI**                              | Nothing to verify            | `vigiles audit` catches hash drift, disabled rules, stale refs |
-
-### Codex / GitHub Copilot
-
-|                               | Without vigiles                  | With vigiles                                            |
-| ----------------------------- | -------------------------------- | ------------------------------------------------------- |
-| **Instructions**              | Hand-written AGENTS.md           | Compiled from `.spec.ts`                                |
-| **Linter rule references**    | Trust-based                      | Verified at compile time                                |
-| **File paths / commands**     | Rot silently                     | Checked at compile time                                 |
-| **Direct edits to AGENTS.md** | Undetected                       | CI catches hash mismatch                                |
-| **Hooks / auto-compile**      | Not available (no plugin system) | Not available — run `vigiles compile` manually or in CI |
-| **CI**                        | Nothing to verify                | Same `vigiles audit` pipeline as Claude                 |
-
-Codex and Copilot have no hook or plugin system. The compile-time verification and CI enforcement still work — the difference is there's no auto-recompilation on edit. You run `vigiles compile` before committing, and CI catches drift.
-
-### What's Deterministic vs What's Not
-
-| Check                            | Deterministic? | How                                                                                  |
-| -------------------------------- | -------------- | ------------------------------------------------------------------------------------ |
-| Linter rule exists in catalog    | Yes            | Node API (`builtinRules`) or CLI (`ruff rule`, `rubocop --show-cops`)                |
-| Linter rule is enabled in config | Yes            | `calculateConfigForFile` (ESLint), `--show-settings` (Ruff), `--show-cops` (RuboCop) |
-| File path exists                 | Yes            | `fs.existsSync`                                                                      |
-| npm script exists                | Yes            | Parsed from `package.json`                                                           |
-| SHA-256 hash matches             | Yes            | Recompute and compare                                                                |
-| Duplicate rule detection         | Yes            | Normalized Compression Distance (NCD) with fixed threshold                           |
-| guidance → enforce suggestion    | **No**         | Agent reads linter docs, reasons about intent — `/strengthen` skill                  |
-| PR comment → lint rule           | **No**         | Agent generates custom rule code — `/pr-to-lint-rule` skill                          |
-| Spec content authoring           | **No**         | Agent or human writes the spec — vigiles verifies it                                 |
-
-Everything vigiles compiles and audits is deterministic — same input, same output, no LLM in the loop. The non-deterministic parts (authoring specs, suggesting upgrades, writing custom rules) are agent skills that run outside the compilation pipeline.
-
-### Flow
-
-```
-                        DETERMINISTIC                          AGENT-ASSISTED
-                  ┌─────────────────────────┐          ┌──────────────────────────┐
-                  │                         │          │                          │
-  .spec.ts ──────┤  vigiles compile         │          │  /strengthen             │
-       │         │    ✓ linter rules exist   │          │    guidance → enforce    │
-       │         │    ✓ rules enabled        │          │                          │
-       │         │    ✓ file paths valid     │          │  /pr-to-lint-rule        │
-       │         │    ✓ commands valid       │          │    PR comment → rule     │
-       │         │    → CLAUDE.md + hash     │          │                          │
-       │         └─────────────────────────┘          │  /edit-spec              │
-       │                                               │    agent edits .spec.ts  │
-       │         ┌─────────────────────────┐          └──────────────────────────┘
-       └────────▶│  vigiles audit           │                     │
-                 │    ✓ hash integrity      │                     │
-                 │    ✓ inline rule checks  │                     ▼
-                 │    ✓ duplicate detection  │          ┌──────────────────────────┐
-                 │    ✓ coverage gaps       │          │  hooks (Claude Code)     │
-                 └─────────────────────────┘          │    auto-compile on edit  │
-                                                       │    auto-regen types      │
-                                                       │    block direct md edits │
-                                                       └──────────────────────────┘
-```
+[Full comparison tables (Claude Code vs Codex), determinism breakdown, and flow diagram →](docs/comparison.md)
 
 ## The Fix
 
@@ -270,57 +204,15 @@ Skill specs use the same helpers for verified references inside instructions. [F
 
 ## Type-Safe Rule References
 
-`vigiles generate-types` scans your actual linter configs and emits a `.d.ts`:
+`vigiles generate-types` scans your linter configs and emits `.vigiles/generated.d.ts`. With this file, `enforce("eslint/no-consolee")` is a red squiggle in your editor — a typo caught at authoring time, not a runtime surprise. Without it, everything falls back to broad types and still works.
 
 ```bash
 $ npx vigiles generate-types
-
-  eslint: 64 enabled rules
-  ruff: 12 enabled rules
-  npm scripts: 5
-  project files: 42
-
+  eslint: 64 enabled rules  |  ruff: 12  |  npm scripts: 5  |  project files: 42
 ✓ Generated .vigiles/generated.d.ts
 ```
 
-The generated file does two things:
-
-**1. Standalone types** for direct import:
-
-```typescript
-// .vigiles/generated.d.ts (auto-generated, DO NOT EDIT)
-declare module "vigiles/generated" {
-  export type EslintRule = "no-console" | "no-unused-vars" | ...;
-  export type RuffRule = "E501" | "F401" | "T201" | ...;
-  export type NpmScript = "build" | "test" | "fmt" | ...;
-  export type ProjectFile = "src/spec.ts" | "src/compile.ts" | ...;
-}
-```
-
-**2. Automatic narrowing** of `enforce()`, `file()`, and `cmd()` via declaration merging:
-
-```typescript
-// Also in generated.d.ts — augments vigiles/spec automatically
-declare module "vigiles/spec" {
-  interface KnownLinterRules {
-    eslint: "no-console" | "no-unused-vars" | ...;
-    "@typescript-eslint": "no-floating-promises" | "no-explicit-any" | ...;
-    ruff: "E501" | "F401" | "T201" | ...;
-  }
-  interface KnownProjectFiles { files: "src/spec.ts" | ...; }
-  interface KnownNpmScripts { scripts: "build" | "test" | ...; }
-}
-```
-
-With this file present, `enforce("eslint/no-consolee")` is a red squiggle in your editor — not a runtime surprise. Without it, everything falls back to broad types and still works.
-
-**Commit this file to git.** It should be checked in so that:
-
-- Editors pick up the types immediately (no setup step for new contributors)
-- CI can verify it's fresh: `npx vigiles generate-types --check`
-- Anyone cloning the repo gets autocomplete and type checking out of the box
-
-Re-run `vigiles generate-types` when you add/remove linter rules, npm scripts, or source files. [Details →](docs/linter-support.md#generate-types)
+Commit the file to git. CI can verify it's fresh: `npx vigiles generate-types --check`. [How it works →](docs/linter-support.md#generate-types)
 
 ## CLI
 
@@ -443,59 +335,7 @@ From [Feedback Loop Is All You Need](https://zernie.com/blog/feedback-loop-is-al
 
 ## Output Targets
 
-By default, specs compile to `CLAUDE.md`. Set `target` to compile to other instruction file formats:
-
-```typescript
-// AGENTS.md.spec.ts — single target
-export default claude({
-  target: "AGENTS.md",
-  rules: { ... },
-});
-
-// CLAUDE.md.spec.ts — multiple targets from one spec
-export default claude({
-  target: ["CLAUDE.md", "AGENTS.md"],
-  rules: { ... },
-});
-```
-
-```bash
-$ npx vigiles compile
-✓ CLAUDE.md.spec.ts → CLAUDE.md, AGENTS.md
-```
-
-The compiler, linter cross-referencing, and all validations work identically — only the output filename and heading change. Use sync tools like [rule-porter](https://github.com/nichochar/rule-porter) or [rulesync](https://github.com/dyoshikawa/rulesync) to convert the compiled markdown to non-markdown formats (`.cursorrules`, Copilot, etc.).
-
-## Enforcing Spec Shape with `satisfies`
-
-Use TypeScript's `satisfies` keyword to enforce that your specs always include certain sections or rules:
-
-```typescript
-// Define your project's required spec shape
-type ProjectSpec = {
-  sections: {
-    architecture: string;
-    testing: string;
-  };
-  commands: Record<string, string>;
-  rules: Record<string, Rule>;
-};
-
-// TypeScript errors if you forget a required section
-export default claude({
-  sections: {
-    architecture: "...",
-    testing: "...",
-    // ✗ Remove 'testing' → "Property 'testing' is missing"
-  },
-  commands: {
-    "npm test": "Run all tests",
-  },
-  rules: { ... },
-} satisfies ProjectSpec);
-```
-
-This is a convention you can adopt per-project — define what a "complete" spec looks like for your team, and the compiler enforces it at type-check time.
+Specs compile to `CLAUDE.md` by default. Set `target: "AGENTS.md"` or `target: ["CLAUDE.md", "AGENTS.md"]` for multiple outputs from one spec. For non-markdown formats (`.cursorrules`, Copilot), use [rule-porter](https://github.com/nichochar/rule-porter) or [rulesync](https://github.com/dyoshikawa/rulesync) to convert. [Spec format →](docs/spec-format.md)
 
 ## Related Tools
 

--- a/README.md
+++ b/README.md
@@ -362,10 +362,27 @@ The plugin provides two hooks:
 
 ## Validation
 
-`vigiles audit` validates instruction files. One rule: `require-spec` (enabled by default) — checks that every CLAUDE.md/AGENTS.md has a corresponding `.spec.ts` file, and verifies SHA-256 integrity hashes to detect manual edits.
+`vigiles audit` validates instruction files with three rules:
+
+| Rule                 | Default  | What it checks                                |
+| -------------------- | -------- | --------------------------------------------- |
+| `require-spec`       | `"warn"` | Every CLAUDE.md/AGENTS.md has a `.spec.ts`    |
+| `require-skill-spec` | `"warn"` | Every SKILL.md has a `.spec.ts`               |
+| `freshness`          | `"warn"` | Compiled output matches current project state |
 
 ```bash
-npx vigiles audit    # errors if CLAUDE.md has no spec, or hash is stale
+npx vigiles audit    # checks specs, hashes, freshness, coverage, duplicates
+```
+
+Configure in `.vigilesrc.json`:
+
+```json
+{
+  "rules": {
+    "require-spec": "error",
+    "freshness": "error"
+  }
+}
 ```
 
 Disable per-file with an HTML comment:
@@ -378,11 +395,26 @@ Disable per-file with an HTML comment:
 ...
 ```
 
-Or in `.vigilesrc.json`:
+### Freshness
+
+The `freshness` rule detects when compiled markdown has drifted from project state — disabled linter rules, deleted files, changed configs. Three detection modes:
+
+| Mode                 | What it does                                                            | Cost   |
+| -------------------- | ----------------------------------------------------------------------- | ------ |
+| `"strict"` (default) | Recompiles in memory, diffs output                                      | 2-5s   |
+| `"input-hash"`       | Checks fingerprint of tracked inputs (spec, linter configs, lock files) | <100ms |
+| `"output-hash"`      | Only detects hand-edits to compiled markdown                            | <1ms   |
+
+Strict mode has zero false positives and zero false negatives. Input-hash mode is faster but can false-positive on config whitespace changes. Set the mode in `.vigilesrc.json`:
 
 ```json
-{ "rules": { "require-spec": false } }
+{
+  "freshnessMode": "input-hash",
+  "freshnessInputs": ["../../yarn.lock"]
+}
 ```
+
+In input-hash mode, vigiles auto-detects lock files across 15 ecosystems (npm, Yarn, pnpm, Bun, Bundler, Poetry, uv, PDM, pip, Cargo, Go, Composer, NuGet, SPM, Mix) and tracks them alongside linter configs, package.json, keyFiles references, and generated types. [Full details →](docs/freshness.md)
 
 ## Skills
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,78 @@ Reads fine. Four things are wrong:
 
 The agent reads this, trusts it, and writes code based on stale claims nobody verified.
 
+## What Changes With vigiles
+
+### Claude Code
+
+|                                     | Without vigiles              | With vigiles                                                   |
+| ----------------------------------- | ---------------------------- | -------------------------------------------------------------- |
+| **Instructions**                    | Hand-written CLAUDE.md       | Compiled from `.spec.ts` (build artifact)                      |
+| **Linter rule references**          | Trust-based (nobody checks)  | Verified at compile time against real config                   |
+| **File paths**                      | Rot silently when renamed    | `file()` references checked against filesystem                 |
+| **Commands**                        | Stale scripts go unnoticed   | `cmd()` references checked against package.json                |
+| **Direct edits to CLAUDE.md**       | Anyone can, nobody knows     | PreToolUse hook blocks edits, redirects to spec                |
+| **Linter config changes**           | CLAUDE.md drifts out of sync | PostToolUse hook auto-regenerates types                        |
+| **Spec edits**                      | N/A                          | PostToolUse hook auto-compiles to markdown                     |
+| **guidance → enforce upgrades**     | Manual guesswork             | `/strengthen` reads per-linter docs, suggests upgrades         |
+| **New lint rules from PR feedback** | Copy-paste from review       | `/pr-to-lint-rule` generates rule + tests + spec entry         |
+| **CI**                              | Nothing to verify            | `vigiles audit` catches hash drift, disabled rules, stale refs |
+
+### Codex / GitHub Copilot
+
+|                               | Without vigiles                  | With vigiles                                            |
+| ----------------------------- | -------------------------------- | ------------------------------------------------------- |
+| **Instructions**              | Hand-written AGENTS.md           | Compiled from `.spec.ts`                                |
+| **Linter rule references**    | Trust-based                      | Verified at compile time                                |
+| **File paths / commands**     | Rot silently                     | Checked at compile time                                 |
+| **Direct edits to AGENTS.md** | Undetected                       | CI catches hash mismatch                                |
+| **Hooks / auto-compile**      | Not available (no plugin system) | Not available — run `vigiles compile` manually or in CI |
+| **CI**                        | Nothing to verify                | Same `vigiles audit` pipeline as Claude                 |
+
+Codex and Copilot have no hook or plugin system. The compile-time verification and CI enforcement still work — the difference is there's no auto-recompilation on edit. You run `vigiles compile` before committing, and CI catches drift.
+
+### What's Deterministic vs What's Not
+
+| Check                            | Deterministic? | How                                                                                  |
+| -------------------------------- | -------------- | ------------------------------------------------------------------------------------ |
+| Linter rule exists in catalog    | Yes            | Node API (`builtinRules`) or CLI (`ruff rule`, `rubocop --show-cops`)                |
+| Linter rule is enabled in config | Yes            | `calculateConfigForFile` (ESLint), `--show-settings` (Ruff), `--show-cops` (RuboCop) |
+| File path exists                 | Yes            | `fs.existsSync`                                                                      |
+| npm script exists                | Yes            | Parsed from `package.json`                                                           |
+| SHA-256 hash matches             | Yes            | Recompute and compare                                                                |
+| Duplicate rule detection         | Yes            | Normalized Compression Distance (NCD) with fixed threshold                           |
+| guidance → enforce suggestion    | **No**         | Agent reads linter docs, reasons about intent — `/strengthen` skill                  |
+| PR comment → lint rule           | **No**         | Agent generates custom rule code — `/pr-to-lint-rule` skill                          |
+| Spec content authoring           | **No**         | Agent or human writes the spec — vigiles verifies it                                 |
+
+Everything vigiles compiles and audits is deterministic — same input, same output, no LLM in the loop. The non-deterministic parts (authoring specs, suggesting upgrades, writing custom rules) are agent skills that run outside the compilation pipeline.
+
+### Flow
+
+```
+                        DETERMINISTIC                          AGENT-ASSISTED
+                  ┌─────────────────────────┐          ┌──────────────────────────┐
+                  │                         │          │                          │
+  .spec.ts ──────┤  vigiles compile         │          │  /strengthen             │
+       │         │    ✓ linter rules exist   │          │    guidance → enforce    │
+       │         │    ✓ rules enabled        │          │                          │
+       │         │    ✓ file paths valid     │          │  /pr-to-lint-rule        │
+       │         │    ✓ commands valid       │          │    PR comment → rule     │
+       │         │    → CLAUDE.md + hash     │          │                          │
+       │         └─────────────────────────┘          │  /edit-spec              │
+       │                                               │    agent edits .spec.ts  │
+       │         ┌─────────────────────────┐          └──────────────────────────┘
+       └────────▶│  vigiles audit           │                     │
+                 │    ✓ hash integrity      │                     │
+                 │    ✓ inline rule checks  │                     ▼
+                 │    ✓ duplicate detection  │          ┌──────────────────────────┐
+                 │    ✓ coverage gaps       │          │  hooks (Claude Code)     │
+                 └─────────────────────────┘          │    auto-compile on edit  │
+                                                       │    auto-regen types      │
+                                                       │    block direct md edits │
+                                                       └──────────────────────────┘
+```
+
 ## The Fix
 
 Write your conventions as TypeScript. The compiler catches the lies.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,16 @@ The agent reads this, trusts it, and writes code based on stale claims nobody ve
 | **New lint rules from PR feedback** | Copy-paste from review       | `/pr-to-lint-rule` generates rule + tests + spec entry         |
 | **CI**                              | Nothing to verify            | `vigiles audit` catches hash drift, disabled rules, stale refs |
 
-Also compiles to AGENTS.md for Codex/Copilot — same verification, no hooks (they don't support them). [Full comparison →](docs/comparison.md)
+### Codex
+
+|                               | Without vigiles                  | With vigiles                                            |
+| ----------------------------- | -------------------------------- | ------------------------------------------------------- |
+| **Instructions**              | Hand-written AGENTS.md           | Compiled from `.spec.ts`                                |
+| **Linter rule references**    | Trust-based                      | Verified at compile time                                |
+| **File paths / commands**     | Rot silently                     | Checked at compile time                                 |
+| **Direct edits to AGENTS.md** | Undetected                       | CI catches hash mismatch                                |
+| **Hooks / auto-compile**      | Not available (no plugin system) | Not available — run `vigiles compile` manually or in CI |
+| **CI**                        | Nothing to verify                | Same `vigiles audit` pipeline as Claude                 |
 
 Everything vigiles compiles and audits is **deterministic** — same input, same output, no LLM in the loop. The non-deterministic parts (authoring specs, suggesting upgrades, writing custom rules) are agent skills that run outside the compilation pipeline. [Determinism breakdown and flow diagram →](docs/comparison.md)
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ The agent reads this, trusts it, and writes code based on stale claims nobody ve
 | **New lint rules from PR feedback** | Copy-paste from review       | `/pr-to-lint-rule` generates rule + tests + spec entry         |
 | **CI**                              | Nothing to verify            | `vigiles audit` catches hash drift, disabled rules, stale refs |
 
-### Codex
+<details>
+<summary><b>Codex</b> (same compile-time checks, no hooks)</summary>
 
 |                               | Without vigiles                  | With vigiles                                            |
 | ----------------------------- | -------------------------------- | ------------------------------------------------------- |
@@ -86,6 +87,8 @@ The agent reads this, trusts it, and writes code based on stale claims nobody ve
 | **Direct edits to AGENTS.md** | Undetected                       | CI catches hash mismatch                                |
 | **Hooks / auto-compile**      | Not available (no plugin system) | Not available — run `vigiles compile` manually or in CI |
 | **CI**                        | Nothing to verify                | Same `vigiles audit` pipeline as Claude                 |
+
+</details>
 
 Everything vigiles compiles and audits is **deterministic** — same input, same output, no LLM in the loop. The non-deterministic parts (authoring specs, suggesting upgrades, writing custom rules) are agent skills that run outside the compilation pipeline. [Determinism breakdown and flow diagram →](docs/comparison.md)
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,71 @@
+# What Changes With vigiles
+
+## Claude Code
+
+|                                     | Without vigiles              | With vigiles                                                   |
+| ----------------------------------- | ---------------------------- | -------------------------------------------------------------- |
+| **Instructions**                    | Hand-written CLAUDE.md       | Compiled from `.spec.ts` (build artifact)                      |
+| **Linter rule references**          | Trust-based (nobody checks)  | Verified at compile time against real config                   |
+| **File paths**                      | Rot silently when renamed    | `file()` references checked against filesystem                 |
+| **Commands**                        | Stale scripts go unnoticed   | `cmd()` references checked against package.json                |
+| **Direct edits to CLAUDE.md**       | Anyone can, nobody knows     | PreToolUse hook blocks edits, redirects to spec                |
+| **Linter config changes**           | CLAUDE.md drifts out of sync | PostToolUse hook auto-regenerates types                        |
+| **Spec edits**                      | N/A                          | PostToolUse hook auto-compiles to markdown                     |
+| **guidance → enforce upgrades**     | Manual guesswork             | `/strengthen` reads per-linter docs, suggests upgrades         |
+| **New lint rules from PR feedback** | Copy-paste from review       | `/pr-to-lint-rule` generates rule + tests + spec entry         |
+| **CI**                              | Nothing to verify            | `vigiles audit` catches hash drift, disabled rules, stale refs |
+
+## Codex / GitHub Copilot
+
+|                               | Without vigiles                  | With vigiles                                            |
+| ----------------------------- | -------------------------------- | ------------------------------------------------------- |
+| **Instructions**              | Hand-written AGENTS.md           | Compiled from `.spec.ts`                                |
+| **Linter rule references**    | Trust-based                      | Verified at compile time                                |
+| **File paths / commands**     | Rot silently                     | Checked at compile time                                 |
+| **Direct edits to AGENTS.md** | Undetected                       | CI catches hash mismatch                                |
+| **Hooks / auto-compile**      | Not available (no plugin system) | Not available — run `vigiles compile` manually or in CI |
+| **CI**                        | Nothing to verify                | Same `vigiles audit` pipeline as Claude                 |
+
+Codex and Copilot have no hook or plugin system. The compile-time verification and CI enforcement still work — the difference is there's no auto-recompilation on edit. You run `vigiles compile` before committing, and CI catches drift.
+
+## What's Deterministic vs What's Not
+
+| Check                            | Deterministic? | How                                                                                  |
+| -------------------------------- | -------------- | ------------------------------------------------------------------------------------ |
+| Linter rule exists in catalog    | Yes            | Node API (`builtinRules`) or CLI (`ruff rule`, `rubocop --show-cops`)                |
+| Linter rule is enabled in config | Yes            | `calculateConfigForFile` (ESLint), `--show-settings` (Ruff), `--show-cops` (RuboCop) |
+| File path exists                 | Yes            | `fs.existsSync`                                                                      |
+| npm script exists                | Yes            | Parsed from `package.json`                                                           |
+| SHA-256 hash matches             | Yes            | Recompute and compare                                                                |
+| Duplicate rule detection         | Yes            | Normalized Compression Distance (NCD) with fixed threshold                           |
+| guidance → enforce suggestion    | **No**         | Agent reads linter docs, reasons about intent — `/strengthen` skill                  |
+| PR comment → lint rule           | **No**         | Agent generates custom rule code — `/pr-to-lint-rule` skill                          |
+| Spec content authoring           | **No**         | Agent or human writes the spec — vigiles verifies it                                 |
+
+Everything vigiles compiles and audits is deterministic — same input, same output, no LLM in the loop. The non-deterministic parts (authoring specs, suggesting upgrades, writing custom rules) are agent skills that run outside the compilation pipeline.
+
+## Flow
+
+```
+                        DETERMINISTIC                          AGENT-ASSISTED
+                  ┌─────────────────────────┐          ┌──────────────────────────┐
+                  │                         │          │                          │
+  .spec.ts ──────┤  vigiles compile         │          │  /strengthen             │
+       │         │    ✓ linter rules exist   │          │    guidance → enforce    │
+       │         │    ✓ rules enabled        │          │                          │
+       │         │    ✓ file paths valid     │          │  /pr-to-lint-rule        │
+       │         │    ✓ commands valid       │          │    PR comment → rule     │
+       │         │    → CLAUDE.md + hash     │          │                          │
+       │         └─────────────────────────┘          │  /edit-spec              │
+       │                                               │    agent edits .spec.ts  │
+       │         ┌─────────────────────────┐          └──────────────────────────┘
+       └────────▶│  vigiles audit           │                     │
+                 │    ✓ hash integrity      │                     │
+                 │    ✓ inline rule checks  │                     ▼
+                 │    ✓ duplicate detection  │          ┌──────────────────────────┐
+                 │    ✓ coverage gaps       │          │  hooks (Claude Code)     │
+                 └─────────────────────────┘          │    auto-compile on edit  │
+                                                       │    auto-regen types      │
+                                                       │    block direct md edits │
+                                                       └──────────────────────────┘
+```

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -15,7 +15,7 @@
 | **New lint rules from PR feedback** | Copy-paste from review       | `/pr-to-lint-rule` generates rule + tests + spec entry         |
 | **CI**                              | Nothing to verify            | `vigiles audit` catches hash drift, disabled rules, stale refs |
 
-## Codex / GitHub Copilot
+## Codex
 
 |                               | Without vigiles                  | With vigiles                                            |
 | ----------------------------- | -------------------------------- | ------------------------------------------------------- |
@@ -26,7 +26,7 @@
 | **Hooks / auto-compile**      | Not available (no plugin system) | Not available — run `vigiles compile` manually or in CI |
 | **CI**                        | Nothing to verify                | Same `vigiles audit` pipeline as Claude                 |
 
-Codex and Copilot have no hook or plugin system. The compile-time verification and CI enforcement still work — the difference is there's no auto-recompilation on edit. You run `vigiles compile` before committing, and CI catches drift.
+Codex has no hook or plugin system. The compile-time verification and CI enforcement still work — the difference is there's no auto-recompilation on edit. You run `vigiles compile` before committing, and CI catches drift.
 
 ## What's Deterministic vs What's Not
 

--- a/docs/freshness.md
+++ b/docs/freshness.md
@@ -1,0 +1,124 @@
+# Freshness Detection
+
+vigiles detects when compiled instruction files are out of date. The `freshness` validation rule catches drift between your specs and the compiled markdown.
+
+## Configuration
+
+In `.vigilesrc.json`:
+
+```json
+{
+  "rules": {
+    "freshness": "error"
+  },
+  "freshnessMode": "strict"
+}
+```
+
+### Severity
+
+| Value              | Behavior                                  |
+| ------------------ | ----------------------------------------- |
+| `"error"`          | `vigiles audit` exits non-zero (CI fails) |
+| `"warn"` (default) | Prints warning, exits 0                   |
+| `false`            | Skip freshness checks entirely            |
+
+### Mode
+
+| Mode                 | What it checks                                                 | Cost          | False positives                         | False negatives               |
+| -------------------- | -------------------------------------------------------------- | ------------- | --------------------------------------- | ----------------------------- |
+| `"strict"` (default) | Recompiles in memory, diffs against existing output            | 2-5s per spec | Zero                                    | Zero                          |
+| `"input-hash"`       | Compares stored input fingerprint against current file state   | <100ms        | Possible (whitespace changes in config) | Possible (transitive deps)    |
+| `"output-hash"`      | Only checks if the `.md` was hand-edited (existing hash check) | <1ms          | Zero                                    | Many (misses all input drift) |
+
+**Strict mode** is the correct default. It catches every kind of staleness with zero false positives. The cost is running a full recompile in memory on every `vigiles audit`.
+
+**Input-hash mode** is faster. Use it when compilation is slow (many specs, heavy linter config loading). It tracks a fingerprint of all input files (spec source, linter configs, lock files, keyFiles, generated types). When any input changes, audit flags the output as stale. To use it, set `freshnessMode: "input-hash"` — `vigiles compile` will embed the input fingerprint in the compiled markdown.
+
+**Output-hash mode** is the minimal option. It only detects hand-edits to the compiled markdown (the pre-existing hash check). It won't catch disabled linter rules, deleted files, or spec changes.
+
+## What Counts as an Input
+
+In input-hash mode, vigiles tracks these files:
+
+| Category         | Files                                                                                                                                                                                                                                    | Why                                                    |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| Spec source      | `CLAUDE.md.spec.ts`                                                                                                                                                                                                                      | Any spec change should force recompile                 |
+| Linter configs   | `eslint.config.*`, `.eslintrc.*`, `pyproject.toml`, `ruff.toml`, `Cargo.toml`, `clippy.toml`, `.pylintrc`, `.rubocop.yml`, `.stylelintrc.*`, `setup.cfg`                                                                                 | Disabling a rule makes `enforce()` claims stale        |
+| Package manifest | `package.json`                                                                                                                                                                                                                           | Scripts (`cmd()` refs) and deps (linter plugins)       |
+| Lock files       | `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lockb`, `Gemfile.lock`, `poetry.lock`, `uv.lock`, `pdm.lock`, `Cargo.lock`, `go.sum`, `composer.lock`, `packages.lock.json`, `Package.resolved`, `mix.lock`, `requirements.txt` | Dependency version changes can add/remove linter rules |
+| Referenced files | Every `file()` path in `keyFiles`                                                                                                                                                                                                        | Deletion or rename makes the reference stale           |
+| Generated types  | `.vigiles/generated.d.ts`                                                                                                                                                                                                                | If types are stale, rule references may be invalid     |
+| Extra inputs     | Configured via `freshnessInputs`                                                                                                                                                                                                         | For non-standard files (e.g., monorepo root lock file) |
+
+All files are auto-detected by checking existence at `basePath`. Lock files and linter configs cover 6+ ecosystems (Node.js, Ruby, Python, Rust, Go, PHP, .NET, Swift, Elixir).
+
+## Extra Inputs
+
+For monorepos or non-standard layouts, add extra files to track:
+
+```json
+{
+  "freshnessMode": "input-hash",
+  "freshnessInputs": ["../../yarn.lock", "shared/eslint-config/index.js"]
+}
+```
+
+## How the Input Hash Works
+
+At compile time (`vigiles compile`), when `freshnessMode` is `"input-hash"`:
+
+1. Discover all input files (spec, configs, lock files, keyFiles, etc.)
+2. Compute SHA-256 of each file's contents (missing files hash to `MISSING:<path>`)
+3. Combine all file hashes into a single fingerprint (SHA-256 of sorted hashes)
+4. Embed the fingerprint in the compiled markdown:
+
+```html
+<!-- vigiles:sha256:a1b2c3d4e5f6g7h8 compiled from CLAUDE.md.spec.ts -->
+<!-- vigiles:inputs:f9e8d7c6b5a49382 -->
+
+# CLAUDE.md ...
+```
+
+At audit time (`vigiles audit`):
+
+1. Extract the stored input fingerprint
+2. Recompute the fingerprint from current file state
+3. If they differ → stale
+
+## Audit Output
+
+```
+Freshness check:
+
+  ✓ CLAUDE.md — fresh (strict)
+  ✗ AGENTS.md — Output would differ if recompiled — run `vigiles compile`
+```
+
+With `--summary`:
+
+```
+vigiles: 1 stale (run vigiles compile)
+```
+
+## Lock File Detection
+
+vigiles auto-detects lock files for every major ecosystem. No configuration needed — if the file exists, it's tracked.
+
+| Lock file            | Ecosystem       |
+| -------------------- | --------------- |
+| `package-lock.json`  | Node.js (npm)   |
+| `yarn.lock`          | Node.js (Yarn)  |
+| `pnpm-lock.yaml`     | Node.js (pnpm)  |
+| `bun.lockb`          | Node.js (Bun)   |
+| `Gemfile.lock`       | Ruby (Bundler)  |
+| `poetry.lock`        | Python (Poetry) |
+| `uv.lock`            | Python (uv)     |
+| `pdm.lock`           | Python (PDM)    |
+| `requirements.txt`   | Python (pip)    |
+| `Cargo.lock`         | Rust (Cargo)    |
+| `go.sum`             | Go              |
+| `composer.lock`      | PHP (Composer)  |
+| `packages.lock.json` | .NET (NuGet)    |
+| `Package.resolved`   | Swift (SPM)     |
+| `mix.lock`           | Elixir (Mix)    |

--- a/research/doc-freshness.md
+++ b/research/doc-freshness.md
@@ -293,44 +293,117 @@ No manifest, no input tracking, no false positives from whitespace reformatting.
 
 Input fingerprinting only wins when compilation is expensive enough that you want to **avoid** running it. For vigiles today, it isn't.
 
-### Recommended: configurable freshness rule
+### Recommended: `freshness` validation rule
 
-Make freshness checking a configurable rule in `vigiles.json` (or `package.json` under `"vigiles"`), defaulting to strict:
+Add `freshness` to `RulesConfig` alongside `require-spec` and `require-skill-spec`. Global rule in `.vigilesrc.json`, optional per-spec override in the spec itself.
 
 ```json
 {
   "rules": {
-    "freshness": "strict"
-  }
+    "require-spec": "warn",
+    "freshness": "error"
+  },
+  "freshnessMode": "strict"
 }
 ```
 
-| Mode                 | What `vigiles audit` does                                                                  | Cost                     | False positives                                    |
-| -------------------- | ------------------------------------------------------------------------------------------ | ------------------------ | -------------------------------------------------- |
-| `"strict"` (default) | Recompiles in memory, diffs output. Fails if compiled markdown would change.               | 2-5s (runs full compile) | Zero — it checks the actual output                 |
-| `"input-hash"`       | Checks input fingerprint only. Fails if any tracked input file changed since last compile. | <100ms (hash comparison) | Possible — whitespace changes in config trigger it |
-| `"output-hash"`      | Current behavior. Only checks if the `.md` was hand-edited.                                | <1ms (single hash)       | Zero — but misses input drift entirely             |
-| `false`              | Skip freshness checks.                                                                     | 0                        | N/A                                                |
+Severity controls what happens when staleness is detected (`"error"` = CI fails, `"warn"` = prints warning, `false` = skip). Mode controls **how** staleness is detected:
 
-**Strict mode is correct by default.** It's the only mode with zero false positives AND zero false negatives. The cost is re-running compilation, which takes the same time as `vigiles compile`.
+| Mode                 | What `vigiles audit` does                                                                  | Cost                     | False positives                                    | False negatives                 |
+| -------------------- | ------------------------------------------------------------------------------------------ | ------------------------ | -------------------------------------------------- | ------------------------------- |
+| `"strict"` (default) | Recompiles in memory, diffs output. Fails if compiled markdown would change.               | 2-5s (runs full compile) | Zero — it checks the actual output                 | Zero                            |
+| `"input-hash"`       | Checks input fingerprint only. Fails if any tracked input file changed since last compile. | <100ms (hash comparison) | Possible — whitespace changes in config trigger it | Possible — transitive deps      |
+| `"output-hash"`      | Current behavior. Only checks if the `.md` was hand-edited.                                | <1ms (single hash)       | Zero — but misses input drift entirely             | Many — misses all input changes |
 
-**Input-hash mode is the fast-path optimization.** Projects where compilation is slow (many specs, large linter configs, slow ESLint plugin loading) can opt into input fingerprinting to skip the full recompile. They accept occasional false positives (config reformatting, irrelevant package.json changes) in exchange for faster CI.
+**Strict mode is correct by default.** Zero false positives AND zero false negatives. The cost is re-running compilation, which takes the same time as `vigiles compile`.
 
-**Output-hash mode is the minimal fallback.** For projects that just want "don't hand-edit the markdown" enforcement.
+**Input-hash mode is the fast-path optimization.** For projects where compilation is slow (many specs, large linter configs, slow ESLint plugin loading). Accepts occasional false positives in exchange for faster CI.
+
+**Output-hash mode is the minimal fallback.** "Don't hand-edit the markdown" enforcement only.
+
+### Per-spec override
+
+A spec can override the global freshness mode:
+
+```typescript
+export default claude({
+  freshness: "input-hash", // override global "strict" for this slow spec
+  rules: { ... },
+});
+```
+
+### Lock files as inputs
+
+For input-hash mode, the lock file is a better signal than `package.json` for dependency changes. vigiles auto-detects lock files by language:
+
+| Lock file           | Language | What it catches                              |
+| ------------------- | -------- | -------------------------------------------- |
+| `package-lock.json` | Node.js  | ESLint/Stylelint plugin version changes      |
+| `yarn.lock`         | Node.js  | Same as above (Yarn)                         |
+| `pnpm-lock.yaml`    | Node.js  | Same as above (pnpm)                         |
+| `bun.lockb`         | Node.js  | Same as above (Bun)                          |
+| `Gemfile.lock`      | Ruby     | RuboCop gem version changes                  |
+| `poetry.lock`       | Python   | Pylint plugin version changes                |
+| `uv.lock`           | Python   | Same as above (uv)                           |
+| `Cargo.lock`        | Rust     | Clippy version changes (via rustc version)   |
+| `requirements.txt`  | Python   | Fallback if no lock file (pip freeze output) |
+
+Detection is simple: check `existsSync` for each. First match wins (projects rarely have competing lock files for the same language). The lock file goes into the input hash alongside linter configs and `package.json`.
+
+Why the lock file and not just `package.json`? Because `package.json` can stay identical while the resolved dependency tree changes (version ranges). A Stylelint plugin upgrade from 15.0.0 to 16.0.0 might add/remove rules — `package.json` says `"^15.0.0"` in both cases, but the lock file changes.
+
+For strict mode this doesn't matter (it recompiles from scratch). For input-hash mode it prevents a class of false negatives where dependencies change but `package.json` doesn't.
+
+If the auto-detection is wrong (e.g., monorepo with lock file at a non-standard location), it can be configured explicitly:
+
+```json
+{
+  "freshnessInputs": ["../../yarn.lock"]
+}
+```
+
+### Type changes
+
+```typescript
+// src/types.ts
+
+export type FreshnessMode = "strict" | "input-hash" | "output-hash";
+
+export interface RulesConfig {
+  "require-spec"?: RuleSeverity;
+  "require-skill-spec"?: RuleSeverity;
+  freshness?: RuleSeverity; // NEW
+}
+
+export interface VigilesConfig {
+  ruleMarkers: MarkerType[];
+  rules: Required<RulesConfig>;
+  files: string[];
+  freshnessMode?: FreshnessMode; // NEW — default "strict"
+  freshnessInputs?: string[]; // NEW — extra files to include in input hash
+}
+```
+
+### Default behavior change
+
+Today: `vigiles audit` only checks output hashes (hand-edit detection).
+After: `vigiles audit` also recompiles in memory and diffs (freshness: "error", strict mode by default).
+
+This is a **breaking change** for projects where the compiled markdown has drifted from the spec. But that's the point — those projects have stale instructions. The `"warn"` severity softens the migration, and `false` opts out entirely.
 
 ### Phase 1: `compile --check` (strict mode)
 
 1. `compile.ts` — add `--check` / `dryRun` flag that compiles in memory, compares to existing file
-2. `cli.ts` (`audit`) — when `freshness: "strict"` (default), run compile in check mode
+2. `cli.ts` (`audit`) — when `freshness` rule is enabled and mode is `"strict"`, run compile in check mode
 3. Error message: `"CLAUDE.md is stale — run vigiles compile"`
-4. Fast path: skip if output hash hasn't changed (same as today, but then also run full check)
 
-### Phase 2: Input fingerprinting (opt-in)
+### Phase 2: Input fingerprinting (input-hash mode)
 
 1. `compile.ts` — compute input hash after compilation, embed as second HTML comment
-2. `cli.ts` (`audit`) — when `freshness: "input-hash"`, extract and verify input hash
-3. Error message: `"Inputs changed since last compile (eslint.config.mjs, package.json) — run vigiles compile"`
-4. Show which files changed (diff input list against current state)
+2. Auto-detect lock files + linter configs as inputs
+3. `cli.ts` (`audit`) — when mode is `"input-hash"`, extract and verify input hash
+4. Error message: `"Inputs changed since last compile (eslint.config.mjs, yarn.lock) — run vigiles compile"`
+5. Show which files changed (diff input list against current state)
 
 ### Phase 3: Granular reporting
 

--- a/research/doc-freshness.md
+++ b/research/doc-freshness.md
@@ -1,0 +1,399 @@
+# Doc Freshness: Input Fingerprinting for Stale Spec Detection
+
+## The Gap
+
+vigiles hashes the **compiled output** (the `.md` file). This catches manual edits to the markdown. It does NOT catch when the **inputs** that produced that markdown have changed.
+
+After `vigiles compile` runs successfully:
+
+| What changes                         | Detected today?         | Consequence                                   |
+| ------------------------------------ | ----------------------- | --------------------------------------------- |
+| Someone edits CLAUDE.md by hand      | Yes (hash mismatch)     | `vigiles audit` catches it                    |
+| Linter rule gets disabled in config  | No                      | Spec claims `enforce()`, rule is actually off |
+| Referenced file deleted              | No (until next compile) | Markdown contains stale `file()` path         |
+| npm script removed from package.json | No (until next compile) | Markdown references dead command              |
+| Spec file edited, nobody recompiles  | No                      | Markdown and spec diverge                     |
+| ESLint plugin uninstalled            | No (until next compile) | Markdown references non-existent rules        |
+| `.vigiles/generated.d.ts` stale      | Yes (`--check` mode)    | Types don't match reality                     |
+
+The hash answers: "Was the output tampered with?" It doesn't answer: "Is the output still valid given what's true about the project right now?"
+
+## Prior Art
+
+### Make / CMake — mtime comparison
+
+Track file modification times. If source is newer than target, rebuild.
+
+- Pro: simple, zero overhead
+- Con: mtime is unreliable (git clone resets it, clock skew in CI, `touch` defeats it)
+- Con: doesn't detect content changes on same-second edits
+- **Verdict:** Not suitable. vigiles needs content-based detection, not time-based.
+
+### Bazel / Buck — input fingerprinting
+
+Hash **all inputs** to a build action into a single key. Cache the output by that key. If any input changes, the key changes, the cache misses, and the action re-runs.
+
+- Pro: precise — catches any input variation
+- Pro: deterministic — same inputs always produce same output
+- Pro: cacheable — skip redundant work
+- Con: requires strict input isolation (must enumerate every file that affects the output)
+- **Verdict:** The right model. vigiles can enumerate its inputs: spec file, linter configs, package.json, referenced files.
+
+### Nix — derivation input hashing
+
+Every build step declares its inputs. The derivation hash changes if any input hash changes. The output path is derived from the input hash, so stale outputs are impossible — they live at a different path.
+
+- Pro: hermetic — output is always fresh by construction
+- Con: overkill for vigiles (we're not building packages, just compiling markdown)
+- **Verdict:** The principle is right (hash inputs, not outputs). The mechanism is too heavy.
+
+### Terraform — drift detection
+
+`terraform plan` compares desired state (config) against actual state (cloud resources). Any delta is flagged as drift.
+
+- Pro: detects both directions of drift (config changed, resource changed)
+- Pro: shows a diff, not just "stale"
+- **Verdict:** Good analogy. vigiles should compare "what the spec claims" against "what the project actually has."
+
+### Git tree hashes
+
+Git hashes directory trees content-addressably. Changing one file changes the tree hash all the way up. `git diff --stat` shows exactly what changed.
+
+- Pro: always available, zero setup
+- Pro: can pin a specific commit as "known good"
+- Con: requires git repo
+- Con: only tracks committed state (uncommitted changes invisible)
+- **Verdict:** Useful as one signal. Can record "compiled at git tree hash X" and check if the relevant files changed since.
+
+### TypeScript `tsBuildInfo` — incremental compilation
+
+Stores per-file hashes and dependency graph. On next compile, skips files whose hash (and all transitive dependency hashes) haven't changed.
+
+- Pro: fast incremental builds
+- Con: complex dependency graph maintenance
+- **Verdict:** vigiles has a simpler dependency model (spec → {linter configs, files, package.json}). Full DAG is unnecessary.
+
+## Design
+
+### Input manifest
+
+At compile time, record every input that affected the output. Store alongside the output hash.
+
+```
+<!-- vigiles:sha256:a1b2c3d4e5f6g7h8 compiled from CLAUDE.md.spec.ts -->
+<!-- vigiles:inputs:sha256:f9e8d7c6b5a49382 -->
+```
+
+The input hash is a SHA-256 of the **sorted, concatenated hashes** of all input files:
+
+```
+inputs = sort([
+  sha256(readFile("CLAUDE.md.spec.ts")),       # the spec source
+  sha256(readFile("eslint.config.mjs")),        # linter config
+  sha256(readFile("package.json")),             # scripts + deps
+  sha256(readFile("tsconfig.json")),            # if referenced
+  sha256(readFile("src/compile.ts")),           # each file() reference
+  sha256(readFile("src/linters.ts")),           # each file() reference
+  ...                                           # all keyFiles entries
+])
+inputHash = sha256(inputs.join("\n"))
+```
+
+### What counts as an input
+
+| Input category   | Files                                                                                                                                          | Why                                                    |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| Spec source      | `CLAUDE.md.spec.ts`                                                                                                                            | Any change to the spec should force recompile          |
+| Linter configs   | `eslint.config.*`, `.eslintrc.*`, `pyproject.toml` `[tool.ruff]`, `Cargo.toml` `[lints.clippy]`, `.pylintrc`, `.rubocop.yml`, `.stylelintrc.*` | Disabling a rule makes `enforce()` claims stale        |
+| Package manifest | `package.json`                                                                                                                                 | Scripts (`cmd()` references) and deps (linter plugins) |
+| Referenced files | Every `file()` call in the spec                                                                                                                | Deletion or rename makes the reference stale           |
+| Generated types  | `.vigiles/generated.d.ts`                                                                                                                      | If types are stale, rule references may be invalid     |
+
+### What does NOT count as an input
+
+- Source code files that aren't in `keyFiles` — vigiles doesn't lint code, it lints specs
+- `node_modules/` — too large, too volatile; linter config is the proxy
+- `.git/` — internal state, not a build input
+- Other specs — each spec is compiled independently
+
+### Audit behavior
+
+`vigiles audit` gains a new check:
+
+1. Read the compiled `.md` file
+2. Extract the output hash (existing) and input hash (new)
+3. Recompute the input hash from current file state
+4. If input hash mismatches: **"Inputs changed since last compile — run `vigiles compile`"**
+
+This is separate from the output hash check:
+
+| Output hash | Input hash | Meaning                                            |
+| ----------- | ---------- | -------------------------------------------------- |
+| Valid       | Valid      | Everything fresh                                   |
+| Invalid     | Valid      | Someone hand-edited the markdown                   |
+| Valid       | Invalid    | Inputs changed, output is stale — recompile needed |
+| Invalid     | Invalid    | Both changed — recompile needed                    |
+
+### Discovery: which linter configs exist
+
+vigiles already detects linters in `src/linters.ts` and `src/generate-types.ts`. The input manifest reuses this:
+
+```typescript
+function discoverInputFiles(spec: ClaudeSpec, basePath: string): string[] {
+  const inputs: string[] = [];
+
+  // 1. Spec source
+  inputs.push(spec._sourceFile);
+
+  // 2. Linter configs — check existence of known config files
+  const linterConfigs = [
+    "eslint.config.mjs",
+    "eslint.config.js",
+    "eslint.config.ts",
+    ".eslintrc.json",
+    ".eslintrc.js",
+    ".eslintrc.yml",
+    "pyproject.toml",
+    "ruff.toml",
+    "Cargo.toml",
+    ".pylintrc",
+    ".rubocop.yml",
+    ".stylelintrc.json",
+    ".stylelintrc.js",
+    ".stylelintrc.yml",
+  ];
+  for (const cfg of linterConfigs) {
+    if (existsSync(resolve(basePath, cfg))) inputs.push(cfg);
+  }
+
+  // 3. Package manifest
+  inputs.push("package.json");
+
+  // 4. Referenced files from keyFiles
+  for (const filePath of Object.keys(spec.keyFiles ?? {})) {
+    inputs.push(filePath);
+  }
+
+  // 5. Generated types
+  if (existsSync(resolve(basePath, ".vigiles/generated.d.ts"))) {
+    inputs.push(".vigiles/generated.d.ts");
+  }
+
+  return inputs.sort();
+}
+```
+
+### Hash computation
+
+```typescript
+function computeInputHash(inputs: string[], basePath: string): string {
+  const fileHashes = inputs.map((f) => {
+    const fullPath = resolve(basePath, f);
+    if (!existsSync(fullPath)) return `MISSING:${f}`;
+    const content = readFileSync(fullPath, "utf-8");
+    return createHash("sha256").update(content).digest("hex");
+  });
+  return createHash("sha256")
+    .update(fileHashes.join("\n"))
+    .digest("hex")
+    .slice(0, 16);
+}
+```
+
+Missing files hash to `MISSING:<path>` so that file deletion changes the input hash (correctly signaling staleness).
+
+### Storage format
+
+Two options:
+
+**Option A: Second HTML comment** (minimal change)
+
+```html
+<!-- vigiles:sha256:a1b2c3d4e5f6g7h8 compiled from CLAUDE.md.spec.ts -->
+<!-- vigiles:inputs:f9e8d7c6b5a4 -->
+```
+
+Pro: backward-compatible (old vigiles ignores the new comment). Con: two comments at the top.
+
+**Option B: Extend existing comment**
+
+```html
+<!-- vigiles:sha256:a1b2c3d4e5f6g7h8 inputs:f9e8d7c6b5a4 compiled from CLAUDE.md.spec.ts -->
+```
+
+Pro: single comment. Con: breaks existing regex; requires migration.
+
+**Recommendation:** Option A. Backward-compatible, no migration needed.
+
+### Git-based enhancement (optional)
+
+In addition to content hashing, record the git tree hash of tracked input files at compile time:
+
+```html
+<!-- vigiles:git:abc1234 -->
+```
+
+On audit, compare:
+
+```bash
+git diff --name-only abc1234 -- eslint.config.mjs package.json src/compile.ts ...
+```
+
+If any listed file changed in git since that commit, flag as stale.
+
+Pros:
+
+- Catches committed changes (CI scenario)
+- Can show exactly which files changed
+- Very fast (git does the diffing)
+
+Cons:
+
+- Doesn't catch uncommitted changes
+- Requires git repo
+- Commit hash may not exist on shallow clones
+
+**Recommendation:** Content hash is the primary mechanism. Git hash is an optional fast-path optimization for CI.
+
+## Edge Cases
+
+### File deleted after compile
+
+`MISSING:src/utils.ts` in the input hash computation ensures the hash changes when a referenced file is deleted. Audit correctly flags staleness.
+
+### Linter config changes but rules stay the same
+
+Example: reformatting `eslint.config.mjs` (whitespace change, no semantic change). The input hash changes, audit says "recompile needed", but `vigiles compile` produces identical output. This is a false positive.
+
+**Mitigation:** Could hash the "effective config" (linter rule set) instead of the raw config file. But this requires running `calculateConfigForFile` on every audit, which is slow. The false positive is cheap (just re-run compile), so raw file hashing is acceptable.
+
+### Monorepo with shared configs
+
+A root `.eslintrc.json` is inherited by all packages. Changing the root config should invalidate all specs that use ESLint. The input discovery already handles this — it checks for config files at `basePath`, which is the spec's directory.
+
+**Gap:** If the root config is at `../../.eslintrc.json` via ESLint's config cascade, we won't discover it. Fix: resolve the actual ESLint config file location using ESLint's API, not just checking known filenames.
+
+### Large `package.json`
+
+In monorepos, `package.json` can be large. Hashing the full file means any dependency change (even unrelated) triggers a stale signal.
+
+**Mitigation:** Hash only the `scripts` and `devDependencies` sections (the parts vigiles cares about). This is a minor optimization; the false positive cost is low.
+
+## Implementation Plan
+
+### Phase 1: Input manifest (minimal)
+
+1. `compile.ts` — compute input hash after compilation, embed as second HTML comment
+2. `cli.ts` (`audit`) — extract and verify input hash
+3. Error message: `"Inputs changed since last compile (eslint.config.mjs, package.json) — run vigiles compile"`
+4. Show which files changed (diff input list against current state)
+
+### Phase 2: Granular reporting
+
+1. Store the individual file paths + hashes in a sidecar file (`.vigiles/CLAUDE.md.inputs.json`)
+2. On audit, report exactly which inputs changed
+3. Optionally show the delta: "eslint.config.mjs: rule `no-console` was disabled"
+
+### Phase 3: Git integration (optional)
+
+1. Record git commit hash at compile time
+2. On audit, use `git diff` for fast change detection before falling back to content hashing
+3. Support shallow clones by falling back to content hash when commit is missing
+
+## TOC Manifests: Recursive Directory Fingerprinting
+
+A complementary approach: require a `TOC.md` (or `INDEX.md`) in each documented directory that lists all files with descriptions. This turns "directory contents" into a tracked, verifiable artifact.
+
+### How it works
+
+```markdown
+<!-- docs/TOC.md -->
+
+# docs
+
+- `linter-support.md` — Linter cross-referencing engine (6 linters + generate-types)
+- `spec-format.md` — Spec format reference (target, sections, rules)
+- `agent-workflows.md` — Agent workflows (Claude Code, Codex, multi-agent, Cursor)
+- `agent-setup.md` — Non-interactive agent setup guide
+- `inline-mode.md` — Inline mode for gradual adoption
+- `eslint.md` — ESLint reference (shared by strengthen + pr-to-lint-rule)
+```
+
+### Recursive nesting
+
+If a subdirectory has its own `TOC.md`, the parent TOC references the directory, not its individual files:
+
+```markdown
+<!-- skills/TOC.md -->
+
+# skills
+
+- `strengthen/` — Upgrade guidance() → enforce() using linter reference docs
+- `pr-to-lint-rule/` — Convert PR review comments into automated lint rules
+- `edit-spec/` — Edit a spec file with guided workflow
+- `linter-docs/` — Per-linter reference docs (ESLint, RuboCop, Pylint)
+  - See `linter-docs/TOC.md` for contents
+```
+
+### What this enables
+
+1. **Staleness detection** — `vigiles audit` can diff the TOC against `fs.readdirSync`. File added without TOC entry? File deleted but still in TOC? Both are errors.
+2. **Agent discoverability** — Agents reading CLAUDE.md can follow TOC.md to find relevant docs without scanning the filesystem. It's a curated index, not `ls`.
+3. **Compilation** — vigiles can compile TOC.md from a TOC.md.spec.ts, getting the same hash-based freshness guarantees as CLAUDE.md.
+4. **Nested verification** — audit walks the TOC tree recursively. Each level is self-contained.
+
+### Prior art
+
+| Tool                      | Mechanism             | Notes                                                                                                                                             |
+| ------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Rust `mod.rs` / `lib.rs`  | Module declarations   | Every `.rs` file must be declared in its parent module. Undeclared files are dead code. Same principle — directory manifest enforced by compiler. |
+| Python `__init__.py`      | Package marker        | Historically required for Python packages. Declares what's importable. Not a full manifest but marks directory as "this is intentional."          |
+| Cargo `[lib]` / `[[bin]]` | Explicit targets      | Cargo.toml must list all crate entry points. Adding a file without updating Cargo.toml = nothing happens.                                         |
+| Go module / package       | Implicit (convention) | Go uses directory = package, file = source. No manifest — but the convention IS the manifest.                                                     |
+| mdBook `SUMMARY.md`       | Book structure        | mdBook requires `SUMMARY.md` listing all chapters in order. Unlisted files are excluded from the build. Closest prior art to TOC.md.              |
+| Docusaurus `sidebars.js`  | Sidebar structure     | Lists all docs in navigation order. `autogenerated` mode scans filesystem but explicit mode is a manifest.                                        |
+| Sphinx `toctree`          | Document tree         | RST directive listing sub-documents. Missing entries = build warning. Closest to nested TOC approach.                                             |
+| CODEOWNERS                | File ownership        | GitHub's `CODEOWNERS` lists file patterns → owners. Not a manifest but a structured file-level declaration.                                       |
+
+**mdBook's `SUMMARY.md` is the closest match.** It's a markdown file that lists all chapters. Unlisted files are excluded. It's the source of truth for book structure.
+
+### Integration with input fingerprinting
+
+The TOC becomes an input to the fingerprint:
+
+```
+inputs = sort([
+  sha256(readFile("CLAUDE.md.spec.ts")),
+  sha256(readFile("docs/TOC.md")),           # NEW: directory manifest
+  sha256(readFile("skills/TOC.md")),          # NEW: nested manifest
+  sha256(readFile("eslint.config.mjs")),
+  ...
+])
+```
+
+If someone adds a file to `docs/` without updating `docs/TOC.md`:
+
+1. The TOC doesn't change → input hash unchanged → no recompile triggered
+2. But `vigiles audit` independently checks TOC completeness → flags the unlisted file
+3. Two independent signals: "TOC is incomplete" + "inputs haven't changed since last compile"
+
+### vigiles-specific design
+
+For vigiles, the TOC.md could be:
+
+1. **Hand-written** — just a markdown file that humans/agents maintain. Audit verifies it matches the directory.
+2. **Compiled from a spec** — `docs/TOC.md.spec.ts` that uses `file()` references. Then the compiler verifies every listed file exists, and audit verifies no unlisted files snuck in.
+3. **Auto-generated** — `vigiles generate-toc docs/` scans the directory and emits a TOC. Then it's a build artifact like CLAUDE.md, with the same hash-based freshness.
+
+Option 3 (auto-generated) is cleanest: the filesystem is the source of truth, the TOC is a build artifact, and audit verifies freshness. No manual maintenance.
+
+But option 2 (compiled from spec) is more valuable: descriptions can't be auto-generated (they require understanding), so the spec is the right place for human-written descriptions. The compiler just verifies nothing was missed.
+
+## Open Questions
+
+1. **Should `vigiles compile` auto-verify inputs before compiling?** (i.e., if inputs haven't changed, skip compilation entirely — Bazel-style memoization)
+2. **Should the input manifest include the vigiles version?** (A vigiles upgrade might change compilation output even with identical inputs)
+3. **Should `vigiles audit --fix` automatically recompile when inputs are stale?** (Convenient but hides drift)
+4. **How to handle inline mode?** Inline rules have no spec file — the "spec source" input doesn't exist. Input hash would cover just the markdown file + linter configs.
+5. **Should TOC.md be a new compilation target?** (`vigiles init --target=TOC.md` scaffolds a TOC spec for a directory.) Or should it be a separate `vigiles toc` command?
+6. **Recursive TOC depth:** Should nested TOCs be mandatory, or should a root TOC be allowed to list all files flat? Mandatory nesting scales better but adds friction for small projects.

--- a/research/doc-freshness.md
+++ b/research/doc-freshness.md
@@ -281,20 +281,64 @@ In monorepos, `package.json` can be large. Hashing the full file means any depen
 
 ## Implementation Plan
 
-### Phase 1: Input manifest (minimal)
+### The simpler alternative: `compile --check`
+
+Before building input fingerprinting, consider: if compilation is cheap (2-5 seconds), the simplest freshness check is to just recompile in memory and diff:
+
+```bash
+vigiles compile --check   # recompile in memory, compare to existing output
+```
+
+No manifest, no input tracking, no false positives from whitespace reformatting. If the output would differ, it's stale. If identical, it's fresh. This is exactly what `generate-types --check` already does.
+
+Input fingerprinting only wins when compilation is expensive enough that you want to **avoid** running it. For vigiles today, it isn't.
+
+### Recommended: configurable freshness rule
+
+Make freshness checking a configurable rule in `vigiles.json` (or `package.json` under `"vigiles"`), defaulting to strict:
+
+```json
+{
+  "rules": {
+    "freshness": "strict"
+  }
+}
+```
+
+| Mode                 | What `vigiles audit` does                                                                  | Cost                     | False positives                                    |
+| -------------------- | ------------------------------------------------------------------------------------------ | ------------------------ | -------------------------------------------------- |
+| `"strict"` (default) | Recompiles in memory, diffs output. Fails if compiled markdown would change.               | 2-5s (runs full compile) | Zero — it checks the actual output                 |
+| `"input-hash"`       | Checks input fingerprint only. Fails if any tracked input file changed since last compile. | <100ms (hash comparison) | Possible — whitespace changes in config trigger it |
+| `"output-hash"`      | Current behavior. Only checks if the `.md` was hand-edited.                                | <1ms (single hash)       | Zero — but misses input drift entirely             |
+| `false`              | Skip freshness checks.                                                                     | 0                        | N/A                                                |
+
+**Strict mode is correct by default.** It's the only mode with zero false positives AND zero false negatives. The cost is re-running compilation, which takes the same time as `vigiles compile`.
+
+**Input-hash mode is the fast-path optimization.** Projects where compilation is slow (many specs, large linter configs, slow ESLint plugin loading) can opt into input fingerprinting to skip the full recompile. They accept occasional false positives (config reformatting, irrelevant package.json changes) in exchange for faster CI.
+
+**Output-hash mode is the minimal fallback.** For projects that just want "don't hand-edit the markdown" enforcement.
+
+### Phase 1: `compile --check` (strict mode)
+
+1. `compile.ts` — add `--check` / `dryRun` flag that compiles in memory, compares to existing file
+2. `cli.ts` (`audit`) — when `freshness: "strict"` (default), run compile in check mode
+3. Error message: `"CLAUDE.md is stale — run vigiles compile"`
+4. Fast path: skip if output hash hasn't changed (same as today, but then also run full check)
+
+### Phase 2: Input fingerprinting (opt-in)
 
 1. `compile.ts` — compute input hash after compilation, embed as second HTML comment
-2. `cli.ts` (`audit`) — extract and verify input hash
+2. `cli.ts` (`audit`) — when `freshness: "input-hash"`, extract and verify input hash
 3. Error message: `"Inputs changed since last compile (eslint.config.mjs, package.json) — run vigiles compile"`
 4. Show which files changed (diff input list against current state)
 
-### Phase 2: Granular reporting
+### Phase 3: Granular reporting
 
 1. Store the individual file paths + hashes in a sidecar file (`.vigiles/CLAUDE.md.inputs.json`)
 2. On audit, report exactly which inputs changed
 3. Optionally show the delta: "eslint.config.mjs: rule `no-console` was disabled"
 
-### Phase 3: Git integration (optional)
+### Phase 4: Git integration (optional)
 
 1. Record git commit hash at compile time
 2. On audit, use `git diff` for fast change detection before falling back to content hashing

--- a/skills/linter-docs/clippy.md
+++ b/skills/linter-docs/clippy.md
@@ -1,0 +1,241 @@
+# Clippy — Reference
+
+Shared linter reference for vigiles skills. Used by `strengthen` (find existing rules) and `pr-to-lint-rule` (write custom lints).
+
+## Check Existing Lints First
+
+Before writing a custom lint, search these lint groups — the pattern may already be covered:
+
+| Lint group    | Scope                                               | Key lints to know                                                                                                                                            |
+| ------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `correctness` | Code that is outright wrong or will panic           | `uninit_assumed_init`, `wrong_self_convention`, `nonsensical_open_options`, `mistyped_literal_suffixes`, `transmuting_null`, `undropped_manually_drops`      |
+| `suspicious`  | Code that is very likely a bug                      | `suspicious_else_formatting`, `suspicious_unary_op_formatting`, `suspicious_op_assign_impl`, `blanket_clippy_restriction_lints`, `almost_complete_range`     |
+| `style`       | Idiomatic Rust style violations                     | `needless_return`, `redundant_closure`, `match_bool`, `single_match`, `collapsible_if`, `len_zero`, `manual_map`, `if_let_mutex`                             |
+| `complexity`  | Code that can be simplified                         | `unnecessary_cast`, `needless_borrow`, `redundant_clone`, `type_complexity`, `manual_strip`, `option_map_unit_fn`, `useless_conversion`                      |
+| `perf`        | Code that can be made faster                        | `large_enum_variant`, `box_collection`, `redundant_allocation`, `manual_memcpy`, `iter_nth`, `unnecessary_to_owned`, `needless_collect`                      |
+| `pedantic`    | Stricter lints, off by default                      | `unwrap_used`, `expect_used`, `cast_possible_truncation`, `cast_sign_loss`, `missing_errors_doc`, `missing_panics_doc`, `doc_markdown`, `must_use_candidate` |
+| `restriction` | Lints for specific project policies, off by default | `print_stdout`, `print_stderr`, `dbg_macro`, `unimplemented`, `todo`, `unwrap_used`, `expect_used`, `mem_forget`, `shadow_reuse`, `float_arithmetic`         |
+| `nursery`     | Experimental lints, may have false positives        | `missing_const_for_fn`, `cognitive_complexity`, `use_self`, `option_if_let_else`, `redundant_pub_crate`, `significant_drop_tightening`                       |
+| `cargo`       | Cargo manifest issues                               | `multiple_crate_versions`, `wildcard_dependencies`, `negative_feature_names`, `redundant_feature_names`                                                      |
+
+**Tip:** Run `cargo clippy --warn clippy::pedantic` on your codebase to see what pedantic catches before manually hunting for rules. The full lint list is at <https://rust-lang.github.io/rust-clippy/stable/>.
+
+## Lint Configuration
+
+### Cargo.toml `[lints.clippy]` section (recommended)
+
+The modern way to configure Clippy project-wide. Checked into version control, applies to every `cargo clippy` invocation:
+
+```toml
+# Cargo.toml
+[lints.clippy]
+# Enable entire groups
+pedantic = "warn"
+nursery = "warn"
+
+# Override individual lints
+unwrap_used = "deny"
+expect_used = "warn"
+cast_possible_truncation = "allow"
+
+# Restriction lints — opt-in individually
+print_stdout = "warn"
+dbg_macro = "deny"
+```
+
+This replaces the older `#![warn(clippy::pedantic)]` crate-level attribute approach. vigiles reads `Cargo.toml` for `enforce()` verification.
+
+### Inline attributes
+
+Use `#[allow]`, `#[warn]`, and `#[deny]` for per-item overrides:
+
+```rust
+// Suppress a lint on a single function
+#[allow(clippy::too_many_arguments)]
+fn create_widget(a: u32, b: u32, c: u32, d: u32, e: u32, f: u32, g: u32) { /* ... */ }
+
+// Escalate a lint to a hard error for a module
+#[deny(clippy::unwrap_used)]
+mod payment_processing {
+    // Any .unwrap() in this module fails compilation
+}
+
+// Warn on a lint for a specific impl block
+#[warn(clippy::cast_possible_truncation)]
+impl Converter {
+    fn to_u32(&self, val: u64) -> u32 { val as u32 }
+}
+```
+
+Attribute precedence (highest to lowest): `#[forbid]` > `#[deny]` > `#[warn]` > `#[allow]`. `#[forbid]` cannot be overridden by inner attributes — use it for security-critical lints.
+
+### `clippy.toml` / `.clippy.toml`
+
+Project-level configuration for lint thresholds and behavior:
+
+```toml
+# clippy.toml
+too-many-arguments-threshold = 10
+type-complexity-threshold = 500
+cognitive-complexity-threshold = 30
+single-char-binding-names-threshold = 4
+msrv = "1.70.0"
+
+# Disallow certain types
+disallowed-types = [
+    { path = "std::collections::HashMap", reason = "Use indexmap::IndexMap for deterministic iteration" },
+]
+
+# Disallow certain methods
+disallowed-methods = [
+    { path = "std::env::var", reason = "Use config::get() for environment access" },
+]
+
+# Disallow certain macros
+disallowed-macros = [
+    { path = "std::println", reason = "Use tracing::info! instead" },
+]
+```
+
+`disallowed-types`, `disallowed-methods`, and `disallowed-macros` are particularly powerful — they let you ban specific APIs project-wide with custom error messages, no custom lint needed.
+
+## Custom Lints
+
+### dylint — custom Clippy-style lints
+
+[dylint](https://github.com/trailofbits/dylint) loads lint libraries as dynamic libraries, giving you the same compiler internals that Clippy uses:
+
+```rust
+// my_lint/src/lib.rs
+use clippy_utils::diagnostics::span_lint_and_help;
+use rustc_lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc_session::{declare_lint, declare_lint_pass};
+
+declare_lint! {
+    /// Disallow direct database calls outside the `db` module.
+    pub NO_DIRECT_DB_CALL,
+    Warn,
+    "direct database calls should go through the db module"
+}
+
+declare_lint_pass!(NoDirectDbCall => [NO_DIRECT_DB_CALL]);
+
+impl<'tcx> LateLintPass<'tcx> for NoDirectDbCall {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx rustc_hir::Expr<'_>) {
+        if is_direct_db_call(cx, expr) {
+            span_lint_and_help(
+                cx,
+                NO_DIRECT_DB_CALL,
+                expr.span,
+                "direct database calls are not allowed here",
+                None,
+                "use the repository pattern — import from `crate::db` instead",
+            );
+        }
+    }
+}
+```
+
+**When to use dylint vs existing Clippy lints:**
+
+| Situation                                 | Use                                         |
+| ----------------------------------------- | ------------------------------------------- |
+| Ban a specific function/type/macro        | `clippy.toml` `disallowed-*` — zero code    |
+| Enforce naming or style convention        | Existing Clippy pedantic/style lints        |
+| Detect a pattern needing type information | dylint — access to rustc type checker       |
+| Enforce architectural boundaries          | dylint or `cargo-deny` for dependency rules |
+| One-off "don't use X" in a single crate   | `#[deny(clippy::...)]` attribute            |
+
+**dylint tradeoffs:**
+
+- Tied to a specific Rust nightly version (compiler internals are unstable)
+- Requires maintaining a separate crate with `rustc_private` dependencies
+- `clippy_utils` provides helper functions but its API changes between releases
+- Build times increase since the lint library compiles against `rustc` internals
+
+For vigiles, reference dylint lints via: `enforce("clippy/no_direct_db_call", "Use the repository pattern.")` — the lint name maps to the `declare_lint!` identifier (snake_case).
+
+## Edge Cases and Gotchas
+
+### False positives from macros
+
+Clippy lints operate on the expanded AST. Macros can trigger false positives because the expanded code looks different from what the author wrote:
+
+```rust
+// This macro expansion may trigger `clippy::redundant_clone`
+// even though the clone is structurally necessary in the macro output
+my_derive_macro! {
+    struct Foo { bar: String }
+}
+```
+
+Workarounds:
+
+- `#[allow(clippy::...)]` on the macro invocation site
+- Add `#[automatically_derived]` in proc-macro output — Clippy skips many lints for derived code
+- File an issue upstream if the false positive is in a common macro pattern
+
+### Nightly-only lints
+
+Some Clippy lints require nightly Rust because they depend on unstable compiler features. The `nursery` group is the most common source. If you enable `nursery` lints in CI:
+
+- Pin a specific nightly version: `rust-toolchain.toml` with `channel = "nightly-2025-01-15"`
+- Expect breakage on nightly updates — nursery lints can be renamed, removed, or change behavior
+- Never `#[deny]` nursery lints — use `#[warn]` so they don't block builds when behavior changes
+
+### `allow` vs `warn` on groups
+
+Enabling a group and then allowing individual lints works top-down:
+
+```toml
+# Cargo.toml
+[lints.clippy]
+pedantic = "warn"           # Enable all pedantic lints
+module_name_repetitions = "allow"   # But suppress this one
+```
+
+The reverse does NOT work — you cannot `allow` a group and then `warn` an individual lint from it. The group-level `allow` takes precedence. Always enable groups first, then suppress specific lints.
+
+### Interaction with `#[must_use]`
+
+Clippy's `must_use_candidate` lint (pedantic) suggests adding `#[must_use]` to functions that return values. This interacts with other lints:
+
+- Once `#[must_use]` is added, callers who ignore the return value get `unused_must_use` (a rustc warning, not Clippy)
+- `let _ = foo()` silences `unused_must_use` but triggers `let_underscore_must_use` (Clippy restriction)
+- `drop(foo())` silences both but may trigger `drop_non_drop` if the type doesn't implement `Drop`
+
+Recommendation: Enable `must_use_candidate` globally, but only `#[deny(unused_must_use)]` in modules where ignoring results is dangerous (I/O, error handling).
+
+### Unsafe code linting
+
+Clippy provides several lints for `unsafe` code, but they have limitations:
+
+- `undocumented_unsafe_blocks` (restriction) — requires a `// SAFETY:` comment above every `unsafe` block. Enable this project-wide.
+- `unsafe_derive_deserialize` (pedantic) — warns when `Deserialize` is derived on types with unsafe invariants
+- `multiple_unsafe_ops_per_block` (restriction) — each `unsafe` block should contain exactly one unsafe operation for precise `// SAFETY:` documentation
+
+These lints do NOT verify that safety invariants are actually upheld — they only enforce documentation conventions. Use `cargo miri test` and `#[cfg(miri)]` for runtime verification of unsafe code.
+
+### MSRV-aware lints
+
+Clippy respects the `msrv` field in `clippy.toml`. Some lints suggest replacements that require newer Rust versions. If you set `msrv = "1.65.0"`, Clippy won't suggest `let-else` (stabilized in 1.65) but will suppress suggestions for features from 1.66+. Always set this to match your `rust-version` in `Cargo.toml`.
+
+## Mapping PR Feedback to Lint Strategy
+
+| PR comment pattern                          | Best approach                                                                                                     |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| "Don't use `.unwrap()`"                     | `enforce("clippy/unwrap_used", "Use expect() with context or propagate with ?.")` — pedantic, enable project-wide |
+| "Don't call this function"                  | `clippy.toml` `disallowed-methods` — zero custom code, includes custom error message                              |
+| "Don't use this type"                       | `clippy.toml` `disallowed-types` — same approach, works for `HashMap`, `Mutex`, etc.                              |
+| "Don't use `println!`"                      | `enforce("clippy/print_stdout", "Use tracing macros.")` — restriction lint, opt-in                                |
+| "Add error context"                         | Not Clippy — use `#[deny(clippy::unwrap_used)]` + guidance for `anyhow`/`thiserror` patterns                      |
+| "This clone is unnecessary"                 | `enforce("clippy/redundant_clone", "Remove the unnecessary clone.")` — already in complexity group                |
+| "Use `Self` in impl blocks"                 | `enforce("clippy/use_self", "Use Self instead of repeating the type name.")` — nursery lint                       |
+| "Document safety invariants"                | `enforce("clippy/undocumented_unsafe_blocks", "Add a // SAFETY: comment.")` — restriction lint                    |
+| "Too many function parameters"              | `enforce("clippy/too_many_arguments", "Refactor into a config struct.")` — already in complexity group            |
+| "Wildcard deps in Cargo.toml"               | `enforce("clippy/wildcard_dependencies", "Pin dependency versions.")` — cargo group                               |
+| "Every public fn needs error docs"          | `enforce("clippy/missing_errors_doc", "Document the errors this function can return.")` — pedantic                |
+| "Avoid `as` casts"                          | `enforce("clippy/cast_possible_truncation", "Use try_from() or explicit checked conversion.")` — pedantic         |
+| "Don't leave `todo!()` in code"             | `enforce("clippy/todo", "Replace todo!() with an implementation or file an issue.")` — restriction lint           |
+| "Use the builder pattern"                   | Not Clippy — use vigiles `guidance()` for architectural patterns                                                  |
+| "Enforce import boundaries between modules" | Not Clippy — use `cargo-deny` for crate-level boundaries or dylint for module-level enforcement                   |

--- a/skills/linter-docs/eslint.md
+++ b/skills/linter-docs/eslint.md
@@ -1,6 +1,6 @@
-# ESLint — Custom Rules Deep Dive
+# ESLint — Reference
 
-Sub-doc for the `pr-to-lint-rule` skill. Read this before generating an ESLint custom rule.
+Shared linter reference for vigiles skills. Used by `strengthen` (find existing rules) and `pr-to-lint-rule` (write custom rules).
 
 ## Check Existing Plugins First
 

--- a/skills/linter-docs/pylint.md
+++ b/skills/linter-docs/pylint.md
@@ -1,0 +1,288 @@
+# Pylint — Reference
+
+Shared linter reference for vigiles skills. Used by `strengthen` (find existing rules) and `pr-to-lint-rule` (write custom checkers).
+
+## Check Existing Plugins First
+
+Before writing a custom checker, search these plugins — the pattern may already be covered:
+
+| Plugin                          | Scope                                       | Key messages to know                                                                                                                                |
+| ------------------------------- | ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pylint` (core)                 | Convention, Refactor, Warning, Error, Fatal | `C0114` (missing-module-docstring), `R0902` (too-many-instance-attributes), `W0612` (unused-variable), `E1101` (no-member), `W0611` (unused-import) |
+| `pylint-django`                 | Django conventions                          | `E5110` (no-member on Django models), `W5101` (fixme in templates), `C5105` (string-used-as-django-setting)                                         |
+| `pylint-celery`                 | Celery task patterns                        | Detects common Celery anti-patterns (task retry without max_retries, etc.)                                                                          |
+| `pylint-pydantic`               | Pydantic model checking                     | Suppresses false positives from Pydantic's metaclass magic                                                                                          |
+| `pylint-pytest`                 | pytest conventions                          | `W6301` (useless-pytest-mark-decorator), `W6302` (unnecessary-pytest-mark-parametrize)                                                              |
+| `pylint-flask`                  | Flask patterns                              | Suppresses false positives for Flask's app context, request globals                                                                                 |
+| `pylint-sqlalchemy`             | SQLAlchemy ORM                              | Suppresses false `no-member` on SQLAlchemy models                                                                                                   |
+| `pylint-protobuf`               | Protobuf message checking                   | Type-checks protobuf field access, catches typos in field names                                                                                     |
+| `pylint-import-modules`         | Import style enforcement                    | `C6201` (import-modules-only) — enforce `import module` over `from module import name`                                                              |
+| `pylint-secure-coding-standard` | Security patterns                           | Detects insecure patterns: `eval`, `exec`, hardcoded passwords, insecure hash algorithms                                                            |
+
+**Tip:** Many patterns can be handled by Pylint's built-in `bad-names`, `good-names`, `bad-functions`, or the `--disable`/`--enable` system without a custom checker.
+
+**Also consider Ruff.** If the project uses Ruff, it reimplements many Pylint rules (prefixed `PL`) at much higher speed. Check Ruff's rule catalog before writing a Pylint-specific checker.
+
+## Checker Anatomy
+
+Every Pylint checker inherits from `BaseChecker`:
+
+```python
+"""Checker for direct database queries outside the repository layer."""
+
+from astroid import nodes
+from pylint.checkers import BaseChecker
+from pylint.interfaces import HIGH
+
+
+class NoDirectDbQueryChecker(BaseChecker):
+    name = "no-direct-db-query"
+
+    msgs = {
+        "C9001": (
+            "Use %sRepository instead of %s.%s",
+            "no-direct-db-query",
+            "Direct model queries should go through the repository layer.",
+        ),
+    }
+
+    # Optional: add configuration options
+    options = (
+        (
+            "allowed-models",
+            {
+                "default": (),
+                "type": "csv",
+                "metavar": "<models>",
+                "help": "Models that are allowed to be queried directly.",
+            },
+        ),
+    )
+
+    def visit_call(self, node: nodes.Call) -> None:
+        if not isinstance(node.func, nodes.Attribute):
+            return
+        if not isinstance(node.func.expr, nodes.Name):
+            return
+
+        model = node.func.expr.name
+        method = node.func.attrname
+
+        if method in ("objects", "filter", "get", "all", "count", "values"):
+            if model not in self.linter.config.allowed_models:
+                self.add_message(
+                    "no-direct-db-query",
+                    node=node,
+                    args=(model, model, method),
+                    confidence=HIGH,
+                )
+
+
+def register(linter):
+    linter.register_checker(NoDirectDbQueryChecker(linter))
+```
+
+### Key concepts
+
+| Concept       | Purpose             | Notes                                                      |
+| ------------- | ------------------- | ---------------------------------------------------------- |
+| `name`        | Checker identifier  | Must be unique across all checkers                         |
+| `msgs`        | Message dictionary  | Key format: `{C,R,W,E,F}{4 digits}` — category + unique ID |
+| `options`     | Configuration       | Exposed via `pylintrc` or command line                     |
+| `visit_*`     | AST visitor methods | Called for each matching node type                         |
+| `leave_*`     | Post-visit methods  | Called when leaving a node (post-order)                    |
+| `add_message` | Report a violation  | Pass message ID, node, args for formatting                 |
+| `register`    | Plugin entry point  | Module-level function that registers the checker           |
+
+### Message categories
+
+| Prefix | Category   | When to use                                |
+| ------ | ---------- | ------------------------------------------ |
+| `C`    | Convention | Style/naming conventions                   |
+| `R`    | Refactor   | Code that works but should be restructured |
+| `W`    | Warning    | Probable bugs or risky patterns            |
+| `E`    | Error      | Definite bugs or broken code               |
+| `F`    | Fatal      | Pylint can't process the file              |
+
+Choose a unique 4-digit code starting from `9001` to avoid collisions with core Pylint. Check existing codes with `pylint --list-msgs`.
+
+## AST Nodes — Cheat Sheet (astroid)
+
+Pylint uses `astroid` for AST parsing, which adds type inference on top of Python's `ast` module:
+
+| You want to detect         | Node type / visitor                                 | Notes                                         |
+| -------------------------- | --------------------------------------------------- | --------------------------------------------- |
+| Function call `foo()`      | `visit_call` + check `node.func`                    | `node.func` is a `Name` or `Attribute`        |
+| Method call `obj.method()` | `visit_call` + `isinstance(node.func, Attribute)`   | `node.func.attrname` = method name            |
+| Import `import X`          | `visit_import`                                      | `node.names` = list of `(name, alias)` tuples |
+| Import `from X import Y`   | `visit_importfrom`                                  | `node.modname` = module, `node.names` = names |
+| Class definition           | `visit_classdef`                                    | `node.name`, `node.bases`, `node.body`        |
+| Function definition        | `visit_functiondef`                                 | `node.name`, `node.args`, `node.body`         |
+| Assignment `x = ...`       | `visit_assign`                                      | `node.targets`, `node.value`                  |
+| String literal             | `visit_const` + check `isinstance(node.value, str)` |                                               |
+| Decorator `@foo`           | `visit_decorators`                                  | Or check `node.decorators` on function/class  |
+| `raise` statement          | `visit_raise`                                       | `node.exc` = exception expression             |
+| `with` statement           | `visit_with`                                        | `node.items` = context manager list           |
+| `try`/`except`             | `visit_tryexcept`                                   | `node.handlers` = list of except clauses      |
+
+### astroid type inference
+
+astroid can infer types, which is more powerful than plain AST:
+
+```python
+def visit_call(self, node: nodes.Call) -> None:
+    # Infer what the function resolves to
+    try:
+        for inferred in node.func.infer():
+            if isinstance(inferred, nodes.FunctionDef):
+                # We know the actual function being called
+                if inferred.name == "dangerous_function":
+                    self.add_message("no-dangerous-call", node=node)
+    except astroid.InferenceError:
+        pass  # Can't determine — skip
+```
+
+**Caution:** `infer()` can raise `InferenceError` and can return `Uninferable`. Always handle both.
+
+## Testing Checkers
+
+```python
+"""Tests for no_direct_db_query checker."""
+
+import astroid
+import pylint.testutils
+
+from my_checkers.no_direct_db_query import NoDirectDbQueryChecker
+
+
+class TestNoDirectDbQueryChecker(pylint.testutils.UnittestLinter):
+    CHECKER_CLASS = NoDirectDbQueryChecker
+
+    def test_direct_query_flagged(self):
+        node = astroid.extract_node("""
+            User.objects.filter(active=True)  #@
+        """)
+        with self.assertAddsMessages(
+            pylint.testutils.MessageTest(
+                msg_id="no-direct-db-query",
+                node=node,
+                args=("User", "User", "objects"),
+            ),
+        ):
+            self.checker.visit_call(node)
+
+    def test_repository_call_allowed(self):
+        node = astroid.extract_node("""
+            UserRepository.active_users()  #@
+        """)
+        with self.assertNoMessages():
+            self.checker.visit_call(node)
+```
+
+**Testing best practices:**
+
+1. **Use `astroid.extract_node` with `#@` marker.** The marker indicates which node to extract from the code.
+2. **Test with `assertAddsMessages` and `assertNoMessages`.** These are the canonical assertion methods.
+3. **Test configuration options.** If your checker has options, test each combination.
+4. **Test inference edge cases.** Code with dynamic attributes, metaclasses, or `__getattr__` may cause `InferenceError`.
+5. **Run with `pytest` not `unittest`.** Pylint's test utils work with both, but pytest gives better output.
+
+## Registration
+
+### As a Pylint plugin
+
+Add to `pyproject.toml`:
+
+```toml
+[tool.pylint.main]
+load-plugins = ["my_checkers.no_direct_db_query"]
+```
+
+Or `.pylintrc`:
+
+```ini
+[MAIN]
+load-plugins=my_checkers.no_direct_db_query
+```
+
+The module must be importable from `PYTHONPATH`. For a local checker, put it in the project and ensure the path is set.
+
+### vigiles enforce() reference
+
+```typescript
+enforce(
+  "pylint/no-direct-db-query",
+  "Use repository pattern for all DB queries.",
+);
+```
+
+vigiles checks `pylint --help-msg=no-direct-db-query` and verifies the message exists and is enabled.
+
+## Edge Cases and Gotchas
+
+### Symbolic names vs message codes
+
+Pylint messages have both a code (`C0114`) and a symbolic name (`missing-module-docstring`). Both work in vigiles:
+
+```typescript
+enforce("pylint/C0114", "All modules need docstrings.");
+enforce("pylint/missing-module-docstring", "All modules need docstrings.");
+```
+
+Prefer symbolic names — they're readable and stable across Pylint versions.
+
+### astroid inference limitations
+
+astroid can't infer:
+
+- Dynamically constructed classes (`type("Foo", (Base,), {...})`)
+- Heavy metaprogramming (`__init_subclass__`, custom metaclasses)
+- C extensions (some methods on `numpy`, `pandas` are opaque)
+- Runtime-only attributes (`setattr`, `__dict__` manipulation)
+
+If your convention targets heavily dynamic code, expect false negatives. Add a comment explaining the limitation in the checker.
+
+### Plugin vs Ruff
+
+For simple pattern bans, Ruff's built-in rules or `flake8-*` plugins reimplemented in Ruff are 10-100x faster. Use a Pylint custom checker only when you need:
+
+- Type inference (astroid's `infer()`)
+- Cross-function or cross-module analysis
+- Configuration options exposed in `pylintrc`
+- Integration with Django/Flask/SQLAlchemy brain plugins
+
+### Message ID collisions
+
+Core Pylint uses codes `C0001`-`C8999`, `W0001`-`W8999`, etc. Custom checkers should use `9000+` to avoid collisions. Check with:
+
+```bash
+pylint --list-msgs | grep "C90\|W90\|E90"
+```
+
+### Performance
+
+- Pylint is slow on large codebases. Custom checkers add overhead per-file.
+- Avoid `infer()` in hot paths — each call can trigger recursive type resolution.
+- Use `visit_module` + early return to skip files that can't contain violations (e.g., skip test files for production-only rules).
+- Consider `--jobs=N` for parallel execution, but note that custom checkers must be pickle-safe for multiprocessing.
+
+### Monorepo considerations
+
+- Pylint resolves `pylintrc` / `pyproject.toml` from `cwd`, not from the file being linted. In a monorepo, run Pylint per-package.
+- vigiles checks `pylint --help-msg=<name>` from the project `basePath`. If packages have different plugins loaded, run from each package root.
+- Custom checkers must be on `PYTHONPATH`. In a monorepo, use relative `load-plugins` paths or install checkers as a development package.
+
+## Mapping PR Feedback to Checker Strategy
+
+| PR comment pattern                    | Best approach                                                                                  |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| "Don't import X directly"             | `pylint/no-name-in-module` or custom checker with `visit_importfrom`                           |
+| "Don't call X()"                      | `pylint/bad-functions` config or custom checker with `visit_call`                              |
+| "Missing docstring"                   | `pylint/missing-function-docstring` (C0116) — already exists                                   |
+| "Function too long"                   | `pylint/too-many-statements` (R0915) — configure threshold                                     |
+| "Too many arguments"                  | `pylint/too-many-arguments` (R0913) — configure `max-args`                                     |
+| "Use logging instead of print"        | Ruff `T201` or custom checker banning `print()`                                                |
+| "Don't use global state"              | Custom checker detecting `global` keyword or module-level mutation                             |
+| "Always type-hint public methods"     | `pylint/missing-function-docstring` doesn't cover this — use `mypy --strict` or custom checker |
+| "Don't catch bare Exception"          | `pylint/broad-exception-caught` (W0718) — already exists                                       |
+| "Don't use mutable default arguments" | `pylint/dangerous-default-value` (W0102) — already exists                                      |

--- a/skills/linter-docs/rubocop.md
+++ b/skills/linter-docs/rubocop.md
@@ -1,0 +1,277 @@
+# RuboCop — Reference
+
+Shared linter reference for vigiles skills. Used by `strengthen` (find existing rules) and `pr-to-lint-rule` (write custom cops).
+
+## Check Existing Gems First
+
+Before writing a custom cop, search these gems — the pattern may already be covered:
+
+| Gem                   | Scope                                  | Key cops to know                                                                                                                   |
+| --------------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `rubocop` (core)      | Style, Lint, Metrics, Naming, Security | `Style/FrozenStringLiteralComment`, `Lint/UnusedMethodArgument`, `Metrics/MethodLength`, `Naming/MethodName`, `Security/Eval`      |
+| `rubocop-rails`       | Rails conventions                      | `Rails/HttpPositionalArguments`, `Rails/SkipsModelValidations`, `Rails/Output`, `Rails/HasAndBelongsToMany`, `Rails/DynamicFindBy` |
+| `rubocop-rspec`       | RSpec test patterns                    | `RSpec/ExampleLength`, `RSpec/MultipleExpectations`, `RSpec/NestedGroups`, `RSpec/LetSetup`, `RSpec/MessageSpies`                  |
+| `rubocop-minitest`    | Minitest patterns                      | `Minitest/AssertEmptyLiteral`, `Minitest/RefuteNil`, `Minitest/AssertInDelta`                                                      |
+| `rubocop-performance` | Performance anti-patterns              | `Performance/StringReplacement`, `Performance/Detect`, `Performance/Count`, `Performance/FlatMap`, `Performance/CaseWhenSplat`     |
+| `rubocop-rake`        | Rakefile patterns                      | `Rake/Desc`, `Rake/DuplicateTask`, `Rake/MethodDefinitionInTask`                                                                   |
+| `rubocop-sorbet`      | Sorbet type checking                   | `Sorbet/ForbidSuperclassConstLiteral`, `Sorbet/ValidSigil`, `Sorbet/SignatureBuildOrder`                                           |
+| `rubocop-graphql`     | GraphQL conventions                    | `GraphQL/FieldDescription`, `GraphQL/ObjectDescription`, `GraphQL/ArgumentDescription`                                             |
+| `rubocop-factory_bot` | FactoryBot patterns                    | `FactoryBot/ConsistentParenthesesStyle`, `FactoryBot/CreateList`, `FactoryBot/SyntaxMethods`                                       |
+| `rubocop-capybara`    | Capybara test patterns                 | `Capybara/CurrentPathExpectation`, `Capybara/VisibilityMatcher`, `Capybara/SpecificMatcher`                                        |
+
+**Tip:** Many patterns can be handled by configuring existing cops rather than writing new ones. Check if an existing cop has configurable `AllowedMethods`, `AllowedPatterns`, or `Include`/`Exclude` options first.
+
+## Cop Anatomy
+
+Every RuboCop cop inherits from `RuboCop::Cop::Base`:
+
+```ruby
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Custom
+      # Disallow direct database queries outside the repository layer.
+      #
+      # @example
+      #   # bad
+      #   User.where(active: true)
+      #
+      #   # good
+      #   UserRepository.active_users
+      class NoDirectDbQuery < Base
+        MSG = 'Use the repository pattern — call `%<model>sRepository` instead of `%<model>s.%<method>s`.'
+
+        RESTRICT_ON_SEND = %i[where find find_by first last all count pluck].freeze
+
+        # @!method ar_model_query?(node)
+        def_node_matcher :ar_model_query?, <<~PATTERN
+          (send (const nil? _) {:where :find :find_by :first :last :all :count :pluck} ...)
+        PATTERN
+
+        def on_send(node)
+          return unless ar_model_query?(node)
+
+          model = node.receiver.short_name
+          add_offense(node, message: format(MSG, model: model, method: node.method_name))
+        end
+      end
+    end
+  end
+end
+```
+
+### Key concepts
+
+| Concept            | Purpose                                       | Notes                                                               |
+| ------------------ | --------------------------------------------- | ------------------------------------------------------------------- |
+| `MSG`              | Error message string                          | Use `format` with `%<name>s` for interpolation                      |
+| `RESTRICT_ON_SEND` | Whitelist of method names                     | Performance optimization — cop only runs on matching `send` nodes   |
+| `def_node_matcher` | AST pattern matcher                           | DSL for matching Ruby AST patterns — replaces manual node traversal |
+| `def_node_search`  | Like `def_node_matcher` but finds all matches | Returns an enumerator of matching nodes                             |
+| `add_offense`      | Report a violation                            | Accepts `node`, optional `message:` and `severity:`                 |
+
+### Cop departments
+
+| Department | When to use                                           |
+| ---------- | ----------------------------------------------------- |
+| `Lint`     | Code that is/will be broken                           |
+| `Style`    | Code that works but violates a convention             |
+| `Metrics`  | Complexity thresholds (method length, ABC size, etc.) |
+| `Naming`   | Naming conventions                                    |
+| `Security` | Security anti-patterns                                |
+| `Custom`   | Your project-specific cops                            |
+
+## Node Pattern DSL — Cheat Sheet
+
+RuboCop's node pattern DSL is the primary way to match AST nodes:
+
+| You want to detect    | Pattern                             | Notes                                         |
+| --------------------- | ----------------------------------- | --------------------------------------------- |
+| Method call `foo`     | `(send nil? :foo ...)`              | `nil?` = no receiver                          |
+| Method call `obj.foo` | `(send _ :foo ...)`                 | `_` = any receiver                            |
+| Method call `Foo.bar` | `(send (const nil? :Foo) :bar ...)` | Constant receiver                             |
+| String literal `"x"`  | `(str "x")`                         |                                               |
+| Symbol `:x`           | `(sym :x)`                          |                                               |
+| Block `foo { }`       | `(block (send nil? :foo) ...)`      |                                               |
+| Class definition      | `(class (const nil? :Name) ...)`    |                                               |
+| `if` conditional      | `(if _ _ _)`                        | Three children: condition, if-body, else-body |
+| Instance variable     | `(ivar :@name)`                     |                                               |
+| Constant assignment   | `(casgn nil? :NAME _)`              |                                               |
+| `require "x"`         | `(send nil? :require (str "x"))`    |                                               |
+
+**Wildcards and captures:**
+
+- `_` — matches any single node
+- `...` — matches any number of nodes (rest)
+- `$_` — capture a node into a variable
+- `nil?` — matches nil (no receiver for top-level calls)
+- `{:foo :bar}` — matches either `:foo` or `:bar`
+- `(send _ {:puts :print :p} ...)` — matches puts/print/p on any receiver
+
+**Pro tip:** Run `ruby-parse -e 'your_code_here'` to see the AST for any Ruby expression. The `parser` gem must be installed.
+
+## Auto-Correct
+
+### `extend AutoCorrector` — opt-in auto-fix
+
+```ruby
+class NoDirectDbQuery < Base
+  extend AutoCorrector
+
+  def on_send(node)
+    return unless ar_model_query?(node)
+
+    add_offense(node) do |corrector|
+      model = node.receiver.short_name
+      corrector.replace(node, "#{model}Repository.#{node.method_name}")
+    end
+  end
+end
+```
+
+Available corrector methods:
+
+| Method                                | What it does                     |
+| ------------------------------------- | -------------------------------- |
+| `corrector.replace(node, text)`       | Replace node with text           |
+| `corrector.insert_before(node, text)` | Insert text before node          |
+| `corrector.insert_after(node, text)`  | Insert text after node           |
+| `corrector.remove(node)`              | Remove node                      |
+| `corrector.wrap(node, before, after)` | Wrap node with before/after text |
+
+Safety rules for auto-correct:
+
+- **Mark unsafe corrections** with `def autocorrect_enabled? = false` or use the cop's `Safe` / `SafeAutoCorrect` metadata in `.rubocop.yml`
+- **Never change runtime behavior.** If the fix might break code, don't auto-correct.
+- RuboCop runs `rubocop -a` (safe only) vs `rubocop -A` (all including unsafe). Default to safe.
+
+## Testing Cops
+
+```ruby
+# frozen_string_literal: true
+
+require "rubocop"
+require "rubocop/rspec/expect_offense"
+
+RSpec.describe RuboCop::Cop::Custom::NoDirectDbQuery, :config do
+  # Tests that valid code produces no offenses
+  it "accepts repository pattern calls" do
+    expect_no_offenses(<<~RUBY)
+      UserRepository.active_users
+    RUBY
+  end
+
+  # Tests that invalid code produces the right offense
+  it "registers offense for direct AR query" do
+    expect_offense(<<~RUBY)
+      User.where(active: true)
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Use the repository pattern — call `UserRepository` instead of `User.where`.
+    RUBY
+  end
+
+  # Tests auto-correction
+  it "auto-corrects to repository call" do
+    expect_offense(<<~RUBY)
+      User.find(1)
+      ^^^^^^^^^^^^ Use the repository pattern — call `UserRepository` instead of `User.find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      UserRepository.find(1)
+    RUBY
+  end
+end
+```
+
+**Testing best practices:**
+
+1. **Use `expect_offense` with caret markers.** The carets (`^`) must align with the exact offense location.
+2. **Test edge cases.** Dynamic receivers, safe navigation (`&.`), chained methods, blocks.
+3. **Test configuration.** If your cop respects `AllowedMethods`, test with and without the config.
+4. **Use `:config` shared context** to get a default configuration object.
+
+## Registration
+
+### In `.rubocop.yml`
+
+```yaml
+require:
+  - ./lib/rubocop/cop/custom/no_direct_db_query
+
+Custom/NoDirectDbQuery:
+  Enabled: true
+  Include:
+    - "app/**/*.rb"
+  Exclude:
+    - "app/repositories/**/*.rb"
+```
+
+### vigiles enforce() reference
+
+```typescript
+enforce(
+  "rubocop/Custom/NoDirectDbQuery",
+  "Use repository pattern for all DB queries.",
+);
+```
+
+vigiles checks `rubocop --show-cops Custom/NoDirectDbQuery` and verifies `Enabled: true`.
+
+## Edge Cases and Gotchas
+
+### Safe vs unsafe cops
+
+RuboCop distinguishes `Safe: true` (default) from `Safe: false`. Unsafe cops can produce false positives. When writing a custom cop that can't guarantee correctness (e.g., it doesn't understand metaprogramming), set:
+
+```yaml
+Custom/MyCop:
+  Safe: false
+  SafeAutoCorrect: false
+```
+
+### Metaprogramming blind spots
+
+RuboCop's AST parser doesn't understand:
+
+- `method_missing` / `respond_to_missing?`
+- `define_method` with dynamic names
+- `send` / `public_send` with variable method names
+- ActiveRecord dynamic finders (`find_by_name` generated at runtime)
+
+If your convention targets code that's often generated via metaprogramming, expect false negatives.
+
+### Node matcher vs manual traversal
+
+Use `def_node_matcher` for simple patterns. Switch to manual `node.children`, `node.each_descendant`, etc. when you need:
+
+- Cross-method analysis (e.g., "if method A exists, method B must also exist")
+- State tracking across the file (e.g., counting total occurrences)
+- Complex conditional logic that the pattern DSL can't express
+
+### Performance
+
+- Always use `RESTRICT_ON_SEND` when targeting method calls — it skips the cop entirely for non-matching methods.
+- Avoid `on_send` without `RESTRICT_ON_SEND` on large codebases — it fires for every method call.
+- `def_node_search` iterates descendants and can be slow on deeply nested ASTs. Prefer `def_node_matcher` on specific node types.
+
+### Monorepo considerations
+
+- RuboCop resolves `.rubocop.yml` from the file being linted, walking up directories. Each sub-project can have its own config.
+- vigiles checks `rubocop --show-cops <CopName>` from the project `basePath`. In a monorepo, run from each gem/app root.
+- Custom cops must be `require`-able from the config file's location. Use relative paths or bundle them in a gem.
+
+## Mapping PR Feedback to Cop Strategy
+
+| PR comment pattern                         | Best approach                                                                    |
+| ------------------------------------------ | -------------------------------------------------------------------------------- |
+| "Don't call X directly"                    | Check if an existing cop covers it; otherwise custom cop with `RESTRICT_ON_SEND` |
+| "Use our wrapper for Y"                    | Custom cop — detect raw calls, suggest wrapper                                   |
+| "Method too long"                          | `Metrics/MethodLength` — configure `Max:` threshold                              |
+| "Missing frozen_string_literal"            | `Style/FrozenStringLiteralComment` — already exists                              |
+| "Don't use `puts` in production"           | Custom cop or `Rails/Output` if using Rails                                      |
+| "Always add description to GraphQL fields" | `rubocop-graphql` `GraphQL/FieldDescription`                                     |
+| "Test files too complex"                   | `RSpec/ExampleLength`, `RSpec/NestedGroups` — configure thresholds               |
+| "Naming convention violated"               | `Naming/*` cops — highly configurable                                            |
+| "Security issue: eval"                     | `Security/Eval` — already exists                                                 |
+| "Don't skip validations"                   | `Rails/SkipsModelValidations` — already exists                                   |

--- a/skills/linter-docs/ruff.md
+++ b/skills/linter-docs/ruff.md
@@ -1,0 +1,187 @@
+# Ruff — Reference
+
+Shared linter reference for vigiles skills. Used by `strengthen` (find existing rules) and `pr-to-lint-rule` (write custom rules).
+
+## Check Existing Rules First
+
+Ruff reimplements 800+ rules from flake8, pylint, isort, pyupgrade, and others. Before writing a custom rule, check if Ruff already covers it:
+
+| Prefix    | Source                    | Key rules                                                                                                                                     |
+| --------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `E` / `W` | pycodestyle               | `E501` (line-too-long), `W291` (trailing-whitespace), `E711` (none-comparison)                                                                |
+| `F`       | pyflakes                  | `F401` (unused-import), `F841` (unused-variable), `F811` (redefined-unused-name)                                                              |
+| `I`       | isort                     | `I001` (unsorted-imports), `I002` (missing-required-import)                                                                                   |
+| `N`       | pep8-naming               | `N801` (invalid-class-name), `N802` (invalid-function-name), `N806` (non-lowercase-variable)                                                  |
+| `UP`      | pyupgrade                 | `UP006` (non-pep585-annotation), `UP007` (non-pep604-annotation), `UP035` (deprecated-import)                                                 |
+| `S`       | flake8-bandit             | `S101` (assert), `S105` (hardcoded-password-string), `S301` (suspicious-pickle-usage)                                                         |
+| `B`       | flake8-bugbear            | `B006` (mutable-argument-default), `B007` (unused-loop-control-variable), `B905` (zip-without-explicit-strict)                                |
+| `A`       | flake8-builtins           | `A001` (builtin-variable-shadowing), `A002` (builtin-argument-shadowing)                                                                      |
+| `C4`      | flake8-comprehensions     | `C400` (unnecessary-generator-list), `C401` (unnecessary-generator-set), `C408` (unnecessary-collection-call)                                 |
+| `T20`     | flake8-print              | `T201` (print), `T203` (pprint)                                                                                                               |
+| `SIM`     | flake8-simplify           | `SIM102` (collapsible-if), `SIM108` (if-else-block-instead-of-if-exp), `SIM110` (reimplemented-builtin)                                       |
+| `PL`      | pylint                    | `PLC0414` (useless-import-alias), `PLE1205` (logging-too-many-args), `PLR0913` (too-many-arguments), `PLW0602` (global-variable-not-assigned) |
+| `PTH`     | flake8-use-pathlib        | `PTH100` (os-path-abspath), `PTH118` (os-path-join), `PTH123` (builtin-open)                                                                  |
+| `RUF`     | ruff-specific             | `RUF001` (ambiguous-unicode-character), `RUF005` (collection-literal-concatenation), `RUF013` (implicit-optional)                             |
+| `D`       | pydocstyle                | `D100` (undocumented-public-module), `D103` (undocumented-public-function), `D400` (first-line-should-end-with-period)                        |
+| `ANN`     | flake8-annotations        | `ANN001` (missing-type-function-argument), `ANN201` (missing-return-type-public-function)                                                     |
+| `ARG`     | flake8-unused-arguments   | `ARG001` (unused-function-argument), `ARG002` (unused-method-argument)                                                                        |
+| `ERA`     | eradicate                 | `ERA001` (commented-out-code)                                                                                                                 |
+| `TCH`     | flake8-type-checking      | `TCH001` (typing-only-first-party-import), `TCH002` (typing-only-third-party-import)                                                          |
+| `FBT`     | flake8-boolean-trap       | `FBT001` (boolean-typed-positional-argument), `FBT002` (boolean-default-value-positional-argument)                                            |
+| `ICN`     | flake8-import-conventions | `ICN001` (unconventional-import-alias) — e.g., `import numpy as np`                                                                           |
+| `PIE`     | flake8-pie                | `PIE790` (unnecessary-placeholder), `PIE804` (no-unnecessary-dict-kwargs)                                                                     |
+| `RSE`     | flake8-raise              | `RSE102` (unnecessary-paren-on-raise-exception)                                                                                               |
+| `RET`     | flake8-return             | `RET501` (unnecessary-return-none), `RET504` (unnecessary-assign)                                                                             |
+| `TID`     | flake8-tidy-imports       | `TID252` (relative-imports) — ban relative imports                                                                                            |
+| `PERF`    | perflint                  | `PERF101` (unnecessary-list-cast), `PERF401` (manual-list-comprehension)                                                                      |
+| `FURB`    | refurb                    | `FURB105` (print-empty-string), `FURB118` (reimplemented-operator)                                                                            |
+
+**Tip:** Run `ruff rule <CODE>` to see the full description of any rule. Run `ruff linter` to see all available rule groups.
+
+## Rule Selection
+
+Configure in `pyproject.toml`:
+
+```toml
+[tool.ruff.lint]
+select = [
+  "E", "W",    # pycodestyle
+  "F",         # pyflakes
+  "I",         # isort
+  "B",         # flake8-bugbear
+  "S",         # flake8-bandit
+  "UP",        # pyupgrade
+  "SIM",       # flake8-simplify
+  "T20",       # flake8-print
+  "RUF",       # ruff-specific
+]
+ignore = [
+  "E501",      # line-too-long (handled by formatter)
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["S101"]  # allow assert in tests
+"__init__.py" = ["F401"]  # allow unused imports in __init__
+```
+
+Or in `ruff.toml` (same syntax without `[tool.ruff]` prefix):
+
+```toml
+[lint]
+select = ["E", "F", "I", "B"]
+```
+
+### Selecting individual rules vs groups
+
+- `"F"` enables all pyflakes rules
+- `"F401"` enables only `F401`
+- `"ALL"` enables everything (noisy — use `ignore` to subtract)
+- Use `extend-select` to add rules without overriding the default set
+
+## Custom Rules
+
+**Ruff does not support user-defined rules.** If no existing rule covers your pattern:
+
+1. **Configure existing rules** — many rules accept options (e.g., `flake8-import-conventions` lets you set allowed aliases)
+2. **Use `ruff.lint.flake8-import-conventions.aliases`** — for import alias enforcement
+3. **Use `ruff.lint.flake8-tidy-imports.banned-api`** — for banning specific imports/modules
+4. **Use ast-grep** — for arbitrary AST pattern matching, reference via `enforce()` with an ast-grep rule
+5. **Write a Pylint checker** — if you need the full power of a custom rule with AST analysis, use Pylint (Ruff can coexist with Pylint in CI)
+
+```toml
+# Ban specific APIs without a custom rule
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"os.system".msg = "Use subprocess.run instead."
+"typing.Dict".msg = "Use dict instead (PEP 585)."
+```
+
+## Auto-Fix
+
+Ruff provides auto-fix for many rules:
+
+```bash
+ruff check --fix              # apply safe fixes only
+ruff check --fix --unsafe-fixes  # include unsafe fixes
+ruff check --fix-only         # only fix, don't report remaining violations
+```
+
+**Safe vs unsafe fixes:**
+
+- **Safe** — guaranteed to not change semantics (e.g., removing unused imports)
+- **Unsafe** — may change semantics (e.g., `UP007` rewriting `Optional[X]` to `X | None` can break runtime type checking)
+
+Check fixability per rule with `ruff rule <CODE>` — it shows whether the rule has a fix and if it's safe.
+
+### vigiles enforce() reference
+
+```typescript
+enforce("ruff/F401", "Remove unused imports.");
+enforce("ruff/T201", "Use logging module instead of print.");
+enforce("ruff/S101", "Don't use assert in production code.");
+```
+
+vigiles checks `ruff rule <CODE>` and verifies the rule exists, then parses `ruff check --show-settings` to confirm it's enabled.
+
+## Edge Cases and Gotchas
+
+### Ruff vs Pylint (PL prefix)
+
+Ruff reimplements many Pylint rules with the `PL` prefix. The mapping is not 1:1 — some Pylint rules have no Ruff equivalent, and Ruff's implementations may differ in edge cases.
+
+| Ruff code | Pylint equivalent                      | Notes         |
+| --------- | -------------------------------------- | ------------- |
+| `PLR0913` | `R0913` (too-many-arguments)           | Same behavior |
+| `PLC0414` | `C0414` (useless-import-alias)         | Same behavior |
+| `PLW0602` | `W0602` (global-variable-not-assigned) | Same behavior |
+| `PLE1205` | `E1205` (logging-too-many-args)        | Same behavior |
+
+If the project uses both Ruff and Pylint, disable Pylint rules that Ruff already covers to avoid duplicate reports.
+
+### Preview rules
+
+Some rules are behind `--preview` flag. These are not stable and may change between versions. Don't use `enforce()` on preview rules unless you pin the Ruff version.
+
+```toml
+[tool.ruff]
+preview = true  # enables preview rules
+```
+
+### Formatter vs linter conflicts
+
+Ruff has both a linter (`ruff check`) and a formatter (`ruff format`). Some linter rules conflict with the formatter:
+
+- `E501` (line-too-long) — the formatter handles line length; disable in the linter
+- `W291`/`W292`/`W293` — whitespace rules handled by formatter
+- `COM812` (missing-trailing-comma) — conflicts with formatter in some cases
+
+The Ruff docs recommend: `ignore = ["E501", "W291", "W292", "W293"]` when using `ruff format`.
+
+### Monorepo config inheritance
+
+Ruff resolves config by walking up from the file being linted. In a monorepo:
+
+- Each package can have its own `pyproject.toml` with `[tool.ruff]`
+- A root config applies to all packages unless overridden
+- Use `extend` to inherit from a shared config: `extend = "../../pyproject.toml"`
+
+vigiles discovers Ruff config at `basePath` only. In a monorepo, run vigiles from each package root.
+
+## Mapping PR Feedback to Rule Strategy
+
+| PR comment pattern            | Best approach                                                      |
+| ----------------------------- | ------------------------------------------------------------------ |
+| "Remove unused imports"       | `ruff/F401` — already exists                                       |
+| "Don't use print()"           | `ruff/T201` — already exists                                       |
+| "Sort your imports"           | `ruff/I001` — already exists                                       |
+| "Use pathlib not os.path"     | `ruff/PTH*` — enable the PTH group                                 |
+| "Don't use assert in prod"    | `ruff/S101` — already exists, ignore in tests via per-file-ignores |
+| "Remove commented-out code"   | `ruff/ERA001` — already exists                                     |
+| "Add type annotations"        | `ruff/ANN*` — enable the ANN group                                 |
+| "Use comprehensions"          | `ruff/C4*` — enable the C4 group                                   |
+| "Don't shadow builtins"       | `ruff/A001` / `A002` — already exists                              |
+| "Simplify this if"            | `ruff/SIM102` / `SIM108` — already exists                          |
+| "Don't use mutable defaults"  | `ruff/B006` — already exists                                       |
+| "Ban specific import"         | `flake8-tidy-imports.banned-api` config — no custom rule needed    |
+| "Naming convention violated"  | `ruff/N*` — enable the N group                                     |
+| "Don't use os.system"         | `flake8-tidy-imports.banned-api` config                            |
+| "Complex pattern not in Ruff" | Write a Pylint checker or use ast-grep                             |

--- a/skills/linter-docs/stylelint.md
+++ b/skills/linter-docs/stylelint.md
@@ -1,0 +1,247 @@
+# Stylelint — Reference
+
+Shared linter reference for vigiles skills. Used by `strengthen` (find existing rules) and `pr-to-lint-rule` (write custom rules).
+
+## Check Existing Plugins First
+
+Before writing a custom rule, search these packages — the pattern may already be covered:
+
+| Plugin                                      | Scope                    | Key rules                                                                                                                                   |
+| ------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `stylelint-config-standard`                 | Standard CSS conventions | Extends `stylelint-config-recommended`, adds `declaration-block-no-redundant-longhand-properties`, `shorthand-property-no-redundant-values` |
+| `stylelint-config-recommended`              | Error prevention         | `no-descending-specificity`, `no-duplicate-selectors`, `declaration-block-no-duplicate-properties`                                          |
+| `stylelint-order`                           | Property ordering        | `order/properties-order`, `order/properties-alphabetical-order` — configurable sort orders                                                  |
+| `stylelint-scss`                            | SCSS syntax              | `scss/no-duplicate-mixins`, `scss/no-unused-private-members`, `scss/at-rule-no-unknown`, `scss/dollar-variable-pattern`                     |
+| `stylelint-config-css-modules`              | CSS Modules              | Adjusts rules for `:global`, `:local`, `composes` syntax                                                                                    |
+| `stylelint-config-tailwindcss`              | Tailwind CSS             | Allows Tailwind directives (`@tailwind`, `@apply`, `@screen`)                                                                               |
+| `stylelint-no-unsupported-browser-features` | Browser compat           | Flags CSS features not supported by your browserslist targets                                                                               |
+| `stylelint-declaration-strict-value`        | Value enforcement        | Require variables/functions for specific properties (colors, fonts, z-index)                                                                |
+| `stylelint-config-clean-order`              | Property order           | Opinionated property ordering (positioning → box model → typography → visual → misc)                                                        |
+| `stylelint-config-prettier`                 | Prettier compat          | Disables rules that conflict with Prettier (deprecated in Stylelint v15+)                                                                   |
+| `stylelint-a11y`                            | Accessibility            | `a11y/no-outline-none`, `a11y/no-text-size-adjust`, `a11y/media-prefers-reduced-motion`                                                     |
+
+**Tip:** Stylelint v15+ removed all stylistic rules (spacing, formatting). Use Prettier for formatting, Stylelint for correctness.
+
+## Rule Anatomy
+
+Every Stylelint rule is a function that receives options and returns a checker:
+
+```js
+const stylelint = require("stylelint");
+
+const ruleName = "plugin/no-important";
+const messages = stylelint.utils.ruleMessages(ruleName, {
+  rejected: "Unexpected !important — use utility classes instead.",
+});
+const meta = { url: "https://example.com/rules/no-important" };
+
+/** @type {import('stylelint').Rule} */
+const ruleFunction = (primary, secondary, context) => {
+  return (root, result) => {
+    const validOptions = stylelint.utils.validateOptions(result, ruleName, {
+      actual: primary,
+      possible: [true],
+    });
+    if (!validOptions) return;
+
+    root.walkDecls((decl) => {
+      if (decl.important) {
+        stylelint.utils.report({
+          message: messages.rejected,
+          node: decl,
+          result,
+          ruleName,
+        });
+      }
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+module.exports = stylelint.createPlugin(ruleName, ruleFunction);
+```
+
+### Key concepts
+
+| Concept                             | Purpose                                    | Notes                                                     |
+| ----------------------------------- | ------------------------------------------ | --------------------------------------------------------- |
+| `primary`                           | First option (usually `true` or a pattern) | What the user passes in config                            |
+| `secondary`                         | Second option (usually an object)          | Additional configuration                                  |
+| `context`                           | Execution context                          | Contains `fix` boolean for auto-fix mode                  |
+| `root`                              | PostCSS AST root node                      | Entry point for walking the CSS tree                      |
+| `result`                            | Results accumulator                        | Pass to `stylelint.utils.report()`                        |
+| `stylelint.utils.report()`          | Report a violation                         | Canonical way to report — handles severity, ignores, etc. |
+| `stylelint.utils.validateOptions()` | Validate rule config                       | Returns false if config is invalid                        |
+
+### PostCSS AST node types
+
+| Node type     | What it represents      | Walker method         | Example                     |
+| ------------- | ----------------------- | --------------------- | --------------------------- |
+| `Root`        | Entire stylesheet       | —                     | Top-level container         |
+| `Rule`        | Selector + declarations | `root.walkRules()`    | `.button { color: red }`    |
+| `Declaration` | Property: value pair    | `root.walkDecls()`    | `color: red`                |
+| `AtRule`      | `@` rule                | `root.walkAtRules()`  | `@media (min-width: 768px)` |
+| `Comment`     | CSS comment             | `root.walkComments()` | `/* comment */`             |
+
+Properties on `Declaration`: `decl.prop` (property name), `decl.value` (value string), `decl.important` (boolean).
+
+## Configuration
+
+### `.stylelintrc.json`
+
+```json
+{
+  "extends": ["stylelint-config-standard"],
+  "plugins": ["stylelint-order"],
+  "rules": {
+    "declaration-no-important": true,
+    "selector-max-specificity": "0,3,0",
+    "order/properties-alphabetical-order": true
+  }
+}
+```
+
+### `stylelint.config.js` (flat config)
+
+```js
+module.exports = {
+  extends: ["stylelint-config-standard"],
+  rules: {
+    "declaration-no-important": true,
+  },
+  overrides: [
+    {
+      files: ["**/*.scss"],
+      extends: ["stylelint-config-standard-scss"],
+    },
+  ],
+};
+```
+
+### Key config concepts
+
+- **`extends`** — inherit from shared configs (order matters — later overrides earlier)
+- **`plugins`** — load additional rule packages
+- **`rules`** — enable/disable/configure individual rules (`true`, `null`, or `[value, options]`)
+- **`overrides`** — per-file rule configuration (like ESLint overrides)
+
+## Testing Rules
+
+```js
+const { lint } = require("stylelint");
+
+async function testRule() {
+  const result = await lint({
+    code: "a { color: pink !important; }",
+    config: {
+      plugins: ["./plugin-no-important.js"],
+      rules: { "plugin/no-important": true },
+    },
+  });
+
+  console.log(result.results[0].warnings);
+  // [{ rule: "plugin/no-important", text: "Unexpected !important...", line: 1, column: 19 }]
+}
+```
+
+For plugin development, use `jest-preset-stylelint` or test via `lint()` directly.
+
+**Testing best practices:**
+
+1. **Test with `lint()` API** — canonical method, works with any test runner
+2. **Test valid and invalid cases** — ensure no false positives
+3. **Test with SCSS/Less** if the plugin should support preprocessor syntax
+4. **Test `overrides`** — if the rule has options, test each configuration
+
+### vigiles enforce() reference
+
+```typescript
+enforce("stylelint/declaration-no-important", "Use utility classes instead.");
+enforce(
+  "stylelint/selector-max-specificity",
+  "Keep specificity low for maintainability.",
+);
+```
+
+vigiles loads Stylelint config via `createLinter` + `getConfigForFile`, checks if the rule value is not `null`.
+
+## Edge Cases and Gotchas
+
+### CSS-in-JS
+
+Stylelint supports CSS-in-JS via custom syntaxes:
+
+```json
+{
+  "overrides": [
+    {
+      "files": ["**/*.{js,jsx,ts,tsx}"],
+      "customSyntax": "@stylelint/postcss-css-in-js"
+    }
+  ]
+}
+```
+
+Note: `@stylelint/postcss-css-in-js` is deprecated as of Stylelint v15. For styled-components / emotion, consider `postcss-styled-syntax` or lint extracted CSS instead.
+
+### SCSS / Less
+
+Use dedicated configs:
+
+- SCSS: `stylelint-config-standard-scss` (includes `stylelint-scss` plugin)
+- Less: `postcss-less` as `customSyntax`
+
+SCSS nesting (`&-modifier`) and mixins may trigger false positives in standard rules. The SCSS config handles this.
+
+### Prettier conflicts (v15+)
+
+Stylelint v15 removed all stylistic rules. If upgrading from v14:
+
+- Remove `stylelint-config-prettier` (no longer needed)
+- Remove manual disables of formatting rules (`indentation`, `string-quotes`, etc.)
+- Stylelint now handles correctness only; Prettier handles formatting
+
+### Property order plugins
+
+`stylelint-order` and `stylelint-config-clean-order` can conflict. Use one ordering strategy:
+
+- Alphabetical: `order/properties-alphabetical-order`
+- Grouped: `order/properties-order` with a custom group list
+- Clean order: extend `stylelint-config-clean-order` (opinionated groups)
+
+### `extends` order matters
+
+```json
+{
+  "extends": ["stylelint-config-standard", "stylelint-config-prettier"]
+}
+```
+
+Later configs override earlier ones. Put base configs first, overrides last.
+
+### Monorepo considerations
+
+- Stylelint resolves config from the file being linted, walking up directories
+- Each package can have its own `.stylelintrc.json`
+- vigiles checks Stylelint config via `createLinter({ cwd: basePath })` — in a monorepo, run from each package root
+
+## Mapping PR Feedback to Rule Strategy
+
+| PR comment pattern           | Best approach                                                                     |
+| ---------------------------- | --------------------------------------------------------------------------------- |
+| "Don't use !important"       | `stylelint/declaration-no-important` — already exists                             |
+| "Keep specificity low"       | `stylelint/selector-max-specificity` with threshold                               |
+| "Sort properties"            | `stylelint-order` plugin — `order/properties-alphabetical-order` or custom groups |
+| "Don't use ID selectors"     | `stylelint/selector-max-id` — already exists                                      |
+| "Use variables for colors"   | `stylelint-declaration-strict-value` plugin                                       |
+| "No vendor prefixes"         | `stylelint/property-no-vendor-prefix`, `value-no-vendor-prefix`                   |
+| "Don't nest too deep"        | `stylelint/selector-max-compound-selectors` with threshold                        |
+| "Use modern CSS"             | `stylelint/declaration-property-value-no-unknown` + browserslist                  |
+| "Remove empty blocks"        | `stylelint/block-no-empty` — already exists                                       |
+| "Don't duplicate properties" | `stylelint/declaration-block-no-duplicate-properties` — already exists            |
+| "Use shorthand"              | `stylelint/declaration-block-no-redundant-longhand-properties` — already exists   |
+| "Font naming convention"     | `stylelint/font-family-name-quotes` — already exists                              |
+| "No unknown @rules"          | `stylelint/at-rule-no-unknown` (or `scss/at-rule-no-unknown` for SCSS)            |

--- a/skills/pr-to-lint-rule/SKILL.md
+++ b/skills/pr-to-lint-rule/SKILL.md
@@ -37,11 +37,11 @@ Based on the detected (or user-specified) language, generate the appropriate rul
 
 #### For JavaScript/TypeScript (ESLint)
 
-**Read `eslint.md` in this skill directory before generating.** It covers plugin lookup, AST selectors, type-aware rules, auto-fix safety, and common gotchas.
+**Read `../linter-docs/eslint.md` before generating.** It covers plugin lookup, AST selectors, type-aware rules, auto-fix safety, and common gotchas.
 
 Before writing a custom rule:
 
-1. **Check existing plugins** — see the plugin table in `eslint.md`. Most "don't import X", "don't call Y()", and naming patterns are already covered by `no-restricted-imports`, `no-restricted-syntax`, or `@typescript-eslint/naming-convention`.
+1. **Check existing plugins** — see the plugin table in `../linter-docs/eslint.md`. Most "don't import X", "don't call Y()", and naming patterns are already covered by `no-restricted-imports`, `no-restricted-syntax`, or `@typescript-eslint/naming-convention`.
 2. **Try `no-restricted-syntax`** with an AST selector — this handles ~80% of one-off patterns with zero custom code.
 3. **Only write a custom rule** when you need type information, multi-node analysis, auto-fix, or configurable options.
 

--- a/skills/pr-to-lint-rule/SKILL.md
+++ b/skills/pr-to-lint-rule/SKILL.md
@@ -35,60 +35,32 @@ Look at the repository to determine:
 
 Based on the detected (or user-specified) language, generate the appropriate rule type:
 
-#### For JavaScript/TypeScript (ESLint)
+**Read the linter-specific reference doc before generating.** Each doc covers existing plugins to check first, rule/lint anatomy, AST patterns, auto-fix safety, testing, and edge cases.
 
-**Read `../linter-docs/eslint.md` before generating.** It covers plugin lookup, AST selectors, type-aware rules, auto-fix safety, and common gotchas.
+| Language | Linter | Reference doc |
+| --- | --- | --- |
+| JavaScript/TypeScript | ESLint | `../linter-docs/eslint.md` |
+| Python | Ruff | `../linter-docs/ruff.md` |
+| Python | Pylint | `../linter-docs/pylint.md` |
+| Ruby | RuboCop | `../linter-docs/rubocop.md` |
+| Rust | Clippy | `../linter-docs/clippy.md` |
+| CSS | Stylelint | `../linter-docs/stylelint.md` |
 
-Before writing a custom rule:
+For all linters, follow this order:
 
-1. **Check existing plugins** — see the plugin table in `../linter-docs/eslint.md`. Most "don't import X", "don't call Y()", and naming patterns are already covered by `no-restricted-imports`, `no-restricted-syntax`, or `@typescript-eslint/naming-convention`.
-2. **Try `no-restricted-syntax`** with an AST selector — this handles ~80% of one-off patterns with zero custom code.
-3. **Only write a custom rule** when you need type information, multi-node analysis, auto-fix, or configurable options.
+1. **Check existing plugins/rules first** — see the plugin table in the linter doc
+2. **Try built-in config options** — most linters have `no-restricted-*` or equivalent rules that handle one-off patterns without custom code
+3. **Only write a custom rule** when you need AST analysis, auto-fix, or configurable options beyond what exists
 
-If a custom rule is needed, generate:
-
-1. **Rule file** (`eslint-rules/<rule-name>.js` or `.ts`) — an ESLint rule using the AST visitor pattern
-2. **Test file** (`eslint-rules/<rule-name>.test.js` or `.ts`) — using `RuleTester` with valid/invalid cases (include TypeScript edge cases if the project uses TS)
-3. **Registration** — add to `eslint.config.js` via a local plugin object (flat config)
-
-Use the ESLint `RuleModule` format with:
-
-- `meta` (type, docs, messages, schema) — set `type` correctly: `"problem"` for bugs, `"suggestion"` for conventions
-- `create(context)` returning AST visitor methods
-- Prescriptive error messages: always tell the developer **what to do**, not just what's wrong
-- Auto-fix via `fix` only if the change is semantics-preserving; use `suggest` otherwise
-
-#### For Python (Ruff custom rules or flake8 plugin)
-
-Generate:
-
-1. A Ruff rule definition if the project uses Ruff, OR a flake8 plugin if using flake8
-2. Test cases
-3. Configuration to add to `pyproject.toml` or `setup.cfg`
-
-#### For Rust (Clippy)
-
-Generate:
-
-1. A `clippy.toml` configuration if the pattern can be caught by existing Clippy lints
-2. Or a custom lint using `dylint` if it requires AST analysis
-3. Test cases
+If a custom rule is needed, the reference doc provides: rule anatomy, AST node cheat sheet, auto-fix/suggest patterns, testing examples, and registration instructions.
 
 #### For Go (go/analysis)
 
-Generate:
-
-1. An analyzer using `golang.org/x/tools/go/analysis`
-2. Test cases using `analysistest`
-3. Integration instructions
+No linter doc yet. Generate an analyzer using `golang.org/x/tools/go/analysis` with `analysistest` tests.
 
 #### For other languages
 
-Generate:
-
-1. The most idiomatic linting approach for that language
-2. Test cases
-3. Integration instructions
+Generate the most idiomatic linting approach with test cases and integration instructions.
 
 ### Step 3: Add to Instruction File
 

--- a/skills/pr-to-lint-rule/SKILL.md
+++ b/skills/pr-to-lint-rule/SKILL.md
@@ -37,16 +37,26 @@ Based on the detected (or user-specified) language, generate the appropriate rul
 
 #### For JavaScript/TypeScript (ESLint)
 
-Generate:
+**Read `eslint.md` in this skill directory before generating.** It covers plugin lookup, AST selectors, type-aware rules, auto-fix safety, and common gotchas.
+
+Before writing a custom rule:
+
+1. **Check existing plugins** — see the plugin table in `eslint.md`. Most "don't import X", "don't call Y()", and naming patterns are already covered by `no-restricted-imports`, `no-restricted-syntax`, or `@typescript-eslint/naming-convention`.
+2. **Try `no-restricted-syntax`** with an AST selector — this handles ~80% of one-off patterns with zero custom code.
+3. **Only write a custom rule** when you need type information, multi-node analysis, auto-fix, or configurable options.
+
+If a custom rule is needed, generate:
 
 1. **Rule file** (`eslint-rules/<rule-name>.js` or `.ts`) — an ESLint rule using the AST visitor pattern
-2. **Test file** (`eslint-rules/<rule-name>.test.js` or `.ts`) — using RuleTester with valid/invalid cases
-3. **Registration** — show how to add the rule to `eslint.config.js` (flat config)
+2. **Test file** (`eslint-rules/<rule-name>.test.js` or `.ts`) — using `RuleTester` with valid/invalid cases (include TypeScript edge cases if the project uses TS)
+3. **Registration** — add to `eslint.config.js` via a local plugin object (flat config)
 
 Use the ESLint `RuleModule` format with:
 
-- `meta` (type, docs, messages, schema)
+- `meta` (type, docs, messages, schema) — set `type` correctly: `"problem"` for bugs, `"suggestion"` for conventions
 - `create(context)` returning AST visitor methods
+- Prescriptive error messages: always tell the developer **what to do**, not just what's wrong
+- Auto-fix via `fix` only if the change is semantics-preserving; use `suggest` otherwise
 
 #### For Python (Ruff custom rules or flake8 plugin)
 

--- a/skills/pr-to-lint-rule/SKILL.md
+++ b/skills/pr-to-lint-rule/SKILL.md
@@ -37,14 +37,14 @@ Based on the detected (or user-specified) language, generate the appropriate rul
 
 **Read the linter-specific reference doc before generating.** Each doc covers existing plugins to check first, rule/lint anatomy, AST patterns, auto-fix safety, testing, and edge cases.
 
-| Language | Linter | Reference doc |
-| --- | --- | --- |
-| JavaScript/TypeScript | ESLint | `../linter-docs/eslint.md` |
-| Python | Ruff | `../linter-docs/ruff.md` |
-| Python | Pylint | `../linter-docs/pylint.md` |
-| Ruby | RuboCop | `../linter-docs/rubocop.md` |
-| Rust | Clippy | `../linter-docs/clippy.md` |
-| CSS | Stylelint | `../linter-docs/stylelint.md` |
+| Language              | Linter    | Reference doc                 |
+| --------------------- | --------- | ----------------------------- |
+| JavaScript/TypeScript | ESLint    | `../linter-docs/eslint.md`    |
+| Python                | Ruff      | `../linter-docs/ruff.md`      |
+| Python                | Pylint    | `../linter-docs/pylint.md`    |
+| Ruby                  | RuboCop   | `../linter-docs/rubocop.md`   |
+| Rust                  | Clippy    | `../linter-docs/clippy.md`    |
+| CSS                   | Stylelint | `../linter-docs/stylelint.md` |
 
 For all linters, follow this order:
 

--- a/skills/pr-to-lint-rule/eslint.md
+++ b/skills/pr-to-lint-rule/eslint.md
@@ -1,0 +1,384 @@
+# ESLint — Custom Rules Deep Dive
+
+Sub-doc for the `pr-to-lint-rule` skill. Read this before generating an ESLint custom rule.
+
+## Check Existing Plugins First
+
+Before writing a custom rule, search these plugins — the pattern may already be covered:
+
+| Plugin                                              | Scope                               | Key rules to know                                                                                                                              |
+| --------------------------------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@typescript-eslint`                                | Type-aware TS rules                 | `no-floating-promises`, `no-misused-promises`, `strict-boolean-expressions`, `naming-convention`, `no-restricted-imports` (type-aware variant) |
+| `eslint-plugin-import-x`                            | Import hygiene (flat-config native) | `no-cycle`, `no-unresolved`, `no-extraneous-dependencies`, `order`, `no-internal-modules`                                                      |
+| `eslint-plugin-boundaries`                          | Module boundary enforcement         | `element-types`, `entry-point`, `external` — define allowed dependency directions between architectural layers                                 |
+| `eslint-plugin-sonarjs`                             | Code smells & complexity            | `cognitive-complexity`, `no-duplicate-string`, `no-identical-functions`, `no-nested-conditional`                                               |
+| `eslint-plugin-unicorn`                             | Modern JS idioms                    | `prefer-node-protocol`, `no-array-for-each`, `prefer-top-level-await`, `filename-case`                                                         |
+| `eslint-plugin-react` / `eslint-plugin-react-hooks` | React patterns                      | `rules-of-hooks`, `exhaustive-deps`, `no-unstable-nested-components`, `jsx-no-leaked-render`                                                   |
+| `eslint-plugin-jsx-a11y`                            | Accessibility                       | `alt-text`, `anchor-is-valid`, `no-autofocus`, `click-events-have-key-events`                                                                  |
+| `eslint-plugin-n`                                   | Node.js-specific                    | `no-sync`, `no-process-exit`, `prefer-global/buffer`, `no-unsupported-features`                                                                |
+| `eslint-plugin-regexp`                              | Regex safety                        | `no-super-linear-backtracking`, `no-misleading-unicode-character`, `prefer-quantifier`                                                         |
+| `eslint-plugin-security`                            | Security anti-patterns              | `detect-object-injection`, `detect-non-literal-regexp`, `detect-child-process`                                                                 |
+| `@eslint/json` / `@eslint/markdown`                 | Non-JS file linting                 | Lint JSON and markdown files with ESLint flat config — useful for config validation                                                            |
+
+**Tip:** `no-restricted-syntax` with an AST selector handles many one-off patterns without a custom rule. Try it first.
+
+## Rule Anatomy
+
+Every ESLint rule is an object with `meta` and `create`:
+
+```js
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: "suggestion", // "problem" | "suggestion" | "layout"
+    docs: {
+      description: "Disallow direct database calls outside the data layer",
+      recommended: false,
+    },
+    messages: {
+      noDirectDb:
+        "Use the repository pattern — import from 'src/data/' instead of calling {{ name }} directly.",
+    },
+    fixable: null, // "code" if you provide a fixer
+    schema: [], // JSON Schema for rule options
+  },
+
+  create(context) {
+    return {
+      // visitor methods keyed by AST node type or selector
+      CallExpression(node) {
+        if (isDirectDbCall(node)) {
+          context.report({
+            node,
+            messageId: "noDirectDb",
+            data: { name: node.callee.name },
+          });
+        }
+      },
+    };
+  },
+};
+```
+
+### meta.type — choose correctly
+
+| Type           | When to use                               | Example                                           |
+| -------------- | ----------------------------------------- | ------------------------------------------------- |
+| `"problem"`    | Code that is/will be broken               | Missing `await` on a promise                      |
+| `"suggestion"` | Code that works but violates a convention | Using `console.log` instead of the project logger |
+| `"layout"`     | Whitespace/formatting only                | Rarely used — Prettier handles this               |
+
+### meta.messages — be prescriptive
+
+Bad: `"Don't do this."` — tells the developer nothing.
+Good: `"Use the {{ replacement }} wrapper instead of {{ original }}."` — tells them exactly what to write.
+
+Always include **what to do** in the message, not just what's wrong.
+
+## AST Node Types — Cheat Sheet
+
+Common patterns and the AST nodes that catch them:
+
+| You want to detect         | AST node / selector                                                             | Notes                               |
+| -------------------------- | ------------------------------------------------------------------------------- | ----------------------------------- |
+| Function call `foo()`      | `CallExpression[callee.name="foo"]`                                             | Selector form — no code needed      |
+| Method call `obj.method()` | `CallExpression[callee.type="MemberExpression"][callee.property.name="method"]` |                                     |
+| Import `from "module"`     | `ImportDeclaration[source.value="module"]`                                      | Static imports only                 |
+| `require("module")`        | `CallExpression[callee.name="require"][arguments.0.value="module"]`             | CJS                                 |
+| Variable named X           | `VariableDeclarator[id.name="X"]`                                               |                                     |
+| Class with decorator       | `ClassDeclaration > Decorator`                                                  | Experimental — needs parser support |
+| JSX element `<Foo>`        | `JSXOpeningElement[name.name="Foo"]`                                            | Needs JSX parser                    |
+| Template literal           | `TemplateLiteral`                                                               | Includes tagged templates           |
+| `throw` statement          | `ThrowStatement`                                                                |                                     |
+| `new Promise()`            | `NewExpression[callee.name="Promise"]`                                          |                                     |
+
+**Pro tip:** Use [AST Explorer](https://astexplorer.net) (parser: `@typescript-eslint/parser`, transform: `ESLint v4`) to prototype visitor logic interactively.
+
+## ESTree Selectors
+
+ESLint supports CSS-like AST selectors. These replace boilerplate visitor code:
+
+```js
+create(context) {
+  return {
+    // Match: import from any path containing "internal"
+    'ImportDeclaration[source.value=/internal/]'(node) {
+      context.report({ node, messageId: "noInternalImport" });
+    },
+
+    // Match: await inside a loop body
+    'ForStatement > BlockStatement AwaitExpression'(node) {
+      context.report({ node, messageId: "noAwaitInLoop" });
+    },
+
+    // Match: console.log, console.warn, console.error
+    'MemberExpression[object.name="console"]'(node) {
+      context.report({ node: node.parent, messageId: "useLogger" });
+    },
+  };
+}
+```
+
+Selector syntax:
+
+- `A > B` — B is a direct child of A
+- `A B` — B is a descendant of A
+- `A[attr="val"]` — attribute match (string equality)
+- `A[attr=/regex/]` — attribute match (regex)
+- `A:exit` — fires when **leaving** the node (post-order)
+- `:not(A)` — negation
+- `A + B` — B immediately follows A (sibling)
+
+## Accessing TypeScript Type Information
+
+For type-aware rules, use `@typescript-eslint/utils`:
+
+```ts
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://example.com/rules/${name}`,
+);
+
+export default createRule({
+  name: "no-unhandled-promise",
+  meta: {
+    type: "problem",
+    docs: { description: "Require promises to be handled" },
+    messages: { unhandled: "This promise must be awaited or returned." },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const services = ESLintUtils.getParserServices(context);
+    const checker = services.program.getTypeChecker();
+
+    return {
+      ExpressionStatement(node) {
+        const tsNode = services.esTreeNodeToTSNodeMap.get(node.expression);
+        const type = checker.getTypeAtLocation(tsNode);
+        if (isPromiseLike(checker, type)) {
+          context.report({ node, messageId: "unhandled" });
+        }
+      },
+    };
+  },
+});
+```
+
+**Requirements for type-aware rules:**
+
+1. The ESLint config must use `@typescript-eslint/parser` with `projectService: true` (or legacy `project` option)
+2. The rule must live in a plugin (not standalone `eslint-rules/` dir) for parser services to work reliably
+3. Type-aware rules are slower — only use when you genuinely need type information
+
+## Auto-Fix and Suggestions
+
+### `fix` — automatic, silent
+
+Use for safe, semantics-preserving changes:
+
+```js
+context.report({
+  node,
+  messageId: "preferNodeProtocol",
+  fix(fixer) {
+    return fixer.replaceText(node.source, `"node:${module}"`);
+  },
+});
+```
+
+Safety rules for `fix`:
+
+- **Never change runtime behavior.** If the fix might break code, use `suggest` instead.
+- **Never remove code** unless it's provably dead.
+- One `fix` per report. Multiple changes go in a single fix call using an array.
+- Test your fix: `RuleTester` will verify the fix output matches `output` in your test case.
+
+### `suggest` — manual, user-picks
+
+Use for changes that might alter semantics:
+
+```js
+context.report({
+  node,
+  messageId: "noDirectDbCall",
+  suggest: [
+    {
+      messageId: "wrapWithRepo",
+      fix(fixer) {
+        return fixer.replaceText(
+          node,
+          `repository.${node.callee.property.name}(${argsText})`,
+        );
+      },
+    },
+  ],
+});
+```
+
+## Testing with RuleTester
+
+```js
+import { RuleTester } from "eslint";
+import rule from "./no-direct-db.js";
+
+const tester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2024,
+    sourceType: "module",
+  },
+});
+
+tester.run("no-direct-db", rule, {
+  valid: [
+    // Always include: correctly following the rule
+    `import { findUser } from "src/data/users";`,
+    // Edge case: dynamic import (intentionally allowed)
+    `const mod = await import("pg");`,
+  ],
+  invalid: [
+    {
+      code: `import { Pool } from "pg";`,
+      errors: [{ messageId: "noDirectDb" }],
+    },
+    // If the rule has a fixer, test the output
+    {
+      code: `const fs = require("fs");`,
+      output: `const fs = require("node:fs");`,
+      errors: [{ messageId: "preferNodeProtocol" }],
+    },
+  ],
+});
+```
+
+**Testing best practices:**
+
+1. **Test the valid cases first.** If valid cases fail, your rule is too aggressive.
+2. **Include edge cases.** Dynamic imports, re-exports, type-only imports, destructured requires.
+3. **Test error placement.** Use `errors: [{ messageId, line, column }]` to verify the squiggly appears on the right token.
+4. **Test with options.** If your rule has configurable options, test each combination.
+5. **For TypeScript rules**, use `@typescript-eslint/rule-tester` and provide `parser` + `parserOptions` with a real `tsconfig.json`.
+
+## Flat Config Registration
+
+ESLint 9+ uses flat config. Register custom rules via a local plugin object:
+
+```js
+// eslint.config.js
+import noDirectDb from "./eslint-rules/no-direct-db.js";
+
+export default [
+  {
+    plugins: {
+      // Namespace all custom rules under "local"
+      local: {
+        rules: {
+          "no-direct-db": noDirectDb,
+        },
+      },
+    },
+    rules: {
+      "local/no-direct-db": "error",
+    },
+  },
+];
+```
+
+**Important:** The config key in `rules` must be `<plugin-namespace>/<rule-name>`. The `enforce()` reference in vigiles matches this: `enforce("eslint/local/no-direct-db", "...")`.
+
+If the project still uses legacy `.eslintrc`, the rule goes in `rulesDir` instead — but flat config is the path forward.
+
+## Edge Cases and Gotchas
+
+### TypeScript AST differences
+
+TypeScript adds AST node types that ESTree doesn't have. Common ones to watch for:
+
+- `TSAsExpression` — `x as string` wraps the expression; your visitor might miss the inner node
+- `TSNonNullExpression` — `x!` adds a wrapper node
+- `TSTypeAnnotation` — `: string` on parameters creates child nodes that break naive `node.params.length` checks
+- `TSImportEqualsDeclaration` — `import x = require("y")` is NOT an `ImportDeclaration`
+- `TSEnumDeclaration` — enums look like variable declarations but aren't
+
+**Rule of thumb:** If your rule targets function parameters, imports, or expressions, test it with TypeScript annotations and assertions.
+
+### `no-restricted-syntax` — the 80% solution
+
+Before writing a custom rule, check if `no-restricted-syntax` covers it:
+
+```js
+rules: {
+  "no-restricted-syntax": ["error",
+    {
+      selector: 'CallExpression[callee.object.name="console"]',
+      message: "Use the project logger from 'src/lib/logger'.",
+    },
+    {
+      selector: 'ImportDeclaration[source.value="moment"]',
+      message: "Use dayjs — we're migrating off moment.",
+    },
+  ],
+}
+```
+
+This works for any pattern you can express as an AST selector. You only need a custom rule when you need:
+
+- Type information
+- Multi-node analysis (e.g., "if X is imported, then Y must also be imported")
+- Auto-fix or suggestions
+- Configurable options via schema
+
+### `no-restricted-imports` — the import-specific shortcut
+
+For import bans specifically, `no-restricted-imports` is more ergonomic:
+
+```js
+rules: {
+  "no-restricted-imports": ["error", {
+    paths: [
+      { name: "lodash", message: "Import specific lodash functions: lodash/get" },
+      { name: "moment", message: "Use dayjs instead." },
+    ],
+    patterns: [
+      { group: ["src/internal/*"], message: "Use the public API from src/index.ts" },
+    ],
+  }],
+}
+```
+
+### Auto-fix conflicts
+
+If two rules try to fix the same range of code, ESLint drops both fixes. Avoid this by:
+
+- Keeping fix ranges tight (fix only the exact tokens, not the whole statement)
+- Using `suggest` instead of `fix` when the rule might overlap with Prettier or another fixer
+- Testing with `--fix-dry-run` before enabling in CI
+
+### Performance
+
+- Avoid `Program:exit` handlers that walk the entire AST — use specific node visitors instead.
+- Selector matching has overhead. For hot paths, a manual `CallExpression` check is faster than a complex selector.
+- Type-aware rules add ~2-5x overhead because they invoke the TypeScript compiler. Group them in a separate config block with `files: ["src/**/*.ts"]` so they only run on TS files.
+- If your custom rules directory has more than ~10 rules, bundle them into a proper plugin package for better caching.
+
+### Monorepo considerations
+
+- ESLint flat config is resolved from `cwd`, not from the file being linted. In a monorepo, set `cwd` to the package root, not the workspace root.
+- `vigiles generate-types` discovers ESLint rules using `calculateConfigForFile("dummy.js")` from the project `basePath`. If your monorepo has different configs per package, run `generate-types` from each package root.
+- Plugin rules must be installed in the `node_modules` visible from the config file's location. Hoisted deps in a monorepo can cause "plugin not found" errors — install them in the package's own `devDependencies`.
+
+## Mapping PR Feedback to Rule Strategy
+
+| PR comment pattern                  | Best approach                                                                                      |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------- |
+| "Don't import from X"               | `no-restricted-imports` — zero custom code                                                         |
+| "Don't call X()"                    | `no-restricted-syntax` with a `CallExpression` selector                                            |
+| "Use X instead of Y"                | `no-restricted-syntax` if detection is simple; custom rule with `fix` if you want auto-replacement |
+| "Every file must have X"            | Not ESLint — use vigiles `check(every(...).has(...))`                                              |
+| "This promise isn't awaited"        | `@typescript-eslint/no-floating-promises` — already exists                                         |
+| "Use our custom hook"               | Custom rule checking `CallExpression` against an allow-list                                        |
+| "Wrong naming convention"           | `@typescript-eslint/naming-convention` — highly configurable, rarely needs custom code             |
+| "Don't use `any`"                   | `@typescript-eslint/no-explicit-any` — already exists                                              |
+| "Wrap API calls with error handler" | Custom rule: detect unwrapped `fetch`/`axios` calls, `suggest` the wrapper                         |
+| "Don't mutate state directly"       | `eslint-plugin-react` `no-direct-mutation-state` or custom rule checking assignment targets        |

--- a/skills/strengthen/SKILL.md
+++ b/skills/strengthen/SKILL.md
@@ -25,9 +25,12 @@ Also check which linters are present:
 
 Based on which linters are present, read the corresponding reference docs:
 
-- ESLint / Stylelint → `../linter-docs/eslint.md`
-- RuboCop → `../linter-docs/rubocop.md`
+- ESLint → `../linter-docs/eslint.md`
+- Stylelint → `../linter-docs/stylelint.md`
+- Ruff → `../linter-docs/ruff.md`
 - Pylint → `../linter-docs/pylint.md`
+- RuboCop → `../linter-docs/rubocop.md`
+- Clippy → `../linter-docs/clippy.md`
 
 These docs contain plugin tables, recommended rules, and decision matrices for mapping patterns to rules.
 

--- a/skills/strengthen/SKILL.md
+++ b/skills/strengthen/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: strengthen
+description: Upgrade guidance() rules to enforce() by finding existing linter rules that match
+disable-model-invocation: true
+---
+
+Scan spec files for `guidance()` rules and suggest `enforce()` replacements backed by real linter rules.
+
+## Instructions
+
+### Step 1: Discover What's Installed
+
+Run `npx vigiles generate-types` to get the full list of enabled linter rules in the project. Read `.vigiles/generated.d.ts` to see every rule available across all detected linters.
+
+Also check which linters are present:
+
+- **ESLint** — look for `eslint.config.*` or `.eslintrc.*` in the project root, and `eslint` in `package.json` devDependencies
+- **Ruff** — look for `ruff` section in `pyproject.toml` or `ruff.toml`
+- **Clippy** — look for `Cargo.toml` with `[lints.clippy]`
+- **Pylint** — look for `.pylintrc` or `pylint` section in `pyproject.toml`
+- **RuboCop** — look for `.rubocop.yml`
+- **Stylelint** — look for `stylelint` in `package.json` or `.stylelintrc.*`
+
+### Step 2: Read the Linter Reference Docs
+
+Based on which linters are present, read the corresponding reference docs:
+
+- ESLint / Stylelint → `../linter-docs/eslint.md`
+- RuboCop → `../linter-docs/rubocop.md`
+- Pylint → `../linter-docs/pylint.md`
+
+These docs contain plugin tables, recommended rules, and decision matrices for mapping patterns to rules.
+
+### Step 3: Find All Guidance Rules
+
+Find all `.spec.ts` files in the project (`**/*.md.spec.ts`). For each file, identify every `guidance()` rule.
+
+### Step 4: Match Each Guidance Rule
+
+For each guidance rule, determine if an existing linter rule can enforce it:
+
+1. **Check the generated types first** — if `.vigiles/generated.d.ts` lists a rule that directly matches, suggest it.
+2. **Check the plugin tables** in the linter reference docs — the guidance text may describe a pattern covered by a well-known plugin rule.
+3. **Check built-in ESLint rules** — `no-restricted-syntax`, `no-restricted-imports`, and `no-restricted-properties` can enforce many patterns via config alone, no custom rule needed.
+4. **If no existing rule fits**, note it as a candidate for `/pr-to-lint-rule` (custom rule authoring) but don't generate one — just flag it.
+
+When matching, think about what the guidance rule is actually asking for, not just keyword matching. For example:
+
+- "Use our custom logger" → `eslint/no-console` (bans the wrong thing, the rule enforces the right thing)
+- "Don't import from internal modules" → `eslint/no-restricted-imports` with a `patterns` config, or `import/no-internal-modules`
+- "Prefer composition over inheritance" → no linter rule, stays as guidance
+- "Every API handler must validate input" → no general linter rule, could be a custom rule → flag for `/pr-to-lint-rule`
+
+### Step 5: Present Suggestions
+
+For each guidance rule that can be strengthened, show:
+
+```typescript
+// Before
+"rule-id": guidance("Original guidance text"),
+
+// After
+"rule-id": enforce("linter/rule-name", "Original guidance text"),
+```
+
+If the rule requires linter config changes (e.g., adding options to `no-restricted-imports`), show the config change too.
+
+Group the output:
+
+1. **Direct replacements** — an existing enabled rule matches perfectly
+2. **Requires config** — a built-in rule matches but needs options added to the linter config
+3. **Requires plugin install** — a known plugin has the rule but isn't installed yet
+4. **No match** — stays as guidance, or candidate for `/pr-to-lint-rule`
+
+### Step 6: Apply Changes
+
+Ask the user which suggestions to apply. For approved changes:
+
+1. Edit the spec file — replace `guidance()` with `enforce()`
+2. If linter config changes are needed, apply them
+3. Run `npm run build && npx vigiles compile` to verify
+4. If compilation fails (rule doesn't exist or is disabled), report the error and revert

--- a/skills/strengthen/SKILL.md
+++ b/skills/strengthen/SKILL.md
@@ -8,22 +8,42 @@ Scan spec files for `guidance()` rules and suggest `enforce()` replacements back
 
 ## Instructions
 
+### Step 0: Choose Mode
+
+Ask the user:
+
+> **Auto or interactive?**
+>
+> - **Auto** — I'll apply all safe changes (direct replacements where the rule is already enabled), commit, and show you the diff. Risky changes (require config edits or plugin installs) go in a summary for you to review.
+> - **Interactive** — I'll present each suggestion and you pick which ones to apply.
+
+Default to interactive if the user doesn't specify.
+
 ### Step 1: Discover What's Installed
 
 Run `npx vigiles generate-types` to get the full list of enabled linter rules in the project. Read `.vigiles/generated.d.ts` to see every rule available across all detected linters.
 
-Also check which linters are present:
+Note which linter prefixes appear in the generated types (e.g., `EslintRule`, `RuffRule`). You'll only need reference docs for detected linters.
 
-- **ESLint** — look for `eslint.config.*` or `.eslintrc.*` in the project root, and `eslint` in `package.json` devDependencies
-- **Ruff** — look for `ruff` section in `pyproject.toml` or `ruff.toml`
-- **Clippy** — look for `Cargo.toml` with `[lints.clippy]`
-- **Pylint** — look for `.pylintrc` or `pylint` section in `pyproject.toml`
-- **RuboCop** — look for `.rubocop.yml`
-- **Stylelint** — look for `stylelint` in `package.json` or `.stylelintrc.*`
+### Step 2: Find All Guidance Rules
 
-### Step 2: Read the Linter Reference Docs
+Find all `.spec.ts` files in the project (`**/*.md.spec.ts`). For each file, identify every `guidance()` rule.
 
-Based on which linters are present, read the corresponding reference docs:
+### Step 3: Match Against Generated Types (Fast Path)
+
+For each guidance rule, check if an enabled rule in `.vigiles/generated.d.ts` directly matches. This is the fast, deterministic path — no doc reading needed.
+
+Look for:
+
+- **Exact rule name in text** — guidance says "no-console" and `no-console` is in EslintRule
+- **Semantic match** — guidance says "don't use console.log" and `no-console` is available
+- **Rule description match** — guidance says "unused variables" and `no-unused-vars` or `@typescript-eslint/no-unused-vars` is available
+
+If a match is found and the rule is in the generated types (meaning it's already enabled), this is a **direct replacement** — no config changes needed.
+
+### Step 4: Read Linter Docs (Slow Path)
+
+For guidance rules that didn't match in Step 3, read the linter reference docs for the project's detected linters:
 
 - ESLint → `../linter-docs/eslint.md`
 - Stylelint → `../linter-docs/stylelint.md`
@@ -32,54 +52,117 @@ Based on which linters are present, read the corresponding reference docs:
 - RuboCop → `../linter-docs/rubocop.md`
 - Clippy → `../linter-docs/clippy.md`
 
-These docs contain plugin tables, recommended rules, and decision matrices for mapping patterns to rules.
+**Only read docs for linters the project actually uses.** Skip docs for linters with no rules in generated types.
 
-### Step 3: Find All Guidance Rules
+Check the plugin tables and decision matrices. The guidance text may describe a pattern covered by:
 
-Find all `.spec.ts` files in the project (`**/*.md.spec.ts`). For each file, identify every `guidance()` rule.
+- A plugin rule that's installed but not enabled
+- A plugin that's not installed yet
+- A `no-restricted-*` config pattern (see Step 4b)
 
-### Step 4: Match Each Guidance Rule
+### Step 4b: `no-restricted-*` Patterns
 
-For each guidance rule, determine if an existing linter rule can enforce it:
+Many guidance rules can be enforced via built-in linter config without a custom rule. This is the most common strengthen pattern — "don't do X" maps to a restriction config.
 
-1. **Check the generated types first** — if `.vigiles/generated.d.ts` lists a rule that directly matches, suggest it.
-2. **Check the plugin tables** in the linter reference docs — the guidance text may describe a pattern covered by a well-known plugin rule.
-3. **Check built-in ESLint rules** — `no-restricted-syntax`, `no-restricted-imports`, and `no-restricted-properties` can enforce many patterns via config alone, no custom rule needed.
-4. **If no existing rule fits**, note it as a candidate for `/pr-to-lint-rule` (custom rule authoring) but don't generate one — just flag it.
+**ESLint:**
 
-When matching, think about what the guidance rule is actually asking for, not just keyword matching. For example:
+```js
+// "Don't import from internal modules"
+"no-restricted-imports": ["error", {
+  patterns: [{ group: ["src/internal/*"], message: "Use the public API." }]
+}],
 
-- "Use our custom logger" → `eslint/no-console` (bans the wrong thing, the rule enforces the right thing)
-- "Don't import from internal modules" → `eslint/no-restricted-imports` with a `patterns` config, or `import/no-internal-modules`
-- "Prefer composition over inheritance" → no linter rule, stays as guidance
-- "Every API handler must validate input" → no general linter rule, could be a custom rule → flag for `/pr-to-lint-rule`
+// "Don't call console.log"
+"no-restricted-syntax": ["error", {
+  selector: 'CallExpression[callee.object.name="console"]',
+  message: "Use the project logger."
+}],
+
+// "Don't use moment.js"
+"no-restricted-imports": ["error", {
+  paths: [{ name: "moment", message: "Use dayjs instead." }]
+}],
+```
+
+**Ruff:**
+
+```toml
+# "Don't use os.system"
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"os.system".msg = "Use subprocess.run instead."
+```
+
+**RuboCop:**
+
+```yaml
+# "Don't use puts in production" — if Rails/Output doesn't fit
+Custom/NoPuts:
+  Enabled: true
+```
+
+When suggesting a `no-restricted-*` change:
+
+1. Show the exact config edit needed (which file, which section)
+2. Show the `enforce()` rule that references it
+3. Note that this changes linter config, not just the spec
 
 ### Step 5: Present Suggestions
 
-For each guidance rule that can be strengthened, show:
+Group the output into tiers:
+
+**Tier 1: Direct replacements** (rule already enabled — zero risk)
 
 ```typescript
 // Before
-"rule-id": guidance("Original guidance text"),
-
+"no-console": guidance("Use structured logger instead of console.log"),
 // After
-"rule-id": enforce("linter/rule-name", "Original guidance text"),
+"no-console": enforce("eslint/no-console", "Use structured logger instead of console.log"),
 ```
 
-If the rule requires linter config changes (e.g., adding options to `no-restricted-imports`), show the config change too.
+**Tier 2: Config-backed** (rule exists but needs config options)
 
-Group the output:
+```typescript
+// Spec change:
+"no-moment": enforce("eslint/no-restricted-imports", "Use dayjs instead of moment."),
 
-1. **Direct replacements** — an existing enabled rule matches perfectly
-2. **Requires config** — a built-in rule matches but needs options added to the linter config
-3. **Requires plugin install** — a known plugin has the rule but isn't installed yet
-4. **No match** — stays as guidance, or candidate for `/pr-to-lint-rule`
+// Config change needed (eslint.config.mjs):
+"no-restricted-imports": ["error", {
+  paths: [{ name: "moment", message: "Use dayjs instead." }]
+}],
+```
+
+**Tier 3: Plugin install needed**
+
+```
+"cognitive-complexity": guidance("Keep functions simple")
+→ Install eslint-plugin-sonarjs, enable sonarjs/cognitive-complexity
+→ enforce("eslint/sonarjs/cognitive-complexity", "Keep functions simple")
+```
+
+**Tier 4: No match** (stays as guidance, or candidate for `/pr-to-lint-rule`)
+
+```
+"research-first": guidance("Google unfamiliar APIs first.")
+→ No linter rule can enforce this. Stays as guidance.
+→ Want me to run /pr-to-lint-rule to create a custom rule?
+```
 
 ### Step 6: Apply Changes
 
-Ask the user which suggestions to apply. For approved changes:
+**In auto mode:**
 
-1. Edit the spec file — replace `guidance()` with `enforce()`
-2. If linter config changes are needed, apply them
-3. Run `npm run build && npx vigiles compile` to verify
-4. If compilation fails (rule doesn't exist or is disabled), report the error and revert
+1. Apply all Tier 1 changes (edit spec files, replace `guidance()` with `enforce()`)
+2. Run `npm run build && npx vigiles compile` to verify each change compiles
+3. If any compilation fails, revert that specific change and report the error
+4. Commit all successful changes
+5. Present Tier 2-4 as a summary for the user to review
+
+**In interactive mode:**
+
+1. Present all tiers
+2. Ask the user which suggestions to apply
+3. For approved Tier 2 changes: edit the linter config, then edit the spec
+4. Run `npm run build && npx vigiles compile` to verify
+5. If compilation fails, report the error and revert
+
+**For Tier 4 (no match):** Ask the user if they want to run `/pr-to-lint-rule` for any of the unmatched rules to create custom rules.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,7 +20,8 @@ import {
 import { resolve } from "node:path";
 import { globSync } from "glob";
 import { generateTypes } from "./generate-types.js";
-import { validate, loadConfig as loadValidateConfig } from "./validate.js";
+import { validate, loadConfig } from "./validate.js";
+import type { VigilesConfig } from "./types.js";
 
 import {
   compileClaude,
@@ -48,34 +49,8 @@ import type { FreshnessResult } from "./freshness.js";
 
 const IGNORE_NODE_MODULES = ["node_modules/**"];
 
-// ---------------------------------------------------------------------------
-// Config loading
-// ---------------------------------------------------------------------------
-
-interface VigilesConfig {
-  maxRules?: number;
-  maxTokens?: number;
-  maxSectionLines?: number;
-  catalogOnly?: boolean;
-  linters?: Record<string, { rulesDir?: string | string[] }>;
-  /** How to detect staleness. Default: "strict" (recompile and diff). */
-  freshnessMode?: "strict" | "input-hash" | "output-hash";
-  /** Extra files to track in input-hash mode. */
-  freshnessInputs?: string[];
-}
-
-function loadConfig(): VigilesConfig {
-  const configPath = resolve(process.cwd(), "vigiles.config.ts");
-  // For now, fall back to .vigilesrc.json-style detection.
-  // Full TS config loading (via tsx/jiti) is a future enhancement.
-  if (existsSync(configPath)) {
-    console.log(
-      `Note: vigiles.config.ts found but TS config loading is not yet supported.`,
-    );
-    console.log(`Using default config. TS config support coming soon.`);
-  }
-  return {};
-}
+// Config is loaded from .vigilesrc.json via validate.ts::loadConfig().
+// All settings (validation, compilation, freshness) are in one place.
 
 // ---------------------------------------------------------------------------
 // Spec loading
@@ -406,7 +381,7 @@ interface CombinedCheckResult {
 
 function check(filePaths: string[], silent = false): CombinedCheckResult {
   const hashes = verifyHashes(filePaths, silent);
-  const vConfig = loadValidateConfig();
+  const vConfig = loadConfig();
   const specsValid = validateSpecs(filePaths, vConfig.rules, silent);
   return {
     valid: hashes.valid && specsValid,
@@ -719,13 +694,11 @@ async function audit(
   const guidanceCount = await countGuidanceRules(silent);
 
   // 5. Freshness check
-  const validateConfig = loadValidateConfig();
-  const freshnessSeverity = validateConfig.rules.freshness;
+  const freshnessSeverity = config?.rules.freshness;
   let freshnessErrors = 0;
   if (freshnessSeverity) {
     if (!silent) console.log("\nFreshness check:\n");
-    const mode =
-      config?.freshnessMode ?? validateConfig.freshnessMode ?? "strict";
+    const mode = config?.freshnessMode ?? "strict";
     freshnessErrors = await checkFreshness(
       files,
       mode,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -524,7 +524,7 @@ function auditExitCode(report: AuditReport): 0 | 1 | 2 {
   )
     return 2;
   if (report.duplicatePairs > 0) return 1;
-  // Coverage gaps and strengthen suggestions are informational, not failures
+  // Coverage gaps and guidance counts are informational, not failures
   return 0;
 }
 
@@ -683,9 +683,8 @@ async function audit(
     restArgs.length > 0 ? files : undefined,
   );
 
-  // 4. Strengthen suggestions
-  if (!silent) console.log("");
-  const strengthenCount = await strengthen(silent);
+  // 4. Guidance rule count (strengthen suggestions moved to /strengthen skill)
+  const guidanceCount = await countGuidanceRules(silent);
 
   const report: AuditReport = {
     hashErrors: hashResult.hashErrors,
@@ -695,7 +694,7 @@ async function audit(
     duplicatePairs: dups.pairCount,
     coverageEnabled: coverage.enabled,
     coverageDocumented: coverage.documented,
-    strengthenSuggestions: strengthenCount,
+    strengthenSuggestions: guidanceCount,
     files,
   };
 
@@ -722,7 +721,9 @@ function printAuditSummary(report: AuditReport): void {
   if (undocumented > 0)
     parts.push(`${String(undocumented)} undocumented rules`);
   if (report.strengthenSuggestions > 0)
-    parts.push(`${String(report.strengthenSuggestions)} strengthenable`);
+    parts.push(
+      `${String(report.strengthenSuggestions)} guidance (run /strengthen to upgrade)`,
+    );
   if (parts.length === 0) {
     console.log("vigiles: clean");
   } else {
@@ -1255,7 +1256,7 @@ async function setup(args: string[]): Promise<void> {
   console.log("Setup complete.\n");
   console.log(`  1. Edit ${specPaths} — add your project's conventions`);
   console.log(
-    "  2. Run `npx vigiles strengthen` to upgrade guidance → enforce",
+    "  2. Run `/strengthen` in Claude Code to upgrade guidance → enforce",
   );
   if (!strict) {
     console.log(
@@ -1279,121 +1280,25 @@ async function setup(args: string[]): Promise<void> {
 // Strengthen: guidance() → enforce() suggestions
 // ---------------------------------------------------------------------------
 
-// Keywords in guidance text that map to known linter rules
-const GUIDANCE_TO_LINTER: Array<{
-  keywords: string[];
-  rules: string[];
-}> = [
-  {
-    keywords: ["console.log", "console", "no-console", "logger", "logging"],
-    rules: ["eslint/no-console", "ruff/T201"],
-  },
-  {
-    keywords: ["any", "no-explicit-any", "unknown", "type safety"],
-    rules: ["@typescript-eslint/no-explicit-any"],
-  },
-  {
-    keywords: ["await", "promise", "floating", "async", ".catch"],
-    rules: ["@typescript-eslint/no-floating-promises"],
-  },
-  {
-    keywords: ["unused", "dead code", "no-unused"],
-    rules: ["eslint/no-unused-vars", "@typescript-eslint/no-unused-vars"],
-  },
-  {
-    keywords: ["import", "barrel", "internal", "restricted"],
-    rules: ["eslint/no-restricted-imports", "import/no-internal-modules"],
-  },
-  {
-    keywords: ["unwrap", "expect", "panic"],
-    rules: ["clippy/unwrap_used"],
-  },
-  {
-    keywords: ["print", "println", "stdout"],
-    rules: ["ruff/T201", "clippy/print_stdout"],
-  },
-  {
-    keywords: ["assert", "assertion"],
-    rules: ["ruff/S101"],
-  },
-  {
-    keywords: ["todo", "fixme", "hack"],
-    rules: ["eslint/no-warning-comments"],
-  },
-  {
-    keywords: ["debugger"],
-    rules: ["eslint/no-debugger"],
-  },
-  {
-    keywords: ["eval"],
-    rules: ["eslint/no-eval"],
-  },
-];
-
-async function strengthen(silent = false): Promise<number> {
-  const log = (msg: string): void => {
-    if (!silent) console.log(msg);
-  };
-  log("Scanning specs for guidance rules that could be enforced...\n");
-
+async function countGuidanceRules(silent = false): Promise<number> {
   const specs = findSpecs();
-  if (specs.length === 0) {
-    log("No .spec.ts files found. Run `vigiles init` first.");
-    return 0;
-  }
+  if (specs.length === 0) return 0;
 
-  // Scan available linter rules
-  const typesResult = generateTypes({ basePath: process.cwd() });
-  const allLinterRules = new Set<string>();
-  for (const l of typesResult.linters) {
-    for (const r of l.rules) {
-      allLinterRules.add(`${l.linter}/${r}`);
-    }
-  }
-
-  let suggestions = 0;
-
+  let count = 0;
   for (const specPath of specs) {
     const spec = await loadSpec(specPath);
     if (!spec || spec._specType !== "claude") continue;
-
-    for (const [ruleId, rule] of Object.entries(spec.rules)) {
-      if (rule._kind !== "guidance") continue;
-      const text = rule.text.toLowerCase();
-
-      // Find matching linter rules via keyword matching
-      const matches: string[] = [];
-      for (const mapping of GUIDANCE_TO_LINTER) {
-        if (mapping.keywords.some((kw) => text.includes(kw))) {
-          for (const candidate of mapping.rules) {
-            if (allLinterRules.has(candidate)) {
-              matches.push(candidate);
-            }
-          }
-        }
-      }
-
-      if (matches.length > 0) {
-        suggestions++;
-        log(`  "${ruleId}" (guidance) → could be enforced:`);
-        for (const m of matches) {
-          log(`    enforce("${m}", "${rule.text.slice(0, 60)}")`);
-        }
-        log("");
-      }
+    for (const rule of Object.values(spec.rules)) {
+      if (rule._kind === "guidance") count++;
     }
   }
 
-  if (suggestions === 0) {
-    log("No strengthening suggestions found. All guidance rules look correct,");
-    log("or no matching linter rules are enabled in your project.");
-  } else {
-    log(`${String(suggestions)} rule(s) could be strengthened.`);
-    log(
-      "Edit the spec to replace guidance() with enforce() for the suggested rules.",
+  if (!silent && count > 0) {
+    console.log(
+      `${String(count)} guidance rule(s) — run /strengthen to find enforce() upgrades\n`,
     );
   }
-  return suggestions;
+  return count;
 }
 
 // ---------------------------------------------------------------------------
@@ -1550,7 +1455,7 @@ async function main(): Promise<void> {
     }
 
     case "audit": {
-      // audit = verify + discover + strengthen
+      // audit = verify + discover + guidance count
       const flags = args.slice(1).filter((a) => a.startsWith("--"));
       const report = await audit(restArgs, flags, config);
       const exitCode = auditExitCode(report);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,6 +33,14 @@ import type { ClaudeSpec, SkillSpec } from "./spec.js";
 import { findSimilarRules } from "./proofs.js";
 import { parseInlineRules } from "./inline.js";
 import { checkLinterRule } from "./linters.js";
+import {
+  discoverInputs,
+  computeInputHash,
+  addInputHash,
+  checkOutputHashFreshness,
+  checkInputHashFreshness,
+} from "./freshness.js";
+import type { FreshnessResult } from "./freshness.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -50,6 +58,10 @@ interface VigilesConfig {
   maxSectionLines?: number;
   catalogOnly?: boolean;
   linters?: Record<string, { rulesDir?: string | string[] }>;
+  /** How to detect staleness. Default: "strict" (recompile and diff). */
+  freshnessMode?: "strict" | "input-hash" | "output-hash";
+  /** Extra files to track in input-hash mode. */
+  freshnessInputs?: string[];
 }
 
 function loadConfig(): VigilesConfig {
@@ -176,7 +188,12 @@ async function compile(
     const basePath = process.cwd();
 
     if (spec._specType === "claude") {
-      const { markdown, errors, linterResults, targets } = compileClaude(spec, {
+      const {
+        markdown: rawMarkdown,
+        errors,
+        linterResults,
+        targets,
+      } = compileClaude(spec, {
         basePath,
         specFile: specPath,
         maxRules: config.maxRules,
@@ -185,6 +202,19 @@ async function compile(
         catalogOnly: config.catalogOnly,
         linters: config.linters,
       });
+
+      // Embed input hash for freshness tracking
+      let markdown = rawMarkdown;
+      if (config.freshnessMode === "input-hash") {
+        const inputs = discoverInputs(
+          specPath,
+          spec,
+          basePath,
+          config.freshnessInputs,
+        );
+        const inputHash = computeInputHash(inputs.files, basePath);
+        markdown = addInputHash(rawMarkdown, inputHash);
+      }
 
       const linterCount = linterResults.filter((r) => r.exists).length;
       const primaryOutput = specPath.replace(/\.spec\.ts$/, "");
@@ -512,6 +542,7 @@ interface AuditReport {
   coverageEnabled: number;
   coverageDocumented: number;
   strengthenSuggestions: number;
+  freshnessErrors: number;
   files: string[];
 }
 
@@ -520,7 +551,8 @@ function auditExitCode(report: AuditReport): 0 | 1 | 2 {
   if (
     report.hashErrors > 0 ||
     report.validationErrors > 0 ||
-    report.inlineErrors > 0
+    report.inlineErrors > 0 ||
+    report.freshnessErrors > 0
   )
     return 2;
   if (report.duplicatePairs > 0) return 1;
@@ -686,6 +718,23 @@ async function audit(
   // 4. Guidance rule count (strengthen suggestions moved to /strengthen skill)
   const guidanceCount = await countGuidanceRules(silent);
 
+  // 5. Freshness check
+  const validateConfig = loadValidateConfig();
+  const freshnessSeverity = validateConfig.rules.freshness;
+  let freshnessErrors = 0;
+  if (freshnessSeverity) {
+    if (!silent) console.log("\nFreshness check:\n");
+    const mode =
+      config?.freshnessMode ?? validateConfig.freshnessMode ?? "strict";
+    freshnessErrors = await checkFreshness(
+      files,
+      mode,
+      config,
+      freshnessSeverity,
+      silent,
+    );
+  }
+
   const report: AuditReport = {
     hashErrors: hashResult.hashErrors,
     validationErrors: hashResult.validationErrors,
@@ -695,6 +744,7 @@ async function audit(
     coverageEnabled: coverage.enabled,
     coverageDocumented: coverage.documented,
     strengthenSuggestions: guidanceCount,
+    freshnessErrors,
     files,
   };
 
@@ -724,6 +774,8 @@ function printAuditSummary(report: AuditReport): void {
     parts.push(
       `${String(report.strengthenSuggestions)} guidance (run /strengthen to upgrade)`,
     );
+  if (report.freshnessErrors > 0)
+    parts.push(`${String(report.freshnessErrors)} stale (run vigiles compile)`);
   if (parts.length === 0) {
     console.log("vigiles: clean");
   } else {
@@ -1279,6 +1331,106 @@ async function setup(args: string[]): Promise<void> {
 // ---------------------------------------------------------------------------
 // Strengthen: guidance() → enforce() suggestions
 // ---------------------------------------------------------------------------
+
+async function checkFreshness(
+  files: string[],
+  mode: "strict" | "input-hash" | "output-hash",
+  config: VigilesConfig | undefined,
+  severity: "warn" | "error",
+  silent: boolean,
+): Promise<number> {
+  const log = (msg: string): void => {
+    if (!silent) console.log(msg);
+  };
+
+  let errorCount = 0;
+  const basePath = process.cwd();
+
+  for (const filePath of files) {
+    const abs = resolve(basePath, filePath);
+    if (!existsSync(abs)) continue;
+    const content = readFileSync(abs, "utf-8");
+
+    // Find the spec that compiled this file
+    const hashMatch = content.match(
+      /<!--\s*vigiles:sha256:[a-f0-9]+\s+compiled from (.+?)\s*-->/,
+    );
+    if (!hashMatch) {
+      // No hash = hand-written file, skip freshness check
+      continue;
+    }
+
+    let result: FreshnessResult;
+    const specFile = hashMatch[1];
+
+    if (mode === "strict") {
+      // Recompile in memory and diff
+      const spec = await loadSpec(specFile);
+      if (!spec || spec._specType !== "claude") {
+        log(`  ? ${filePath} — can't load spec "${specFile}", skipping`);
+        continue;
+      }
+      const compiled = compileClaude(spec, {
+        basePath,
+        specFile,
+        maxRules: config?.maxRules,
+        maxTokens: config?.maxTokens,
+        maxSectionLines: config?.maxSectionLines,
+        catalogOnly: config?.catalogOnly,
+        linters: config?.linters,
+      });
+      // Compare markdown body (strip hash/input lines)
+      const metaRe = /^<!-- vigiles:(sha256|inputs):[^\n]+ -->\r?\n?/gm;
+      const existingBody = content.replace(metaRe, "").trim();
+      const compiledBody = compiled.markdown.replace(metaRe, "").trim();
+      if (existingBody === compiledBody) {
+        result = { fresh: true, mode: "strict" };
+      } else {
+        result = {
+          fresh: false,
+          mode: "strict",
+          reason: "Output would differ if recompiled — run `vigiles compile`",
+        };
+      }
+    } else if (mode === "input-hash") {
+      const specFile = hashMatch[1];
+      const spec = await loadSpec(specFile);
+      if (!spec || spec._specType !== "claude") {
+        log(`  ? ${filePath} — can't load spec "${specFile}", skipping`);
+        continue;
+      }
+      const inputs = discoverInputs(
+        specFile,
+        spec,
+        basePath,
+        config?.freshnessInputs,
+      );
+      result = checkInputHashFreshness(content, inputs.files, basePath);
+    } else {
+      // output-hash mode
+      result = checkOutputHashFreshness(content);
+    }
+
+    if (!result.fresh) {
+      errorCount++;
+      const marker = severity === "error" ? "✗" : "⚠";
+      log(`  ${marker} ${filePath} — ${result.reason ?? "stale"}`);
+      if (result.changedFiles && result.changedFiles.length > 0) {
+        for (const f of result.changedFiles) {
+          log(`    changed: ${f}`);
+        }
+      }
+    } else if (!silent) {
+      log(`  ✓ ${filePath} — fresh (${mode})`);
+    }
+  }
+
+  if (errorCount === 0) {
+    log("  All files fresh.");
+  }
+
+  return severity === "error" ? errorCount : 0;
+}
 
 async function countGuidanceRules(silent = false): Promise<number> {
   const specs = findSpecs();

--- a/src/freshness.test.ts
+++ b/src/freshness.test.ts
@@ -1,0 +1,448 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  detectLockFiles,
+  detectLinterConfigs,
+  discoverInputs,
+  computeInputHash,
+  addInputHash,
+  extractInputHash,
+  checkOutputHashFreshness,
+  checkInputHashFreshness,
+} from "./freshness.js";
+import type { ClaudeSpec } from "./spec.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "vigiles-freshness-"));
+}
+
+function makeSpec(overrides?: Partial<ClaudeSpec>): ClaudeSpec {
+  return {
+    _specType: "claude",
+    rules: {},
+    ...overrides,
+  } as ClaudeSpec;
+}
+
+// ---------------------------------------------------------------------------
+// detectLockFiles
+// ---------------------------------------------------------------------------
+
+describe("detectLockFiles", () => {
+  let tmpDir: string;
+
+  before(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  after(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty array when no lock files exist", () => {
+    const result = detectLockFiles(tmpDir);
+    assert.deepEqual(result, []);
+  });
+
+  it("detects package-lock.json", () => {
+    writeFileSync(join(tmpDir, "package-lock.json"), "{}");
+    const result = detectLockFiles(tmpDir);
+    assert.ok(result.includes("package-lock.json"));
+  });
+
+  it("detects yarn.lock", () => {
+    writeFileSync(join(tmpDir, "yarn.lock"), "");
+    const result = detectLockFiles(tmpDir);
+    assert.ok(result.includes("yarn.lock"));
+  });
+
+  it("detects pnpm-lock.yaml", () => {
+    writeFileSync(join(tmpDir, "pnpm-lock.yaml"), "");
+    const result = detectLockFiles(tmpDir);
+    assert.ok(result.includes("pnpm-lock.yaml"));
+  });
+
+  it("detects bun.lockb", () => {
+    writeFileSync(join(tmpDir, "bun.lockb"), "");
+    const result = detectLockFiles(tmpDir);
+    assert.ok(result.includes("bun.lockb"));
+  });
+
+  it("detects Gemfile.lock", () => {
+    writeFileSync(join(tmpDir, "Gemfile.lock"), "");
+    const result = detectLockFiles(tmpDir);
+    assert.ok(result.includes("Gemfile.lock"));
+  });
+
+  it("detects poetry.lock", () => {
+    writeFileSync(join(tmpDir, "poetry.lock"), "");
+    const result = detectLockFiles(tmpDir);
+    assert.ok(result.includes("poetry.lock"));
+  });
+
+  it("detects uv.lock", () => {
+    writeFileSync(join(tmpDir, "uv.lock"), "");
+    const result = detectLockFiles(tmpDir);
+    assert.ok(result.includes("uv.lock"));
+  });
+
+  it("detects pdm.lock", () => {
+    writeFileSync(join(tmpDir, "pdm.lock"), "");
+    const result = detectLockFiles(tmpDir);
+    assert.ok(result.includes("pdm.lock"));
+  });
+
+  it("detects Cargo.lock", () => {
+    writeFileSync(join(tmpDir, "Cargo.lock"), "");
+    const result = detectLockFiles(tmpDir);
+    assert.ok(result.includes("Cargo.lock"));
+  });
+
+  it("detects go.sum", () => {
+    writeFileSync(join(tmpDir, "go.sum"), "");
+    const result = detectLockFiles(tmpDir);
+    assert.ok(result.includes("go.sum"));
+  });
+
+  it("detects composer.lock", () => {
+    writeFileSync(join(tmpDir, "composer.lock"), "{}");
+    const result = detectLockFiles(tmpDir);
+    assert.ok(result.includes("composer.lock"));
+  });
+
+  it("detects packages.lock.json (.NET)", () => {
+    writeFileSync(join(tmpDir, "packages.lock.json"), "{}");
+    const result = detectLockFiles(tmpDir);
+    assert.ok(result.includes("packages.lock.json"));
+  });
+
+  it("detects Package.resolved (Swift)", () => {
+    writeFileSync(join(tmpDir, "Package.resolved"), "{}");
+    const result = detectLockFiles(tmpDir);
+    assert.ok(result.includes("Package.resolved"));
+  });
+
+  it("detects mix.lock (Elixir)", () => {
+    writeFileSync(join(tmpDir, "mix.lock"), "");
+    const result = detectLockFiles(tmpDir);
+    assert.ok(result.includes("mix.lock"));
+  });
+
+  it("detects requirements.txt", () => {
+    writeFileSync(join(tmpDir, "requirements.txt"), "flask==2.0");
+    const result = detectLockFiles(tmpDir);
+    assert.ok(result.includes("requirements.txt"));
+  });
+
+  it("returns multiple lock files for polyglot projects", () => {
+    // tmpDir already has all the above files
+    const result = detectLockFiles(tmpDir);
+    assert.ok(
+      result.length > 5,
+      `Expected many lock files, got ${result.length}`,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectLinterConfigs
+// ---------------------------------------------------------------------------
+
+describe("detectLinterConfigs", () => {
+  let tmpDir: string;
+
+  before(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  after(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty array when no configs exist", () => {
+    const result = detectLinterConfigs(tmpDir);
+    assert.deepEqual(result, []);
+  });
+
+  it("detects eslint.config.mjs", () => {
+    writeFileSync(join(tmpDir, "eslint.config.mjs"), "export default [];");
+    const result = detectLinterConfigs(tmpDir);
+    assert.ok(result.includes("eslint.config.mjs"));
+  });
+
+  it("detects .rubocop.yml", () => {
+    writeFileSync(join(tmpDir, ".rubocop.yml"), "---");
+    const result = detectLinterConfigs(tmpDir);
+    assert.ok(result.includes(".rubocop.yml"));
+  });
+
+  it("detects pyproject.toml", () => {
+    writeFileSync(join(tmpDir, "pyproject.toml"), "[tool.ruff]");
+    const result = detectLinterConfigs(tmpDir);
+    assert.ok(result.includes("pyproject.toml"));
+  });
+
+  it("detects .pylintrc", () => {
+    writeFileSync(join(tmpDir, ".pylintrc"), "[MAIN]");
+    const result = detectLinterConfigs(tmpDir);
+    assert.ok(result.includes(".pylintrc"));
+  });
+
+  it("detects Cargo.toml", () => {
+    writeFileSync(join(tmpDir, "Cargo.toml"), "[package]");
+    const result = detectLinterConfigs(tmpDir);
+    assert.ok(result.includes("Cargo.toml"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// discoverInputs
+// ---------------------------------------------------------------------------
+
+describe("discoverInputs", () => {
+  let tmpDir: string;
+
+  before(() => {
+    tmpDir = makeTmpDir();
+    writeFileSync(join(tmpDir, "CLAUDE.md.spec.ts"), "export default {};");
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", scripts: {} }),
+    );
+  });
+
+  after(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("always includes the spec file", () => {
+    const spec = makeSpec();
+    const result = discoverInputs("CLAUDE.md.spec.ts", spec, tmpDir);
+    assert.ok(result.files.includes("CLAUDE.md.spec.ts"));
+  });
+
+  it("includes package.json when present", () => {
+    const spec = makeSpec();
+    const result = discoverInputs("CLAUDE.md.spec.ts", spec, tmpDir);
+    assert.ok(result.files.includes("package.json"));
+  });
+
+  it("includes keyFiles from spec", () => {
+    const spec = makeSpec({
+      keyFiles: { "src/index.ts": "Entry point" },
+    });
+    const result = discoverInputs("CLAUDE.md.spec.ts", spec, tmpDir);
+    assert.ok(result.files.includes("src/index.ts"));
+  });
+
+  it("includes extra configured inputs", () => {
+    const spec = makeSpec();
+    const result = discoverInputs("CLAUDE.md.spec.ts", spec, tmpDir, [
+      "../../yarn.lock",
+    ]);
+    assert.ok(result.files.includes("../../yarn.lock"));
+  });
+
+  it("includes detected linter configs", () => {
+    writeFileSync(join(tmpDir, "eslint.config.mjs"), "export default [];");
+    const spec = makeSpec();
+    const result = discoverInputs("CLAUDE.md.spec.ts", spec, tmpDir);
+    assert.ok(result.files.includes("eslint.config.mjs"));
+    assert.ok(result.linterConfigs.includes("eslint.config.mjs"));
+  });
+
+  it("includes detected lock files", () => {
+    writeFileSync(join(tmpDir, "package-lock.json"), "{}");
+    const spec = makeSpec();
+    const result = discoverInputs("CLAUDE.md.spec.ts", spec, tmpDir);
+    assert.ok(result.files.includes("package-lock.json"));
+    assert.ok(result.lockFiles.includes("package-lock.json"));
+  });
+
+  it("includes .vigiles/generated.d.ts when present", () => {
+    mkdirSync(join(tmpDir, ".vigiles"), { recursive: true });
+    writeFileSync(join(tmpDir, ".vigiles/generated.d.ts"), "// types");
+    const spec = makeSpec();
+    const result = discoverInputs("CLAUDE.md.spec.ts", spec, tmpDir);
+    assert.ok(result.files.includes(".vigiles/generated.d.ts"));
+  });
+
+  it("returns sorted file list", () => {
+    const spec = makeSpec();
+    const result = discoverInputs("CLAUDE.md.spec.ts", spec, tmpDir);
+    const sorted = [...result.files].sort();
+    assert.deepEqual(result.files, sorted);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeInputHash
+// ---------------------------------------------------------------------------
+
+describe("computeInputHash", () => {
+  let tmpDir: string;
+
+  before(() => {
+    tmpDir = makeTmpDir();
+    writeFileSync(join(tmpDir, "a.txt"), "hello");
+    writeFileSync(join(tmpDir, "b.txt"), "world");
+  });
+
+  after(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns a 16-char hex string", () => {
+    const hash = computeInputHash(["a.txt", "b.txt"], tmpDir);
+    assert.match(hash, /^[a-f0-9]{16}$/);
+  });
+
+  it("returns same hash for same inputs", () => {
+    const h1 = computeInputHash(["a.txt", "b.txt"], tmpDir);
+    const h2 = computeInputHash(["a.txt", "b.txt"], tmpDir);
+    assert.equal(h1, h2);
+  });
+
+  it("changes when file content changes", () => {
+    const h1 = computeInputHash(["a.txt"], tmpDir);
+    writeFileSync(join(tmpDir, "a.txt"), "changed");
+    const h2 = computeInputHash(["a.txt"], tmpDir);
+    assert.notEqual(h1, h2);
+  });
+
+  it("changes when a file is deleted", () => {
+    writeFileSync(join(tmpDir, "c.txt"), "temp");
+    const h1 = computeInputHash(["c.txt"], tmpDir);
+    rmSync(join(tmpDir, "c.txt"));
+    const h2 = computeInputHash(["c.txt"], tmpDir);
+    assert.notEqual(h1, h2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addInputHash / extractInputHash
+// ---------------------------------------------------------------------------
+
+describe("addInputHash / extractInputHash", () => {
+  it("embeds hash after sha256 comment", () => {
+    const md =
+      "<!-- vigiles:sha256:abc123 compiled from X.spec.ts -->\n\n# Doc\n";
+    const result = addInputHash(md, "deadbeef12345678");
+    assert.ok(result.includes("<!-- vigiles:inputs:deadbeef12345678 -->"));
+    // sha256 line should still be first
+    assert.ok(result.startsWith("<!-- vigiles:sha256:"));
+  });
+
+  it("extracts embedded input hash", () => {
+    const md =
+      "<!-- vigiles:sha256:abc123 compiled from X.spec.ts -->\n<!-- vigiles:inputs:deadbeef12345678 -->\n\n# Doc\n";
+    const hash = extractInputHash(md);
+    assert.equal(hash, "deadbeef12345678");
+  });
+
+  it("returns null when no input hash present", () => {
+    const md =
+      "<!-- vigiles:sha256:abc123 compiled from X.spec.ts -->\n\n# Doc\n";
+    const hash = extractInputHash(md);
+    assert.equal(hash, null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkOutputHashFreshness
+// ---------------------------------------------------------------------------
+
+describe("checkOutputHashFreshness", () => {
+  it("returns fresh for hand-written file (no hash)", () => {
+    const result = checkOutputHashFreshness("# CLAUDE.md\n\nSome content.\n");
+    assert.equal(result.fresh, true);
+    assert.equal(result.mode, "output-hash");
+  });
+
+  it("returns fresh when hash matches", () => {
+    // Build a valid hashed file
+    const body = "# CLAUDE.md\n\nContent.\n";
+    const { createHash } = require("node:crypto");
+    const hash = createHash("sha256").update(body).digest("hex").slice(0, 16);
+    const content = `<!-- vigiles:sha256:${hash} compiled from CLAUDE.md.spec.ts -->\n\n${body}`;
+    const result = checkOutputHashFreshness(content);
+    assert.equal(result.fresh, true);
+  });
+
+  it("returns stale when hash mismatches", () => {
+    const content =
+      "<!-- vigiles:sha256:0000000000000000 compiled from CLAUDE.md.spec.ts -->\n\n# CLAUDE.md\n\nEdited.\n";
+    const result = checkOutputHashFreshness(content);
+    assert.equal(result.fresh, false);
+    assert.equal(result.mode, "output-hash");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkInputHashFreshness
+// ---------------------------------------------------------------------------
+
+describe("checkInputHashFreshness", () => {
+  let tmpDir: string;
+
+  before(() => {
+    tmpDir = makeTmpDir();
+    writeFileSync(join(tmpDir, "spec.ts"), "export default {};");
+    writeFileSync(join(tmpDir, "config.js"), "module.exports = {};");
+  });
+
+  after(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns stale when no input hash is stored", () => {
+    const content =
+      "<!-- vigiles:sha256:abc compiled from spec.ts -->\n\n# Doc\n";
+    const result = checkInputHashFreshness(content, ["spec.ts"], tmpDir);
+    assert.equal(result.fresh, false);
+    assert.equal(result.mode, "input-hash");
+  });
+
+  it("returns fresh when input hash matches", () => {
+    const files = ["spec.ts", "config.js"];
+    const hash = computeInputHash(files, tmpDir);
+    const content = `<!-- vigiles:sha256:abc compiled from spec.ts -->\n<!-- vigiles:inputs:${hash} -->\n\n# Doc\n`;
+    const result = checkInputHashFreshness(content, files, tmpDir);
+    assert.equal(result.fresh, true);
+  });
+
+  it("returns stale when input file changes", () => {
+    const files = ["spec.ts", "config.js"];
+    const hash = computeInputHash(files, tmpDir);
+    const content = `<!-- vigiles:sha256:abc compiled from spec.ts -->\n<!-- vigiles:inputs:${hash} -->\n\n# Doc\n`;
+
+    // Change an input file
+    writeFileSync(
+      join(tmpDir, "config.js"),
+      "module.exports = { changed: true };",
+    );
+
+    const result = checkInputHashFreshness(content, files, tmpDir);
+    assert.equal(result.fresh, false);
+  });
+
+  it("reports deleted files", () => {
+    writeFileSync(join(tmpDir, "temp.txt"), "exists");
+    const files = ["spec.ts", "temp.txt"];
+    const hash = computeInputHash(files, tmpDir);
+    const content = `<!-- vigiles:sha256:abc compiled from spec.ts -->\n<!-- vigiles:inputs:${hash} -->\n\n# Doc\n`;
+
+    rmSync(join(tmpDir, "temp.txt"));
+    const result = checkInputHashFreshness(content, files, tmpDir);
+    assert.equal(result.fresh, false);
+    assert.ok(result.changedFiles?.some((f) => f.includes("temp.txt")));
+  });
+});

--- a/src/freshness.test.ts
+++ b/src/freshness.test.ts
@@ -4,6 +4,8 @@ import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
+import { createHash } from "node:crypto";
+
 import {
   detectLockFiles,
   detectLinterConfigs,
@@ -370,7 +372,6 @@ describe("checkOutputHashFreshness", () => {
   it("returns fresh when hash matches", () => {
     // Build a valid hashed file
     const body = "# CLAUDE.md\n\nContent.\n";
-    const { createHash } = require("node:crypto");
     const hash = createHash("sha256").update(body).digest("hex").slice(0, 16);
     const content = `<!-- vigiles:sha256:${hash} compiled from CLAUDE.md.spec.ts -->\n\n${body}`;
     const result = checkOutputHashFreshness(content);

--- a/src/freshness.ts
+++ b/src/freshness.ts
@@ -1,0 +1,299 @@
+/**
+ * Freshness detection for compiled instruction files.
+ *
+ * Three modes:
+ * - "strict": recompile in memory, diff against existing output (zero false positives)
+ * - "input-hash": hash tracked input files, compare to stored fingerprint (fast)
+ * - "output-hash": existing behavior — only detects hand-edits to compiled .md
+ */
+
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import type { FreshnessMode } from "./types.js";
+import type { ClaudeSpec } from "./spec.js";
+
+// ---------------------------------------------------------------------------
+// Lock file detection
+// ---------------------------------------------------------------------------
+
+/** Known lock files, ordered by ecosystem then preference. */
+const KNOWN_LOCK_FILES: readonly string[] = [
+  // Node.js
+  "package-lock.json",
+  "yarn.lock",
+  "pnpm-lock.yaml",
+  "bun.lockb",
+  // Ruby
+  "Gemfile.lock",
+  // Python
+  "poetry.lock",
+  "uv.lock",
+  "pdm.lock",
+  "requirements.txt",
+  // Rust
+  "Cargo.lock",
+  // Go
+  "go.sum",
+  // PHP
+  "composer.lock",
+  // .NET
+  "packages.lock.json",
+  // Swift
+  "Package.resolved",
+  // Elixir
+  "mix.lock",
+];
+
+/** Known linter configuration files. */
+const KNOWN_LINTER_CONFIGS: readonly string[] = [
+  // ESLint
+  "eslint.config.mjs",
+  "eslint.config.js",
+  "eslint.config.ts",
+  "eslint.config.cjs",
+  ".eslintrc.json",
+  ".eslintrc.js",
+  ".eslintrc.yml",
+  ".eslintrc.yaml",
+  ".eslintrc.cjs",
+  // Stylelint
+  ".stylelintrc.json",
+  ".stylelintrc.js",
+  ".stylelintrc.yml",
+  ".stylelintrc.yaml",
+  "stylelint.config.js",
+  "stylelint.config.cjs",
+  "stylelint.config.mjs",
+  // Python
+  "pyproject.toml",
+  "ruff.toml",
+  ".pylintrc",
+  "setup.cfg",
+  // Rust
+  "Cargo.toml",
+  "clippy.toml",
+  ".clippy.toml",
+  // Ruby
+  ".rubocop.yml",
+  ".rubocop.yaml",
+];
+
+/**
+ * Detect lock files present at `basePath`.
+ * Returns all found (a project may have multiple ecosystems).
+ */
+export function detectLockFiles(basePath: string): string[] {
+  return KNOWN_LOCK_FILES.filter((f) => existsSync(resolve(basePath, f)));
+}
+
+/**
+ * Detect linter config files present at `basePath`.
+ */
+export function detectLinterConfigs(basePath: string): string[] {
+  return KNOWN_LINTER_CONFIGS.filter((f) => existsSync(resolve(basePath, f)));
+}
+
+// ---------------------------------------------------------------------------
+// Input discovery
+// ---------------------------------------------------------------------------
+
+export interface DiscoveredInputs {
+  /** All input file paths (relative to basePath), sorted. */
+  files: string[];
+  /** Which lock files were detected. */
+  lockFiles: string[];
+  /** Which linter configs were detected. */
+  linterConfigs: string[];
+}
+
+/**
+ * Discover all input files that affect a compiled spec's output.
+ *
+ * Categories:
+ * 1. Spec source file
+ * 2. Linter configuration files
+ * 3. Package manifest (package.json)
+ * 4. Lock files (per-ecosystem)
+ * 5. Referenced files from keyFiles
+ * 6. Generated types (.vigiles/generated.d.ts)
+ * 7. Extra files from freshnessInputs config
+ */
+export function discoverInputs(
+  specFile: string,
+  spec: ClaudeSpec,
+  basePath: string,
+  extraInputs?: string[],
+): DiscoveredInputs {
+  const files = new Set<string>();
+
+  // 1. Spec source
+  files.add(specFile);
+
+  // 2. Linter configs
+  const linterConfigs = detectLinterConfigs(basePath);
+  for (const cfg of linterConfigs) files.add(cfg);
+
+  // 3. Package manifest
+  if (existsSync(resolve(basePath, "package.json"))) {
+    files.add("package.json");
+  }
+
+  // 4. Lock files
+  const lockFiles = detectLockFiles(basePath);
+  for (const lf of lockFiles) files.add(lf);
+
+  // 5. Referenced files from keyFiles
+  if (spec.keyFiles) {
+    for (const filePath of Object.keys(spec.keyFiles)) {
+      files.add(filePath);
+    }
+  }
+
+  // 6. Generated types
+  if (existsSync(resolve(basePath, ".vigiles/generated.d.ts"))) {
+    files.add(".vigiles/generated.d.ts");
+  }
+
+  // 7. Extra configured inputs
+  if (extraInputs) {
+    for (const f of extraInputs) files.add(f);
+  }
+
+  const sorted = [...files].sort();
+  return { files: sorted, lockFiles, linterConfigs };
+}
+
+// ---------------------------------------------------------------------------
+// Input hash computation
+// ---------------------------------------------------------------------------
+
+const INPUT_HASH_RE = /^<!-- vigiles:inputs:([a-f0-9]+) -->\r?\n?/m;
+
+/**
+ * Compute a combined SHA-256 fingerprint of all input files.
+ * Missing files hash to "MISSING:<path>" so deletion changes the hash.
+ */
+export function computeInputHash(
+  inputFiles: string[],
+  basePath: string,
+): string {
+  const fileHashes = inputFiles.map((f) => {
+    const fullPath = resolve(basePath, f);
+    if (!existsSync(fullPath)) return `MISSING:${f}`;
+    const content = readFileSync(fullPath);
+    return createHash("sha256").update(content).digest("hex");
+  });
+  return createHash("sha256")
+    .update(fileHashes.join("\n"))
+    .digest("hex")
+    .slice(0, 16);
+}
+
+/** Embed input hash as an HTML comment in compiled markdown. */
+export function addInputHash(markdown: string, inputHash: string): string {
+  // Insert after the existing vigiles:sha256 comment (first line)
+  const lines = markdown.split("\n");
+  if (lines[0].startsWith("<!-- vigiles:sha256:")) {
+    lines.splice(1, 0, `<!-- vigiles:inputs:${inputHash} -->`);
+    return lines.join("\n");
+  }
+  // Fallback: prepend
+  return `<!-- vigiles:inputs:${inputHash} -->\n${markdown}`;
+}
+
+/** Extract stored input hash from compiled markdown. */
+export function extractInputHash(content: string): string | null {
+  const match = content.match(INPUT_HASH_RE);
+  return match?.[1] ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Freshness check result
+// ---------------------------------------------------------------------------
+
+export interface FreshnessResult {
+  fresh: boolean;
+  mode: FreshnessMode;
+  reason?: string;
+  /** Files that changed (input-hash mode only). */
+  changedFiles?: string[];
+}
+
+/**
+ * Check freshness of a compiled file using output-hash mode.
+ * Only detects hand-edits to the compiled markdown.
+ */
+export function checkOutputHashFreshness(content: string): FreshnessResult {
+  // Re-use existing hash verification
+  const hashLine = content.match(
+    /^<!-- vigiles:sha256:([a-f0-9]+) compiled from (.+) -->/,
+  );
+  if (!hashLine) {
+    return {
+      fresh: true,
+      mode: "output-hash",
+      reason: "No hash found (hand-written file)",
+    };
+  }
+  const expectedHash = hashLine[1];
+  const body = content
+    .replace(
+      /^<!-- vigiles:sha256:[a-f0-9]+ compiled from .+ -->\r?\n\r?\n?/,
+      "",
+    )
+    .replace(INPUT_HASH_RE, "");
+  const actualHash = createHash("sha256")
+    .update(body)
+    .digest("hex")
+    .slice(0, 16);
+  if (actualHash !== expectedHash) {
+    return {
+      fresh: false,
+      mode: "output-hash",
+      reason: "Compiled file was manually edited (hash mismatch)",
+    };
+  }
+  return { fresh: true, mode: "output-hash" };
+}
+
+/**
+ * Check freshness using input-hash mode.
+ * Compares stored input fingerprint against current file state.
+ */
+export function checkInputHashFreshness(
+  content: string,
+  inputFiles: string[],
+  basePath: string,
+): FreshnessResult {
+  const storedHash = extractInputHash(content);
+  if (!storedHash) {
+    return {
+      fresh: false,
+      mode: "input-hash",
+      reason: "No input hash found — run `vigiles compile` to generate one",
+    };
+  }
+
+  const currentHash = computeInputHash(inputFiles, basePath);
+  if (storedHash !== currentHash) {
+    // Report missing files (we can't identify other changes without
+    // storing per-file hashes, but missing files are obvious)
+    const changedFiles: string[] = [];
+    for (const f of inputFiles) {
+      if (!existsSync(resolve(basePath, f))) {
+        changedFiles.push(`${f} (deleted)`);
+      }
+    }
+
+    return {
+      fresh: false,
+      mode: "input-hash",
+      reason: "Inputs changed since last compile — run `vigiles compile`",
+      changedFiles: changedFiles.length > 0 ? changedFiles : undefined,
+    };
+  }
+
+  return { fresh: true, mode: "input-hash" };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,11 +63,26 @@ export interface RulesConfig {
   freshness?: RuleSeverity;
 }
 
-/** Full vigiles configuration. */
+/** Full vigiles configuration. Loaded from .vigilesrc.json. */
 export interface VigilesConfig {
+  // --- Validation ---
   ruleMarkers: MarkerType[];
   rules: Required<RulesConfig>;
   files: string[];
+
+  // --- Compilation ---
+  /** Maximum number of rules allowed per spec. */
+  maxRules?: number;
+  /** Maximum estimated tokens for compiled output. */
+  maxTokens?: number;
+  /** Maximum lines per prose section. */
+  maxSectionLines?: number;
+  /** Skip config-enabled checks, only verify rule exists in catalog. */
+  catalogOnly?: boolean;
+  /** Custom linter configs (rulesDir). */
+  linters?: Record<string, { rulesDir?: string | string[] }>;
+
+  // --- Freshness ---
   /** How to detect staleness. Default: "strict" (recompile and diff). */
   freshnessMode?: FreshnessMode;
   /** Extra files to track in input-hash mode (e.g., monorepo root lock file). */

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,11 +51,16 @@ export interface ValidatePathsResult {
 /** Rule severity: "warn" prints but exits 0, "error" fails, false disables. */
 export type RuleSeverity = "warn" | "error" | false;
 
+/** Freshness detection mode for the `freshness` rule. */
+export type FreshnessMode = "strict" | "input-hash" | "output-hash";
+
 export interface RulesConfig {
   /** Require .spec.ts for CLAUDE.md / AGENTS.md. Default: "warn". */
   "require-spec"?: RuleSeverity;
   /** Require .spec.ts for SKILL.md files. Default: false. */
   "require-skill-spec"?: RuleSeverity;
+  /** Detect stale compiled output. Default: "warn". */
+  freshness?: RuleSeverity;
 }
 
 /** Full vigiles configuration. */
@@ -63,6 +68,10 @@ export interface VigilesConfig {
   ruleMarkers: MarkerType[];
   rules: Required<RulesConfig>;
   files: string[];
+  /** How to detect staleness. Default: "strict" (recompile and diff). */
+  freshnessMode?: FreshnessMode;
+  /** Extra files to track in input-hash mode (e.g., monorepo root lock file). */
+  freshnessInputs?: string[];
 }
 
 /** Valid marker types for rule detection. */

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -424,6 +424,7 @@ describe("loadConfig", () => {
     assert.deepEqual(config.rules, {
       "require-spec": "warn",
       "require-skill-spec": "warn",
+      freshness: "warn",
     });
   });
 

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -58,6 +58,7 @@ const DEFAULT_FILES: string[] = ["CLAUDE.md"];
 const DEFAULT_RULES: Required<RulesConfig> = {
   "require-spec": "warn",
   "require-skill-spec": "warn",
+  freshness: "warn",
 };
 
 const DEFAULT_CONFIG: VigilesConfig = {


### PR DESCRIPTION
The ESLint section in SKILL.md was 8 lines of generic guidance. Now it
references a comprehensive eslint.md covering: plugin lookup table (11
plugins), AST node cheat sheet, ESTree selectors, type-aware rules via
@typescript-eslint/utils, auto-fix vs suggest safety, RuleTester patterns,
flat config registration, TS AST gotchas, monorepo edge cases, and a
decision table mapping PR comment patterns to the right approach
(no-restricted-syntax vs custom rule vs existing plugin).