### PR TITLE
fix: restrict npm package to runtime files via files allowlist

### DIFF
--- a/.vigiles/generated.d.ts
+++ b/.vigiles/generated.d.ts
@@ -83,7 +83,7 @@ declare module "vigiles/generated" {
     | "fmt"
     | "fmt:check";
 
-  /** 30 project files. */
+  /** 33 project files. */
   export type ProjectFile = 
     | "src/action.ts"
     | "src/cedar.test.ts"
@@ -95,6 +95,9 @@ declare module "vigiles/generated" {
     | "src/doc-refs.test.ts"
     | "src/doc-refs.ts"
     | "src/evolve.ts"
+    | "src/frontmatter.test.ts"
+    | "src/frontmatter.ts"
+    | "src/generate-schema.ts"
     | "src/generate-types.ts"
     | "src/hash.ts"
     | "src/inline.test.ts"
@@ -197,6 +200,9 @@ declare module "vigiles/spec" {
       | "src/doc-refs.test.ts"
       | "src/doc-refs.ts"
       | "src/evolve.ts"
+      | "src/frontmatter.test.ts"
+      | "src/frontmatter.ts"
+      | "src/generate-schema.ts"
       | "src/generate-types.ts"
       | "src/hash.ts"
       | "src/inline.test.ts"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,16 @@
     "./compile": "./dist/compile.js",
     "./linters": "./dist/linters.js"
   },
+  "files": [
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
+    "!dist/**/*.test.js",
+    "!dist/**/*.test.d.ts",
+    "action.yml",
+    ".claude-plugin",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "tsc",
     "test": "npm run build && node --test dist/spec.test.js dist/validate.test.js dist/cli.test.js dist/proofs.test.js dist/inline.test.js dist/sidecar.test.js dist/coverage.test.js dist/session.test.js dist/orphans.test.js dist/cedar.test.js dist/doc-refs.test.js dist/frontmatter.test.js",


### PR DESCRIPTION
## Problem

The published npm tarball ships **everything in the repo** — `logo.png` (1.5 MB), all of `research/`, `docs/`, `fixtures/`, `src/` + `*.test.ts`, and `dist/*.test.js` + `*.map` files. That's **1.9 MB packed / 3.5 MB unpacked** for what is a small CLI + library.

(Surfaced from the `npm publish` step of the release pipeline, which lists the tarball contents.)

## Fix

Add a `files` allowlist to `package.json`:

```json
"files": [
  "dist/**/*.js",
  "dist/**/*.d.ts",
  "!dist/**/*.test.js",
  "!dist/**/*.test.d.ts",
  "action.yml",
  ".claude-plugin",
  "README.md",
  "LICENSE"
]
```

Source maps are excluded by omission (`*.js`/`*.d.ts` patterns don't match `*.map`); test artifacts are excluded by negation.

## Result (`npm pack --dry-run`)

| | Before | After |
|---|---|---|
| Packed | 1.9 MB | **87.9 kB** |
| Unpacked | 3.5 MB | **335.6 kB** |
| Files | ~200+ | 51 |

Ships: `dist` runtime + `.d.ts` (no tests/maps), `.claude-plugin/`, `action.yml`, `README`, `LICENSE`, `package.json`. The `bin` (`dist/cli.js`) and `main`/`exports` entry points are all included.

No behavior change — purely what gets packed.

---
_Generated by [Claude Code](https://claude.ai/code/session_016wQBCaTZpTwAM98KQKkWLt)_