### PR TITLE
Fix generate-types to require linter config before discovery

### DIFF
--- a/.vigiles/generated.d.ts
+++ b/.vigiles/generated.d.ts
@@ -83,13 +83,15 @@ declare module "vigiles/generated" {
     | "fmt"
     | "fmt:check";
 
-  /** 16 project files. */
+  /** 18 project files. */
   export type ProjectFile = 
     | "src/action.ts"
     | "src/cli.test.ts"
     | "src/cli.ts"
     | "src/compile.ts"
     | "src/evolve.ts"
+    | "src/freshness.test.ts"
+    | "src/freshness.ts"
     | "src/generate-types.ts"
     | "src/inline.test.ts"
     | "src/inline.ts"
@@ -178,6 +180,8 @@ declare module "vigiles/spec" {
       | "src/cli.ts"
       | "src/compile.ts"
       | "src/evolve.ts"
+      | "src/freshness.test.ts"
+      | "src/freshness.ts"
       | "src/generate-types.ts"
       | "src/inline.test.ts"
       | "src/inline.ts"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "vigiles",
-  "private": true,
+  "version": "2.0.0",
+  "description": "Compile .spec.ts files to instruction files (CLAUDE.md, AGENTS.md) with linter cross-referencing",
   "bin": {
-    "vigiles": "./dist/cli.js"
+    "vigiles": "dist/cli.js"
   },
   "main": "./dist/spec.js",
   "types": "./dist/spec.d.ts",

--- a/src/generate-types.ts
+++ b/src/generate-types.ts
@@ -16,6 +16,40 @@ import { execSync } from "node:child_process";
 import { globSync } from "glob";
 
 // ---------------------------------------------------------------------------
+// Linter config detection
+// ---------------------------------------------------------------------------
+
+function fileContainsSection(filePath: string, section: string): boolean {
+  if (!existsSync(filePath)) return false;
+  try {
+    return readFileSync(filePath, "utf-8").includes(section);
+  } catch {
+    return false;
+  }
+}
+
+function hasRuffConfig(basePath: string): boolean {
+  return (
+    existsSync(resolve(basePath, "ruff.toml")) ||
+    existsSync(resolve(basePath, ".ruff.toml")) ||
+    fileContainsSection(resolve(basePath, "pyproject.toml"), "[tool.ruff")
+  );
+}
+
+function hasPylintConfig(basePath: string): boolean {
+  return (
+    existsSync(resolve(basePath, ".pylintrc")) ||
+    existsSync(resolve(basePath, "pylintrc")) ||
+    fileContainsSection(resolve(basePath, "pyproject.toml"), "[tool.pylint") ||
+    fileContainsSection(resolve(basePath, "setup.cfg"), "[pylint")
+  );
+}
+
+function hasRubocopConfig(basePath: string): boolean {
+  return existsSync(resolve(basePath, ".rubocop.yml"));
+}
+
+// ---------------------------------------------------------------------------
 // Linter rule discovery
 // ---------------------------------------------------------------------------
 
@@ -93,6 +127,7 @@ function discoverStylelintRules(basePath: string): DiscoveredRules | null {
 
 function discoverRuffRules(basePath: string): DiscoveredRules | null {
   try {
+    if (!hasRuffConfig(basePath)) return null;
     execSync("which ruff", { stdio: "ignore" });
     const dummyPath = resolve(basePath, "dummy.py");
     const output = execSync(`ruff check --show-settings ${dummyPath}`, {
@@ -121,6 +156,7 @@ function discoverRuffRules(basePath: string): DiscoveredRules | null {
 
 function discoverPylintRules(basePath: string): DiscoveredRules | null {
   try {
+    if (!hasPylintConfig(basePath)) return null;
     execSync("which pylint", { stdio: "ignore" });
     const output = execSync("pylint --list-msgs-enabled", {
       encoding: "utf-8",
@@ -152,6 +188,7 @@ function discoverPylintRules(basePath: string): DiscoveredRules | null {
 
 function discoverRubocopRules(basePath: string): DiscoveredRules | null {
   try {
+    if (!hasRubocopConfig(basePath)) return null;
     execSync("which rubocop", { stdio: "ignore" });
     const output = execSync(
       "rubocop --list-target-files --show-cops 2>/dev/null | head -500",
@@ -178,9 +215,9 @@ function discoverRubocopRules(basePath: string): DiscoveredRules | null {
 
 function discoverClippyRules(basePath: string): DiscoveredRules | null {
   try {
-    execSync("which cargo", { stdio: "ignore" });
     const cargoPath = resolve(basePath, "Cargo.toml");
     if (!existsSync(cargoPath)) return null;
+    execSync("which cargo", { stdio: "ignore" });
     // Clippy doesn't have a good "list enabled lints" command.
     // We read Cargo.toml [lints.clippy] section for explicit config,
     // and include default warn/deny lints from clippy -W clippy::all


### PR DESCRIPTION
## Summary
- `generate-types` now checks for linter config files before running CLI-based linter discovery (ruff, pylint, rubocop, clippy)
- Previously, any linter binary on `$PATH` would have all its rules added to `generated.d.ts` — even if the project doesn't use that linter
- Also removes `private: true` and adds version/description for npm publish (published as `vigiles@2.0.0`)

## Test plan
- [x] All 307 tests pass
- [x] `vigiles generate-types` now only emits ESLint rules for this project (no ruff/pylint/rubocop pollution)
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)