### PR TITLE
docs: rebuild the README front door and refresh HANDOFF

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -8,103 +8,101 @@
 > request). A **Stop hook** nudges you at ≥5 commits without a refresh.
 >
 > ⚠️ **THIS FILE IS PUBLIC** (open-source repo). NO STRATEGY here — business
-> direction / monetization / competitive framing live ONLY in the `startup/`
-> vault. HANDOFF may POINT to the vault, never describe its contents. (See the
-> `doc-tiers` rule.)
+> direction, monetization, competitive framing, and personal plans live ONLY in the
+> `startup/` vault. HANDOFF may POINT to the vault, never name or describe its
+> contents (naming a topic still reveals it). (See the `doc-tiers` rule.)
 
 ## RESUME HERE
 
-**Branch `claude/unencrypted-filenames-commits-f4lj9l`.** No PR opened.
+**Branch `claude/docs-linting-accuracy-4psb1g`.** No PR opened (open one only if asked).
 
-**VAULT SECURITY FIX: DONE.** All 20 startup/ docs renamed from descriptive names
-to opaque IDs (s01–s20). vault README.md + CLAUDE.md indexes updated to s-numbers.
-Root CLAUDE.md gained `vault-commit-hygiene` rule (recompiled from spec). HANDOFF
-scrubbed of vault filenames. Going-forward hygiene only — old commit history still
-has descriptive names (cleaning requires `git filter-repo` + force-push; separate op).
+**README OVERHAUL: DONE + pushed** (several commits this session). The front door was
+rebuilt for clarity after repeated "it's confusing / so much stuff / what even is it"
+feedback. **Product positioning locked (public-safe product/messaging, not business
+strategy):**
 
-**★ PIVOT GATE CLEARED → PHASE B (2026-07-03).** The disaster-battery benchmark (s31/s32 plan) RAN
-and PASSED both gates. Result in vault `s34` (summary) + `s35` (full detail: table + the exact
-hardened `gate-v2.mjs` scorer + the tightened `gate-v3.mjs`). Public-safe headline: community AI-coding
-safety hooks overwhelmingly fail — median 0/7 blocked, ~79% fail a disaster they explicitly claim to
-guard. Whole run happened IN-SESSION via the sourcegraph+raw workaround
-(`research/scoped-session-github-access.md`). Direction (vault s26/s30/s31): objective = US visa +
-virality ≫ business; ship the SECURITY REPORT ("The State of Agentic Coding Security 2026"); vigiles =
-engine. Report draft started in vault `s36`.
-**NEXT CONCRETE STEPS (in order):** (1) run the TIGHTENED `gate-v3.mjs` (in vault s35 — needs an
-interactive session; executing foreign hooks trips the auto-mode classifier, so a human must approve)
-→ locks the airtight per-claim number; (2) widen the corpus toward N≥100 (more sourcegraph queries +
-awesome-\* lists; recover the 42 unfetched script-refs); (3) author the report (s36) + arXiv twin; queue
-responsible-disclosure fix-PRs. NOTHING PUBLIC until the tightened number is locked (a deflated number
-hurts the visa). The benchmark scraper/scorer is NOT committed (telegraphs the launch) — it lives in
-vault s35; re-create from there or from the public technique doc.
-**PENDING FROM FOUNDER:** the `/goal` prompt format (short objective vs full block — unanswered) so the
-next session can carry a correct persistent goal.
+- vigiles is **a TOOL you run** (ESLint / Lighthouse / `npm audit` class), NOT a
+  framework and NOT a "collection of libs". The FAQ says this outright — it's the #1
+  thing that scared people off.
+- Front door flow: **felt-pain hook → Lighthouse-style A–F report card → 3 real
+  (anonymized) proofs → the `audit`/`lint`/`test`/`eval` verb-map** ("one tool, four
+  verbs", framed _vibes → verified_).
+- **Codex/AGENTS.md is first-class** (instruction-neutral nouns everywhere).
+- **Plain language**: "harness" defined on first use; "specs" made concrete
+  (`CLAUDE.md.spec.ts` + init→compile→CLAUDE.md); security is ONE dev-native gotcha
+  proof, never the brand.
+- The **README top HTML comment holds all the direction rules — READ IT before
+  editing the README** (tagline/proof-order/Codex/audit-vs-lint scope all pinned there).
 
-**OPEN FOLLOW-UPS (from prior session, still pending):**
+**Method (repeatable):** validated via a **6-persona cold-read** (`review-docs` skill:
+newcomer / power-user / plugin-author / skeptical-senior / decision-maker / Codex) +
+two **Fable** positioning consults. Personas landed 4/5 except Codex 3/5; the last pass
+targeted the Codex ceiling + the plain-language stumbles. A re-run to confirm scores
+moved was offered, not yet done.
 
-1. ~~`research/roadmap.md` ~37 dangling refs~~ **RESOLVED / was stale (verified 2026-07):**
-   `roadmap.md` has ZERO broken markdown links and ZERO links INTO the vault — the `startup/`
-   mentions are all compliant PROSE pointers ("see the private `startup/` vault"), which
-   `doc-tiers` allows. Nothing to fix. (roadmap still has strategic Explore/GTM prose @~500/748/830
-   that's borderline but public-safe; de-strategize only if a rule tightens.)
-2. **Broader research-corpus de-strategization** — `research/README.md` "Strategy & bets"
-   leftovers, `research/CLAUDE.md` Scope text. Lower urgency (already-public).
+**Business / strategy direction: SEE THE VAULT.** The active initiative, its next
+concrete steps, and all strategy live ONLY in `startup/` (unlock, then read
+`startup/README.md` for the ID→name index). Do NOT restate — or name the topics of —
+any of it in this file or any public doc.
 
-**Business direction: SEE THE VAULT.** All competitive/monetization strategy + the leading thesis
-live in `startup/` (vault README.md has the ID→name index). Do NOT restate any of it here.
+**⚠️ CLEANUP DEBT (this session found it):** the PREVIOUS HANDOFF committed on `main`
+LEAKED vault-tier strategy into this public file (specifics deliberately omitted here).
+Scrubbed from HEAD this session. **History still holds it** (commit 74d5f15 and earlier)
+— a full purge needs `git filter-repo` + force-push, the same separate op still owed for
+the old vault descriptive filenames.
 
-**Technical direction (public-safe):** vigiles = ONE LOOP — declare (typed spec) → check reality,
-via four instruments: VERIFY (lint/cross-ref), GATE (compiled hooks), MEASURE (evals on your sub),
-OBSERVE (local `.vigiles/runs.jsonl` flight recorder). Full record: `CLAUDE.md` +
-`research/harness-observability-direction.md`.
+**OPEN FOLLOW-UPS (public-safe, still pending):**
 
-### What landed this session (all pushed; suite green except known env-only dialect-drift)
+1. `research/roadmap.md` de-strategization — some borderline Explore/GTM prose remains;
+   de-strategize only if a rule tightens (currently public-safe).
+2. `research/README.md` "Strategy & bets" + `research/CLAUDE.md` Scope text — lower
+   urgency (already public, just tone).
 
-- **VAULT FILENAME SECURITY** — all 20 vault docs renamed to opaque IDs (s01–s20);
-  vault README.md + CLAUDE.md indexes updated; CLAUDE.md.spec.ts gained `vault-commit-hygiene`
-  rule; HANDOFF scrubbed of vault filenames; vault unlocked + re-encrypted on commit.
-- **PIVOT GATE RESEARCH** — 4-agent research fan-out (Sonnet) + Opus synthesis; full raw
-  findings (gate-raw-a1–a4) + synthesis saved to vault. Gate verdict: CONDITIONAL-GO.
-- **DEEP-DIVE RESEARCH (later same day)** — multiple Sonnet fan-outs (VC/YC keyword landscape,
-  uncovered funds, demand-side buyer+analyst validation, distro delta) → vault `s21`–`s23`
-  (synthesis + appendix), plus a personal-strategy doc `s24`. Strategy stays vaulted.
-- **STRATEGY CONVERGENCE (same day, extended)** — further Sonnet fan-outs (open-harness expansion,
-  curation/adoption-intelligence, naming, verifier-vs-framework) → vault `s25`–`s29`. Direction
-  converged (consolidated in `s26`, refined in `s29`). No code changed; all strategy vaulted.
-- **Earlier sessions:** capability-diff PR comment shipped; observe layer built; doc-tiers
-  rule fixed; 41-company competitor research vaulted; 6 research docs migrated to vault.
+**Technical direction (public-safe):** vigiles = ONE LOOP — declare (typed spec) → check
+reality — via four instruments: VERIFY (lint/cross-ref), GATE (compiled hooks), MEASURE
+(evals on your sub), OBSERVE (local `.vigiles/runs.jsonl` flight recorder). Full record:
+`CLAUDE.md` + `research/harness-observability-direction.md`.
+
+### What landed this session (all pushed; suite green)
+
+- **README rebuilt** end-to-end (positioning above). fmt green, all links + `vigiles
+<cmd>` refs resolve, body ~187 lines, footnotes balanced. README-only diffs.
+- Fixed a real accuracy bug: **`audit` vs `lint` scope** now told ONE consistent way
+  (lint = CI gate on the deterministic checks; audit = same + Safety ring + two opt-in
+  live checks + the report). Don't reintroduce "lint is refs-only" or "lint gates the
+  trifecta Safety flag".
+- **HANDOFF.md scrubbed** of leaked strategy (this file).
 
 ### ALSO OPEN (separate track) + Gotchas
 
 - **PR #54 on `claude/haretrail-dogfood-pvdo9t`** — watched by cron `5438c724`. Merge = user's call.
 - **VAULT (`startup/`)** git-crypt, LOCKED at session start → `apt-get install -y git-crypt` +
-  `git-crypt unlock <keyfile>` with the user's base64 key; verify a committed blob is `\0GITCRYPT`.
-  Vault files are in `.prettierignore` (no fmt needed); a committed blob must read `\0GITCRYPT`.
-  **⚠️ `git mv` INTO `startup/` DOES NOT ENCRYPT** (reuses the plaintext blob) — after moving,
-  `git add --renormalize startup/` then VERIFY `git show HEAD:startup/<f>.md | head -c9`=`\0GITCRYPT`.
-  **FILENAMES ARE PUBLIC** — use opaque IDs (s01.md, s02.json, …); the mapping lives in `startup/README.md`.
-  **COMMIT MESSAGES ARE PUBLIC** — use generic messages like `chore: vault` for vault-only changes.
-- **SCOPED-SESSION GITHUB ACCESS + the in-session cross-repo-search WORKAROUND → see the PERMANENT record
-  `research/scoped-session-github-access.md`.** TL;DR: the GitHub API is token-bound to `zernie/vigiles`
-  (cross-repo `search/code` refused regardless of token/network — it's the proxy, not a scope you can fix);
-  BUT cross-GitHub DISCOVERY works in-session via **sourcegraph streaming API + `raw.githubusercontent`**
-  (proven: pulled 148 real hook files, no token/laptop). Only a token-authenticated GitHub-API scrape still
-  needs an external shell. Full mechanics + snippet + gotchas live in that research doc, not here.
+  `base64 -d key.b64 > key.bin && git-crypt unlock key.bin` with the user's base64 key.
+  It was UNLOCKED this session for direction context; nothing from it entered public files;
+  it re-locks next session. Vault files are in `.prettierignore`; a committed blob must read `\0GITCRYPT`.
+  **⚠️ `git mv` INTO `startup/` DOES NOT ENCRYPT** — after moving, `git add --renormalize startup/`
+  then VERIFY `git show HEAD:startup/<f>.md | head -c9`=`\0GITCRYPT`.
+  **FILENAMES + COMMIT MESSAGES ARE PUBLIC** — opaque IDs (s01.md…); generic `chore: vault` messages.
+- **SCOPED-SESSION GITHUB ACCESS + cross-repo-search WORKAROUND → `research/scoped-session-github-access.md`.**
+  GitHub API is token-bound to `zernie/vigiles`; cross-GitHub discovery works in-session via the
+  sourcegraph streaming API + `raw.githubusercontent`. Full mechanics live in that doc.
 - `CLAUDE.md` (root + src/ + core/ + research/) COMPILED from `.spec.ts` — edit the spec + recompile
   (`node dist/cli.js compile <spec>`), NEVER hand-edit. Deleting a keyFiles-listed file → remove its
   keyFiles line first or compile FAILS.
 - RUN ESLINT on new files (`no-confusing-void-expression`, unused imports = ERRORS; `[...str]`→Array.from).
-- `dialect-drift.test.ts` fails LOCALLY (installed claude-code vs pinned 2.1.187); CI pins it. Env-only.
+- `dialect-drift.test.ts` fails LOCALLY (installed claude-code vs pinned version); CI pins it. Env-only.
 - Commits/PR: NO session links / NO raw model-id strings. Conventional-Commit titles.
-- **WORKFLOW FRAGILITY (post-mortem):** wide fan-out self-throttles on ONE rate-limit bucket; and
-  SESSION-COMPACTION INTERRUPT kills a background workflow. FIX: batch (2×2 = peak 2), narrow+fast.
+- **WORKFLOW FRAGILITY:** wide fan-out self-throttles on ONE rate-limit bucket; session-compaction
+  interrupt kills a background workflow. FIX: batch (2×2 = peak 2), narrow+fast. (6 background
+  subagents at once worked fine this session for the persona reads.)
 
 ### Decisions of record (don't relitigate)
 
-- Repo is PUBLIC → strategy is VAULT-ONLY (doc-tiers rule fixed). HANDOFF/research/CLAUDE.md = public.
+- Repo is PUBLIC → strategy is VAULT-ONLY (`doc-tiers`). HANDOFF/research/CLAUDE.md/README = public.
+- **README = a TOOL you run, not a framework**; pain-first `vibes → verified`; Codex equal to
+  Claude Code; security is a proof not the brand; the 2/7→7/7 hook battery stays PARKED for launch.
 - Vault filenames MUST be opaque IDs; commit messages for vault changes MUST be generic.
 - Capability-diff PR comment shipped; observe layer built (frozen). Guards KEPT (hidden runtime kind).
-- Competitor research (41 cos) + synthesis + distro thesis are vaulted; the LEADING direction is in the vault.
 
 ## Don't re-read unless the task needs it
 

--- a/README.md
+++ b/README.md
@@ -1,96 +1,76 @@
 <!--
   README DIRECTION — read before editing; keep changes aligned.
   This file is the FRONT DOOR + a marketing asset for someone who already lives
-  in Claude Code / Codex. Optimize for a phone-skimmer.
+  in Claude Code / Codex. Optimize for a phone-skimmer who should come away
+  understanding WHAT IT IS and wanting to run it — never scared off.
 
-  TAGLINE = VERIFY-FIRST (decided 2026-07): "Catch the silent breakage in your
-  Claude Code & Codex setup" + subhead "verify your CLAUDE.md, skills, and hooks
-  are real — and prove they actually work." Lead with references-are-real (the
-  unique catch only vigiles makes); test/observe fold in AFTER. Do NOT revert to
-  the old test-first "tests your skills never had" tagline. Stay coding-scoped
-  (name CC/Codex + CLAUDE.md/skills/hooks) so it's never mistaken for a
-  general-agent tool. NOT "observability" as the headline (it undersells verify +
-  reads as the general-app category).
+  HOOK = "VIBES → VERIFIED" (founder direction 2026-07). The bold tagline is the
+  dev-native emotional truth: "Your AI agent's harness is running on vibes"
+  (untested + unverified by default). It's CRAFT/self-aware bait, NOT enterprise
+  fear — this is an OSS dev tool, not a security product. The tagline draws the
+  eye; the verify-first SUBHEAD keeps the substance ("verify your CLAUDE.md,
+  skills, and hooks are real — and prove they work"). Do NOT revert to the old
+  test-first "tests your skills never had" tagline. Stay coding-scoped (name
+  CC/Codex + CLAUDE.md/AGENTS.md/skills/hooks) so it's never mistaken for a
+  general-agent tool. NOT "observability" as the headline.
 
-  SPINE = CONCEPT 5 (proof/demo-led). Lead with REAL, screenshotable catches on
-  plugins people actually ship, THEN explain the mechanism. The proofs are not
-  illustrative — every block traces to a real dogfood run captured in
-  research/dogfood/. THREE COMMUNITY catches, anonymized (2026-06-29: Proof 1 is now a
-  lethal-trifecta exfil path → Safety 80, from madappgang's `tester` shown as
-  "my-plugin" — added to pay off the new Safety-ring hero; Proof 2 a skill-description
-  collision → wrong-skill-fires (claude-flow, Triggering F); Proof 3 an
-  AskUserQuestion-never-available tool) — all real GRADED/structural defects that
-  REPRODUCE on current main. NEVER replace a real catch with a fabricated one. (The
-  earlier Proof 1 was a missing-SKILL.md/Truthfulness catch, swapped 2026-06-28: its
-  source (superpowers) is clean on current main and NO reproducible dead-file-ref
-  exists in popular OSS — those are an adopt+strengthen payoff, see
-  research/oss-audit-render-findings.md.)
+  CATEGORY = A TOOL YOU RUN, not a framework, not a lib-collection. The analogues
+  are ESLint / Lighthouse / npm audit: one command, a report, an optional CI gate.
+  The FAQ says this outright ("Is this a framework?") because it's the #1 thing
+  that scares people off. The library/subpath exports are the automation door for
+  the 5% — never the pitch.
 
-  WHY ONLY TWO (decided 2026-06-28): the earlier Proofs 3-4 leaned on
-  pr-review-toolkit's "review agents inherit all tools" as an official-plugin
-  defect. But inherit-all (a subagent with no `tools:` line) is now ADVISORY, not a
-  graded penalty — omitting the tool contract is a near-universal, legitimate
-  authoring style (an OSS sweep of 122 plugins found 109 whose only finding was
-  this), so penalizing it cried wolf. With that change the official plugins are all
-  a clean A, so a "even Anthropic has bugs" proof would be dishonest — Proofs 3-4
-  were DROPPED rather than reframed. The leaderboard feature still exists; it just
-  isn't a headline proof.
+  SPINE = proof/demo-led. Lead with REAL, screenshotable catches on plugins people
+  actually ship, THEN the mechanism. Every proof traces to a real dogfood run in
+  research/dogfood/ — NEVER fabricate one. PROOF ORDER = most-RELATABLE first
+  (a broken tool ref → a skill collision → the security gotcha last as the "and
+  even THIS" bite). Security is ONE dev-native GOTCHA proof, framed as craft
+  ("the tool your agent thinks it has and doesn't", "it can quietly leak your
+  secrets"), NEVER as enterprise/compliance/national-interest framing and NEVER
+  the brand — if it reads as "a security scanner" the other ~80% (references,
+  triggering, testing) vanishes. Current proofs, anonymized: (1) an
+  AskUserQuestion-never-available tool; (2) a skill-description collision
+  (Triggering F); (3) a lethal-trifecta exfil path (Safety). All real, reproduce
+  on current main.
 
-  DON'T SHAME OSS: community catches are real but ANONYMIZED in public copy (no
-  obra/superpowers, madappgang by name) — real names live only in research/dogfood/.
-  If an official/vendor proof returns, punch UP (name Anthropic's own); never name a
-  volunteer's repo to show its bug.
+  FALSE CONFIDENCE is the coined term of art (a guard that looks like it works
+  and silently doesn't) — defined once in the Test section, citable, let it recur.
 
-  1. LEAD WITH BENEFITS / the reader's CONCRETE PAIN, never an apology, caveat, or
+  FUNNEL: "How it works" OPENS with the audit/lint/test/eval verb-map table (what
+  it checks / needs-a-model? / when) — the load-bearing "one tool, not four" fix
+  (all 6 README-review personas named it their #1 change). KEEP it + the
+  "audit + lint are one engine, two outputs" reconciliation. Frame it as
+  vibes → verified.
+
+  DON'T SHAME OSS: community catches are real but ANONYMIZED (no obra/superpowers,
+  madappgang, claude-flow by name) — real names live only in research/dogfood/.
+  Punch UP only (name Anthropic's own) if an official proof ever returns.
+
+  Guard / compiled hooks + the 2/7→7/7 disaster battery are PARKED FOR LAUNCH
+  (see research/roadmap.md) — do NOT make the battery the hero here.
+
+  RULES:
+  1. LEAD WITH BENEFITS / the reader's CONCRETE PAIN, never an apology or
      competitor. A bolded lead-in is the first thing read — make it the hook/win.
-     End a section on the win, not the trade-off. A paragraph is ≤ ~3 lines.
-  2. PROOF FIRST, mechanism second. The three instruments (Lint/Test/Eval) come
-     AFTER the proof stack as "how it does it", not as a competing front door.
-     "How it works" OPENS with the audit/lint/test/eval verb-map table (what it
-     checks / needs-a-model? / when) — this is the load-bearing "one tool, not
-     four" fix (all 6 README-review personas named it their #1 change); KEEP it,
-     and keep the "audit + lint are one engine, two outputs" reconciliation.
-  2b. INSTRUCTION-NEUTRAL NOUNS: body copy says CLAUDE.md *or* AGENTS.md (never
-     CLAUDE.md alone) so Codex readers aren't second-class; the Lint header is
-     "your instructions stop lying", and Codex is surfaced in the intro + Quick
-     start, NOT only inside <details>. Don't revert headers to CLAUDE.md-only.
-  3. SPEC-FIRST IS THE DEFAULT but easy — `init` ADOPTS your CLAUDE.md into a spec,
-     skills edit it, you rarely hand-write .spec.ts. Give it ONE home (Quick start),
-     not five scattered mentions. `eject` always reverses. Inline markdown is the
-     zero-TS floor.
-  4. Guard / compiled hooks is PARKED FOR LAUNCH (see research/roadmap.md). Live set
-     is Lint/Test/Eval. Do NOT make the 2/7→7/7 battery the hero — re-add post-HN.
-  5. SCANNABLE + SHORT — ~200-line cap; punchy cells, bullets, runnable blocks.
-     Push depth into docs/ and LINK it.
-  6. NO INTERNAL VOCABULARY (moat / measurement-authority / flywheel) and NO
-     research/ links — name the user benefit.
-  7. ASSETS: the hero vigiles-audit.png is a REAL current report (a community
-     plugin rendered as "my-plugin" to anonymize) — C 72 with five rings, the
-     SAFETY ring (80) flagging a subagent holding all three lethal-trifecta legs
-     (a prompt-injection exfil path) + an inline subagent-tool-contract fix; the
-     dramatic Safety catch is the whole point of leading with this report (chose
-     the "bite" over a clean A 92 on 2026-06-29). No dialect-drift banner (HTML
-     report is terminal-banner-free by design). Re-render via headless Chromium on
-     the React report if the UI changes (recipe: copy a trifecta-bearing plugin to
-     my-plugin/, `node dist/cli.js audit my-plugin --no-json --no-serve`,
-     headless_shell `--window-size=820,1180 --force-device-scale-factor=2
-     --screenshot` on vigiles-report.html, then `rm -rf my-plugin
-     vigiles-report.html`). (vigiles-demo.gif was removed
-     from Proof 1 — it rendered as a frozen half-typed terminal and was redundant
-     with the code block; if a lint demo returns, it belongs in the Lint section
-     with a non-frozen asset.)
-
-  READABILITY (the 2026-06-29 pass — why this reads the way it does):
-  A. ONE bold per block, on the single phrase the eye should catch. Bold
-     everywhere = bold nowhere. Link CTAs may stay bold (they're navigation).
-  B. ONE idea per sentence. No em-dash clause-chains, no stacked parentheticals.
-     If a clause needs a paren, cut it or give it its own line.
-  C. PLAIN words in every LEAD; push jargon (rings, recall/precision,
-     interceptTools, selector, deterministic) into the linked docs. A skimmer who
-     lives in Claude Code still may not know the vocabulary.
-  D. SHOW via the proofs/code blocks; don't stack adjectives ("real, popular,
-     free, model-less") on top of what the block already proves.
-  E. SELL the outcome before the mechanism; the instruments come AFTER the proofs.
+     A paragraph is ≤ ~3 lines.
+  2. INSTRUCTION-NEUTRAL NOUNS: body copy says CLAUDE.md *or* AGENTS.md (never
+     CLAUDE.md alone); Codex surfaced in intro + Quick start, not only <details>.
+  3. SPEC-FIRST IS THE DEFAULT but easy — `init` ADOPTS your instructions into a
+     spec, skills edit it, you rarely hand-write .spec.ts. One home (Quick start).
+     `eject` always reverses.
+  4. SCANNABLE + SHORT — ~220-line body cap; punchy cells, bullets, runnable
+     blocks. Push depth into docs/ and LINK it.
+  5. NO INTERNAL VOCABULARY (moat / measurement-authority / flywheel), NO
+     research/ links, NO enterprise/national-interest framing — name the user
+     benefit. ONE bold per block. ONE idea per sentence.
+  6. ASSETS: the hero vigiles-audit.png is a REAL current report (a community
+     plugin rendered as "my-plugin") — C 72, five rings. It's the Lighthouse
+     report-card screenshot = the shareable artifact; the report card, not the
+     Safety ring, is the point. Re-render via headless Chromium on the React
+     report if the UI changes (recipe: copy a plugin to my-plugin/,
+     `node dist/cli.js audit my-plugin --no-json --no-serve`, headless_shell
+     `--window-size=820,1180 --force-device-scale-factor=2 --screenshot` on
+     vigiles-report.html, then `rm -rf my-plugin vigiles-report.html`).
 -->
 
 <p align="center">
@@ -100,7 +80,7 @@
 <h1 align="center">vigiles</h1>
 
 <p align="center">
-  <strong>Catch the silent breakage in your Claude Code &amp; Codex setup.</strong>
+  <strong>Your AI agent's harness is running on vibes.</strong>
 </p>
 
 <p align="center">
@@ -115,27 +95,27 @@
 
 ---
 
-**Your skills, hooks, and instructions are your agent's harness.** You wrote all of it. Nothing checks any of it.
+**You stopped vibe-coding. Your harness didn't.**
 
-A subagent (a helper your agent hands work to) wired to a tool that doesn't exist. A hook that looks like it blocks and doesn't. Two skills the agent can't tell apart. It all looks fine, and it breaks silently mid-task.
+The CLAUDE.md, skills, and hooks meant to keep your agent on track are themselves unchecked — nobody verified they're real, nobody tested they work. That's not a system. That's vibes.
 
-vigiles[^name] checks your harness is _real_, not just well-formed — for Claude Code (`CLAUDE.md`) and Codex (`AGENTS.md`) alike:
+And vibes break silently mid-task: a subagent wired to a tool that doesn't exist, a hook that looks like it blocks and doesn't, two skills the agent can't tell apart. It all looks fine right up until it doesn't.
+
+vigiles[^name] checks your harness is _real_, not just well-formed — Claude Code (`CLAUDE.md`) and Codex (`AGENTS.md`) alike. One command, no key, no config, safe on any repo:
 
 ```bash
 npx vigiles audit
 ```
 
-No key, no config, safe on any repo. Here's what it caught on plugins people actually
-ship. ↓
+Here's what it caught on plugins people actually ship. ↓
 
 ## What it caught
 
 <p align="center">
-  <img src="vigiles-audit.png" width="760" alt="vigiles audit report scoring my-plugin C (72/100): five categories scored A–F — Truthfulness, Triggering, Structure, Safety, Tested — with the Safety category flagging a subagent that holds all three lethal-trifecta legs (a prompt-injection exfil path), plus an inline fix card for a subagent declaring a tool that doesn't exist" />
+  <img src="vigiles-audit.png" width="760" alt="vigiles audit report scoring my-plugin C (72/100): five categories scored A–F — Truthfulness, Triggering, Structure, Safety, Tested — with an inline fix card for a subagent declaring a tool that doesn't exist" />
 </p>
 
-**Like Google's Lighthouse, but for your agent harness.** Five categories, each scored
-A–F, every fix shown inline:
+**Like Google's Lighthouse, but for your agent harness.** One command grades it A–F across five categories, every fix shown inline:
 
 - **Truthfulness** — do the references resolve?
 - **Triggering** — do skills fire, without colliding?
@@ -143,22 +123,16 @@ A–F, every fix shown inline:
 - **Safety** — any way for the agent to leak your data?
 - **Tested** — does the harness ship tests?
 
-It runs locally and only reads, so it's safe on any repo and the same on every OS.
-**[Audit a harness →](docs/for-plugin-authors.md)**
+It only reads, so it's safe on any repo and identical on every OS. Three of the things it found, all real: ↓
 
-## Proof 1 — your agent can read your secrets and ship them out
+## Proof 1 — a tool your agent thinks it has and doesn't
 
 ```text
-◑ Safety   80  (80/100)
-    └ subagent "tester" holds all three lethal-trifecta legs:
-        reads private data (Bash, Read) · takes in untrusted web content (WebFetch)
-        · can send data out (Bash, WebFetch)
+✗ tester — Tool "AskUserQuestion" is never available to a subagent.
+    → remove or correct it — it's silently dropped from the contract.
 ```
 
-Give one subagent all three powers and it's a **prompt-injection exfil path**: a poisoned
-web page can tell it to read your `.env` and POST it anywhere — no exploit code, just the
-tools it was handed. vigiles flags it from the tool list alone, free, no model.
-**[How the Safety check works →](docs/for-plugin-authors.md)**
+This subagent — a helper your main agent hands work to — lists a tool that doesn't exist for it. The harness drops it without a word, so the agent quietly loses a capability it thinks it has. The markdown is perfectly valid. vigiles catches it and hands you the **one-line fix**.
 
 ## Proof 2 — two skills your agent can't tell apart
 
@@ -168,38 +142,26 @@ tools it was handed. vigiles flags it from the tool list alone, free, no model.
       apart, so the wrong one fires  (e.g. "agent-coder" ↔ "agent-tester", 83% alike)
 ```
 
-One popular plugin ships **45 pairs of skills** with near-identical descriptions. The
-agent picks which skill to run by reading those descriptions, so when two match it
-fires the wrong one. The markdown is perfectly valid.
+One popular plugin ships **45 pairs of skills** with near-identical descriptions. Your agent picks which skill to run by _reading_ those descriptions, so when two match it fires the wrong one. Still perfectly valid markdown.
 **[How triggering works →](docs/measuring-skills.md)**
 
-## Proof 3 — a tool your subagent silently can't call
+## Proof 3 — it can quietly read your secrets and send them out
 
 ```text
-✗ tester — Tool "AskUserQuestion" is never available to a subagent.
-    → remove or correct it — it's silently dropped from the contract.
+◑ Safety   80  (80/100)
+    └ subagent "tester" holds all three lethal-trifecta legs:
+        reads private data (Bash, Read) · takes in untrusted web content (WebFetch)
+        · can send data out (Bash, WebFetch)
 ```
 
-This subagent declares a tool that doesn't exist. The harness drops it silently, so
-the agent loses a capability it thinks it has. vigiles catches it and gives you the
-**one-line fix**.
+Hand one subagent all three powers and a poisoned web page can tell it to read your `.env` and POST it anywhere — no exploit code, just the tools it was given. vigiles spots it from the tool list alone, free, no model.
 
-That's the whole idea — it checks your harness against reality, not style. Every
-referenced tool, hook, file, script, and skill is verified to actually resolve — and
-where you name a linter rule, it's checked to exist _and_ be enabled (ESLint, Ruff,
-Clippy and more).
-**[Full guide →](docs/verifying-instruction-files.md)**
+That's the whole idea: it checks your harness against **reality, not style**. Every tool, hook, file, script, and skill you reference is verified to actually resolve — and where you name a linter rule, it's checked to exist _and_ be enabled (ESLint, Ruff, Clippy, and more).
+**[Everything it catches →](docs/what-vigiles-catches.md)** · point `audit` at a whole marketplace and it ranks every plugin the same way.
 
-All three catches are free and need no model. vigiles also **prevents** whole classes
-of bug up front — once your instructions are a spec, a broken reference won't compile.
-**[Everything it catches and prevents →](docs/what-vigiles-catches.md)** · point `audit`
-at a whole marketplace and it ranks every plugin the same way.
-**[Audit a marketplace →](docs/for-plugin-authors.md)**
+## How it works — vibes → verified
 
-## How it works
-
-`audit` is the report. Three checks compute it — and go further than _does it exist_ to
-_does it work_. Almost none of it needs a model or a key.
+`audit` shows you the vibes. Turning them into _verified_ is one tool worn four ways — and almost none of it needs a model or a key.
 
 | Command | Answers                       | Needs a model?           | When to run              |
 | ------- | ----------------------------- | ------------------------ | ------------------------ |
@@ -208,34 +170,21 @@ _does it work_. Almost none of it needs a model or a key.
 | `test`  | Does the harness behave?      | No — a scripted stand-in | Every commit             |
 | `eval`  | Does a skill actually help?   | Yes — your subscription  | On demand                |
 
-`audit` and `lint` are one engine, two outputs: `audit` is the read-only report you run
-yourself, `lint` runs the same deterministic checks as a pass/fail gate in CI. `test` and
-`eval` go past existence to behaviour and value.
+`audit` and `lint` are one engine, two outputs: `audit` is the read-only report you run yourself, `lint` runs the same checks as a pass/fail gate in CI. `test` and `eval` go past _does it exist_ to _does it work_.
 
 ### 🔎 Lint — your instructions stop lying
 
-Every path, script, symbol, and rule verified against reality — the catches above. You
-don't write the checks: `npx vigiles init` turns your `CLAUDE.md` or `AGENTS.md`, skills,
-and subagents into _specs_ (same content, plus a layer vigiles can verify). Non-destructive,
-edited by your agent in plain English, undone by `eject`.
+Every path, script, symbol, and rule verified against reality — the catches above. You don't write the checks: `npx vigiles init` turns your `CLAUDE.md` or `AGENTS.md`, skills, and subagents into _specs_ (same content, plus a layer vigiles can verify). Non-destructive, edited by your agent in plain English, undone by `eject`.
 **[How →](docs/verifying-instruction-files.md)**
 
 ### 🧪 Test — does the harness actually do its job?
 
-A hook that blocks nothing, a skill that hijacks unrelated prompts, context that never
-reaches the model — each passes a naive "did it run?" check. vigiles tests the real
-thing: hooks **block**, skills **fire**, subagents **finish what they promised**, and a
-stray `git push` is caught before it happens. It uses a scripted stand-in for the model,
-not a live call — so it needs no key and runs on every commit.
+A hook that blocks nothing, a skill that hijacks unrelated prompts, context that never reaches the model — each passes a naive "did it run?" check. That gap is **false confidence**: a guard that looks like it works and silently doesn't. vigiles tests the real thing — hooks block, skills fire, subagents finish what they promised, a stray `git push` is caught before it happens. It drives a scripted stand-in for the model, not a live call, so it needs no key and runs on every commit.
 **[How testing works →](docs/harness-testing.md)**
 
 ### 📊 Eval — does a skill help, or just cost more?
 
-_"65% fewer tokens." Says who?_ vigiles A/Bs the claim on real coding tasks and reports
-the token bill, whether it hit its target, and whether the code still works. promptfoo
-and DeepEval bill **per token, every run**; vigiles runs on your own Claude Pro/Max
-subscription. Evals run locally; a committed lock file — like a `package-lock` — records
-the result, so **CI catches stale numbers without calling the model again**.
+_"65% fewer tokens." Says who?_ vigiles A/Bs the claim on real coding tasks and reports the token bill, whether it hit its target, and whether the code still works. promptfoo and DeepEval bill **per token, every run**; vigiles runs on your own Claude Pro/Max subscription. Evals run locally; a committed lock file — like a `package-lock` — records the result, so CI catches stale numbers without calling the model again.
 **[Measure a skill →](docs/measuring-skills.md)**
 
 ## Quick start
@@ -264,19 +213,15 @@ npx vigiles init   # adopts your files (non-destructive — eject reverses), add
 
 Interactive in a terminal, non-interactive for agents/CI (or `--yes`).
 
-**Works with Claude Code and Codex** — vigiles verifies `CLAUDE.md` and `AGENTS.md` the
-same way. **[Codex setup →](docs/harnesses.md)**
+**Works with Claude Code and Codex** — vigiles verifies `CLAUDE.md` and `AGENTS.md` the same way. **[Codex setup →](docs/harnesses.md)**
 
-**Adoption is smooth: one command, then your agent does the rest.** `init` installs
-the **skills and hooks**, so a plain-English ask does the work — no specs to
-hand-write, no hooks to wire:
+**Adoption is smooth: one command, then your agent does the rest.** `init` installs the **skills and hooks**, so a plain-English ask does the work — no specs to hand-write, no hooks to wire:
 
 - _"test my skills"_ → scaffolds **and runs** a trigger/behaviour test, then commits its result so CI can check it (`test-harness`)
 - _"harden my rules"_ → upgrades prose guidance into enforced linter rules (`strengthen`)
 - _"add a rule to my CLAUDE.md"_ → edits the source and recompiles (`edit-spec`)
 
-The **hooks** keep it honest in-loop — nudging the agent to mark a reference or
-refresh a stale eval — so there are no chores to remember.
+The **hooks** keep it honest in-loop — nudging the agent to mark a reference or refresh a stale eval — so there are no chores to remember.
 
 <details>
 <summary>What <code>init</code> sets up</summary>
@@ -286,14 +231,13 @@ refresh a stale eval — so there are no chores to remember.
 - Adds `vigiles` to `devDependencies`; installs the Claude Code plugin (skills + hooks) via the marketplace — globally, never vendored.
 - Wires CI as a `zernie/vigiles@v1` workflow that posts a sticky PR comment + a `valid` output.
 
-Targets Claude Code and Codex out of the box, or
-[your own harness](docs/authoring-an-adapter.md). Prefer to write tests yourself?
-JS **or** TS (`*.harness.{mjs,ts}`) — run with `npx vigiles test`.
+Targets Claude Code and Codex out of the box, or [your own harness](docs/authoring-an-adapter.md). Prefer to write tests yourself? JS **or** TS (`*.harness.{mjs,ts}`) — run with `npx vigiles test`.
 
 </details>
 
 ## FAQ
 
+- **Is this a framework I have to build around?** No. It's a tool you run — like ESLint, Lighthouse, or `npm audit`. One command, a report, an optional CI gate. There's a library API for automation, but you never touch it to get value.
 - **Isn't this just a markdown linter?** No — it checks whether your instruction file is _true_ (every path/script/symbol/rule exists and is enabled), then tests and measures your harness. A style linter can't do any of that.
 - **Do I have to write TypeScript?** No — your agent writes the spec (`init` adopts your CLAUDE.md into one), or plain markdown lints with zero new files. Compiler-grade guarantees are opt-in, like TS's `strict` ([why?](docs/faq.md#why-are-the-strongest-guarantees-opt-in-not-the-default)).
 - **Non-JS repo?** `npx vigiles lint` verifies your CLAUDE.md with no install (Ruff/Clippy/Pylint/… too).

--- a/README.md
+++ b/README.md
@@ -1,83 +1,66 @@
 <!--
   README DIRECTION — read before editing; keep changes aligned.
-  This file is the FRONT DOOR + a marketing asset for someone who already lives
-  in Claude Code / Codex. Optimize for a phone-skimmer who should come away
-  understanding WHAT IT IS and wanting to run it — never scared off.
+  Front door + marketing asset for someone who lives in Claude Code / Codex.
+  Optimize for a phone-skimmer who must come away knowing WHAT IT IS and wanting
+  to run it — never scared off. Validated by a 6-persona cold-read (2026-07):
+  newcomer / power-user / plugin-author / skeptical-senior / decision-maker /
+  Codex-user. The fixes below trace to that review — don't regress them.
 
-  HOOK = FELT PAIN, then breadth (founder direction 2026-07). The bold tagline is
-  a SPECIFIC second-person pain the reader recognizes instantly: "You have a
-  CLAUDE.md rule your agent follows half the time. Time to fix that." Dev-native
-  CRAFT bait, NOT enterprise fear (this is an OSS dev tool, not a security
-  product). A specific pain stings harder than an abstract line — the risk is
-  looking narrow, so the report-card + 5 rings RIGHT BELOW immediately show the
-  breadth (the sting, then "oh it does way more"). The review-parallel callout
-  ("You review every PR. Nothing reviews your CLAUDE.md.") is now the INTRO bold
-  lead (broadens the one rule → the whole harness); "vibes" carries the intro body
-  ("that's not a system, that's vibes") + the "vibes → verified" How-it-works
-  section. Arc: tagline (one felt pain) → intro (nothing reviews any of it → it's
-  vibes) → How it works (vibes → verified). Keep the verify-first SUBHEAD for
-  substance. CLAUDE.md stays in the tagline/lead for punch; Codex/AGENTS.md is
-  covered in the intro + subhead. Do NOT revert to the old test-first "tests your
-  skills never had" tagline. Stay coding-scoped (CC/Codex + CLAUDE.md/AGENTS.md/
-  skills/hooks). NOT "observability" as the headline.
+  HOOK = FELT PAIN, then breadth (founder direction 2026-07). Bold tagline is a
+  specific second-person pain: "You have a rule your agent follows half the time
+  — and no way to know which one." It's rhetorical (the reader's own uncertainty),
+  NOT an ecosystem stat — do NOT reintroduce a bare "%"/number in the tagline (the
+  doc mocks uncited stats: "'65% fewer tokens.' Says who?", so a fake stat up top
+  reads as hypocrisy). Dev-native CRAFT bait, NOT enterprise fear (OSS dev tool,
+  not a security product). The report-card + 5 rings RIGHT BELOW show the breadth
+  so the specific hook doesn't read as narrow.
 
-  CATEGORY = A TOOL YOU RUN, not a framework, not a lib-collection. The analogues
-  are ESLint / Lighthouse / npm audit: one command, a report, an optional CI gate.
-  The FAQ says this outright ("Is this a framework?") because it's the #1 thing
-  that scares people off. The library/subpath exports are the automation door for
-  the 5% — never the pitch.
+  DEFINE "HARNESS" on first use (the load-bearing noun, used ~15×) — gloss it as
+  "the CLAUDE.md/AGENTS.md rules, skills, subagents, and hooks steering your
+  agent." 4 of 6 personas bounced on it being undefined. Keep the gloss.
 
-  SPINE = proof/demo-led. Lead with REAL, screenshotable catches on plugins people
-  actually ship, THEN the mechanism. Every proof traces to a real dogfood run in
-  research/dogfood/ — NEVER fabricate one. PROOF ORDER = most-RELATABLE first
-  (a broken tool ref → a skill collision → the security gotcha last as the "and
-  even THIS" bite). Security is ONE dev-native GOTCHA proof, framed as craft
-  ("the tool your agent thinks it has and doesn't", "it can quietly leak your
-  secrets"), NEVER as enterprise/compliance/national-interest framing and NEVER
-  the brand — if it reads as "a security scanner" the other ~80% (references,
-  triggering, testing) vanishes. Current proofs, anonymized: (1) an
-  AskUserQuestion-never-available tool; (2) a skill-description collision
-  (Triggering F); (3) a lethal-trifecta exfil path (Safety). All real, reproduce
-  on current main.
+  INSTRUCTION-NEUTRAL NOUNS (Codex was the lowest score): body copy says CLAUDE.md
+  OR AGENTS.md, never CLAUDE.md alone. The tagline may keep punch, but Codex must
+  appear within the first sentence or two (the harness gloss names AGENTS.md), and
+  every "adopts your CLAUDE.md"/"verifies your CLAUDE.md" gets "or AGENTS.md".
 
-  FALSE CONFIDENCE is the coined term of art (a guard that looks like it works
-  and silently doesn't) — defined once in the Test section, citable, let it recur.
+  CATEGORY = A TOOL YOU RUN (ESLint/Lighthouse/npm audit class), NOT a framework,
+  NOT a lib-collection. The FAQ says this outright — it's the #1 thing that scares
+  people off. The library/subpath exports are the automation door for the 5%.
 
-  FUNNEL: "How it works" OPENS with the audit/lint/test/eval verb-map table (what
-  it checks / needs-a-model? / when) — the load-bearing "one tool, not four" fix
-  (all 6 README-review personas named it their #1 change). KEEP it + the
-  "audit + lint are one engine, two outputs" reconciliation. Frame it as
-  vibes → verified.
+  AUDIT vs LINT — ONE CONSISTENT, ACCURATE STORY (a persona caught 3 conflicting
+  answers): `lint` = the CI gate on the deterministic checks (broken refs, tool
+  contracts, dead hooks, skill collisions — Proofs 1 & 2). `audit` = those same
+  checks + the Safety ring + two opt-in LIVE checks (MCP connects? skills fire?)
+  + the graded report. Do NOT claim lint gates the lethal-trifecta Safety flag
+  (it's an audit ring, not a default gating rule) and do NOT say lint is
+  refs-only. The table row, the reconciliation line, and the Lint subsection must
+  all agree.
 
-  DON'T SHAME OSS: community catches are real but ANONYMIZED (no obra/superpowers,
-  madappgang, claude-flow by name) — real names live only in research/dogfood/.
-  Punch UP only (name Anthropic's own) if an official proof ever returns.
+  SPINE = proof/demo-led. Real, screenshotable catches on shipped plugins, THEN
+  mechanism. Every proof traces to a real dogfood run (research/dogfood/) — NEVER
+  fabricate one. Order = most-RELATABLE first (broken tool ref → skill collision →
+  secrets-exfil gotcha last as the bite). The intro triplet maps 1:1 to the 3
+  proofs. Security is ONE dev-native GOTCHA proof, never the brand. Add a repro
+  line ("run `npx vigiles audit <any-repo>` for your own") + a one-line note that
+  examples use CC subagents but the checks run on Codex too. FALSE CONFIDENCE is
+  the coined term (a guard that looks like it works and silently doesn't), defined
+  once in the Test section.
 
-  Guard / compiled hooks + the 2/7→7/7 disaster battery are PARKED FOR LAUNCH
-  (see research/roadmap.md) — do NOT make the battery the hero here.
+  FUNNEL: "How it works" opens with the audit/lint/test/eval verb-map table — the
+  load-bearing "one tool, not four" fix. Frame it vibes → verified. Name that
+  init/compile/eject manage the spec layer (personas noticed the verb-count gap).
 
-  RULES:
-  1. LEAD WITH BENEFITS / the reader's CONCRETE PAIN, never an apology or
-     competitor. A bolded lead-in is the first thing read — make it the hook/win.
-     A paragraph is ≤ ~3 lines.
-  2. INSTRUCTION-NEUTRAL NOUNS: body copy says CLAUDE.md *or* AGENTS.md (never
-     CLAUDE.md alone); Codex surfaced in intro + Quick start, not only <details>.
-  3. SPEC-FIRST IS THE DEFAULT but easy — `init` ADOPTS your instructions into a
-     spec, skills edit it, you rarely hand-write .spec.ts. One home (Quick start).
-     `eject` always reverses.
-  4. SCANNABLE + SHORT — ~220-line body cap; punchy cells, bullets, runnable
-     blocks. Push depth into docs/ and LINK it.
-  5. NO INTERNAL VOCABULARY (moat / measurement-authority / flywheel), NO
-     research/ links, NO enterprise/national-interest framing — name the user
-     benefit. ONE bold per block. ONE idea per sentence.
-  6. ASSETS: the hero vigiles-audit.png is a REAL current report (a community
-     plugin rendered as "my-plugin") — C 72, five rings. It's the Lighthouse
-     report-card screenshot = the shareable artifact; the report card, not the
-     Safety ring, is the point. Re-render via headless Chromium on the React
-     report if the UI changes (recipe: copy a plugin to my-plugin/,
-     `node dist/cli.js audit my-plugin --no-json --no-serve`, headless_shell
-     `--window-size=820,1180 --force-device-scale-factor=2 --screenshot` on
-     vigiles-report.html, then `rm -rf my-plugin vigiles-report.html`).
+  DON'T SHAME OSS: catches are ANONYMIZED (no obra/superpowers, madappgang,
+  claude-flow by name) — real names live only in research/dogfood/.
+  Guard/compiled-hooks + the 2/7→7/7 battery are PARKED FOR LAUNCH — not the hero.
+
+  RULES: lead with the reader's CONCRETE PAIN; ≤ ~3-line paragraphs; ONE bold per
+  block; ONE idea per sentence; NO internal vocabulary (moat/flywheel) / NO
+  research/ links / NO enterprise/national-interest framing — name the user
+  benefit; ~220-line body cap; push depth into docs/ and LINK it. Assets: the hero
+  vigiles-audit.png is a REAL current report (a community plugin as "my-plugin"),
+  C 72, five rings — re-render via headless Chromium if the UI changes.
 -->
 
 <p align="center">
@@ -87,11 +70,11 @@
 <h1 align="center">vigiles</h1>
 
 <p align="center">
-  <strong>You have a CLAUDE.md rule your agent follows half the time. Time to fix that.</strong>
+  <strong>You have a rule your agent follows half the time — and no way to know which one.</strong>
 </p>
 
 <p align="center">
-  Verify your CLAUDE.md, skills, and hooks are real — and prove they actually work.
+  Verify your CLAUDE.md or AGENTS.md, skills, and hooks are real — and prove they actually work.
 </p>
 
 <p align="center">
@@ -104,17 +87,17 @@
 
 **You review every PR. Nothing reviews your CLAUDE.md.**
 
-The CLAUDE.md, skills, and hooks meant to keep your agent on track are themselves unchecked — nobody verified they're real, nobody tested they work. That's not a system. That's vibes.
+Your **harness** — the CLAUDE.md or AGENTS.md rules, skills, subagents, and hooks steering your agent — is the one part nobody checks. Nobody verified it's real. Nobody tested it works. That's not a system. That's vibes.
 
-And vibes break silently mid-task: a subagent wired to a tool that doesn't exist, a hook that looks like it blocks and doesn't, two skills the agent can't tell apart. It all looks fine right up until it doesn't.
+And vibes break silently mid-task: a subagent wired to a tool that doesn't exist, two skills your agent can't tell apart, one helper quietly able to read your secrets and send them out.
 
-vigiles[^name] checks your harness is _real_, not just well-formed — Claude Code (`CLAUDE.md`) and Codex (`AGENTS.md`) alike. One command, no key, no config, safe on any repo:
+vigiles[^name] checks your harness is _real_, not just well-formed — Claude Code and Codex alike. One command, no key, no config, safe on any repo:
 
 ```bash
 npx vigiles audit
 ```
 
-Here's what it caught on plugins people actually ship. ↓
+It's free and open-source, runs entirely on your machine, and never bills per token. (`eval` is the only step that calls a model — on your own Claude subscription.) Here's what it caught on plugins people actually ship. ↓
 
 ## What it caught
 
@@ -130,7 +113,7 @@ Here's what it caught on plugins people actually ship. ↓
 - **Safety** — any way for the agent to leak your data?
 - **Tested** — does the harness ship tests?
 
-It only reads, so it's safe on any repo and identical on every OS. Three of the things it found, all real: ↓
+These are real scans of public plugins — run `npx vigiles audit <any-repo>` for your own. The examples below use Claude Code subagents; the same checks run on Codex `AGENTS.md`, skills, and hooks. ↓
 
 ## Proof 1 — a tool your agent thinks it has and doesn't
 
@@ -161,27 +144,27 @@ One popular plugin ships **45 pairs of skills** with near-identical descriptions
         · can send data out (Bash, WebFetch)
 ```
 
-Hand one subagent all three powers and a poisoned web page can tell it to read your `.env` and POST it anywhere — no exploit code, just the tools it was given. vigiles spots it from the tool list alone, free, no model.
+Hand one subagent all three powers and a poisoned web page can tell it to read your `.env` and POST it anywhere — no exploit code, just the tools it was given. The **80 still looks like a B** — that's the point: a healthy-looking grade can hide a single subagent that's a data-leak waiting to happen. vigiles spots it from the tool list alone, free, no model.
 
 That's the whole idea: it checks your harness against **reality, not style**. Every tool, hook, file, script, and skill you reference is verified to actually resolve — and where you name a linter rule, it's checked to exist _and_ be enabled (ESLint, Ruff, Clippy, and more).
 **[Everything it catches →](docs/what-vigiles-catches.md)** · point `audit` at a whole marketplace and it ranks every plugin the same way.
 
 ## How it works — vibes → verified
 
-`audit` shows you the vibes. Turning them into _verified_ is one tool worn four ways — and almost none of it needs a model or a key.
+`audit` shows you where your setup is still vibes. Turning that into _verified_ is four commands over one engine — and almost none of it needs a model or a key.
 
-| Command | Answers                       | Needs a model?           | When to run              |
-| ------- | ----------------------------- | ------------------------ | ------------------------ |
-| `audit` | The whole harness, graded A–F | No — read-only[^audit]   | Anytime; it's the report |
-| `lint`  | Are the references real?      | No                       | CI gate (pass/fail)      |
-| `test`  | Does the harness behave?      | No — a scripted stand-in | Every commit             |
-| `eval`  | Does a skill actually help?   | Yes — your subscription  | On demand                |
+| Command | Answers                        | Needs a model?           | When to run              |
+| ------- | ------------------------------ | ------------------------ | ------------------------ |
+| `audit` | Everything, graded A–F         | No — read-only[^audit]   | Anytime; it's the report |
+| `lint`  | Do the structural checks pass? | No                       | CI gate, every push      |
+| `test`  | Does the harness behave?       | No — a scripted stand-in | Every commit             |
+| `eval`  | Does a skill actually help?    | Yes — your subscription  | On demand                |
 
-`audit` and `lint` are one engine, two outputs: `audit` is the read-only report you run yourself, `lint` runs the same checks as a pass/fail gate in CI. `test` and `eval` go past _does it exist_ to _does it work_.
+`audit` and `lint` share one engine. **`lint` is the CI gate** — it fails the build on broken references, bad tool contracts, dead hooks, and skill collisions (Proofs 1 and 2). **`audit`** runs those same checks, adds the Safety ring, renders the graded report, and can also run two opt-in _live_ checks (does your MCP server connect, do your skills fire). `test` and `eval` go past _does it exist_ to _does it work_. (`init` / `compile` / `eject` manage the spec layer underneath; you rarely run them by hand.)
 
 ### 🔎 Lint — your instructions stop lying
 
-Every path, script, symbol, and rule verified against reality — the catches above. You don't write the checks: `npx vigiles init` turns your `CLAUDE.md` or `AGENTS.md`, skills, and subagents into _specs_ (same content, plus a layer vigiles can verify). Non-destructive, edited by your agent in plain English, undone by `eject`.
+Every path, script, symbol, and rule verified against reality — plus tool contracts, skill collisions, and dead hooks (the catches above). You don't write the checks. `npx vigiles init` writes a `CLAUDE.md.spec.ts` beside your file: the same rules, each reference now wrapped so vigiles can confirm it exists. `compile` turns that back into the `CLAUDE.md` (or `AGENTS.md`) your agent already reads. Your agent edits the spec in plain English; `eject` deletes it and leaves your original untouched.
 **[How →](docs/verifying-instruction-files.md)**
 
 ### 🧪 Test — does the harness actually do its job?
@@ -191,7 +174,7 @@ A hook that blocks nothing, a skill that hijacks unrelated prompts, context that
 
 ### 📊 Eval — does a skill help, or just cost more?
 
-_"65% fewer tokens." Says who?_ vigiles A/Bs the claim on real coding tasks and reports the token bill, whether it hit its target, and whether the code still works. promptfoo and DeepEval bill **per token, every run**; vigiles runs on your own Claude Pro/Max subscription. Evals run locally; a committed lock file — like a `package-lock` — records the result, so CI catches stale numbers without calling the model again.
+_"65% fewer tokens." Says who?_ vigiles A/Bs the claim on real coding tasks and reports the token bill, whether it hit its target, and whether the code still works. promptfoo and DeepEval bill **per token, every run**; vigiles runs on your own Claude Pro/Max subscription. Evals run locally; a committed lock file — like a `package-lock` — records the result, so CI catches stale numbers without calling the model again. (On Claude Code today; Codex eval support is landing.)
 **[Measure a skill →](docs/measuring-skills.md)**
 
 ## Quick start
@@ -215,20 +198,19 @@ Or run it yourself:
 
 ```bash
 npx vigiles init   # adopts your files (non-destructive — eject reverses), adds CI,
-                   # installs the Claude Code plugin globally
+                   # installs vigiles's skills + hooks as a Claude Code plugin (in
+                   # ~/.claude/, not your repo). On Codex, skills install globally too.
 ```
 
-Interactive in a terminal, non-interactive for agents/CI (or `--yes`).
-
-**Works with Claude Code and Codex** — vigiles verifies `CLAUDE.md` and `AGENTS.md` the same way. **[Codex setup →](docs/harnesses.md)**
+Interactive in a terminal, non-interactive for agents/CI (or `--yes`). **Works with Claude Code and Codex** — vigiles verifies `CLAUDE.md` and `AGENTS.md` the same way. **[Codex setup →](docs/harnesses.md)**
 
 **Adoption is smooth: one command, then your agent does the rest.** `init` installs the **skills and hooks**, so a plain-English ask does the work — no specs to hand-write, no hooks to wire:
 
 - _"test my skills"_ → scaffolds **and runs** a trigger/behaviour test, then commits its result so CI can check it (`test-harness`)
 - _"harden my rules"_ → upgrades prose guidance into enforced linter rules (`strengthen`)
-- _"add a rule to my CLAUDE.md"_ → edits the source and recompiles (`edit-spec`)
+- _"add a rule to my CLAUDE.md or AGENTS.md"_ → edits the source and recompiles (`edit-spec`)
 
-The **hooks** keep it honest in-loop — nudging the agent to mark a reference or refresh a stale eval — so there are no chores to remember.
+The **hooks** keep it honest in-loop — nudging the agent to tag a linter-rule mention so vigiles can verify it, or to re-run a test whose result just went stale — so there are no chores to remember.
 
 <details>
 <summary>What <code>init</code> sets up</summary>
@@ -236,7 +218,7 @@ The **hooks** keep it honest in-loop — nudging the agent to mark a reference o
 - **Both lint and test** by default; scope with `--lint` / `--test`.
 - **Already have a CLAUDE.md / AGENTS.md, skills, or subagents? `init` adopts them all** into specs faithfully and **non-destructively** — untouched until you `compile` (and `eject` undoes it).
 - Adds `vigiles` to `devDependencies`; installs the Claude Code plugin (skills + hooks) via the marketplace — globally, never vendored.
-- Wires CI as a `zernie/vigiles@v1` workflow that posts a sticky PR comment + a `valid` output.
+- Wires CI as a `zernie/vigiles@v1` workflow (needs only read + PR-comment permissions) that posts a sticky PR comment + a `valid` output.
 
 Targets Claude Code and Codex out of the box, or [your own harness](docs/authoring-an-adapter.md). Prefer to write tests yourself? JS **or** TS (`*.harness.{mjs,ts}`) — run with `npx vigiles test`.
 
@@ -246,21 +228,19 @@ Targets Claude Code and Codex out of the box, or [your own harness](docs/authori
 
 - **Is this a framework I have to build around?** No. It's a tool you run — like ESLint, Lighthouse, or `npm audit`. One command, a report, an optional CI gate. There's a library API for automation, but you never touch it to get value.
 - **Isn't this just a markdown linter?** No — it checks whether your instruction file is _true_ (every path/script/symbol/rule exists and is enabled), then tests and measures your harness. A style linter can't do any of that.
-- **Do I have to write TypeScript?** No — your agent writes the spec (`init` adopts your CLAUDE.md into one), or plain markdown lints with zero new files. Compiler-grade guarantees are opt-in, like TS's `strict` ([why?](docs/faq.md#why-are-the-strongest-guarantees-opt-in-not-the-default)).
-- **Non-JS repo?** `npx vigiles lint` verifies your CLAUDE.md with no install (Ruff/Clippy/Pylint/… too).
+- **Do I have to write TypeScript?** No — your agent writes the spec (`init` adopts your CLAUDE.md or AGENTS.md into one), or plain markdown lints with zero new files. Compiler-grade guarantees are opt-in, like TS's `strict` ([why?](docs/faq.md#why-are-the-strongest-guarantees-opt-in-not-the-default)).
+- **Is it stable enough to adopt?** Yes — the CLI is stable; only the library API is still evolving ([details](STABILITY.md)).
+- **Non-JS repo?** `npx vigiles lint` verifies your CLAUDE.md or AGENTS.md with no install (Ruff/Clippy/Pylint/… too).
 
 **[Full FAQ →](docs/faq.md)**
 
+**Not for you if** you want a model/capability benchmark or runtime guardrails in the request path — vigiles is build-/CI-time.
+
 ## More
 
-- **[What vigiles catches and prevents →](docs/what-vigiles-catches.md)** — the full matrix of harness problems it handles, biggest first, marked prevent / catch / measure.
-- **[CLI →](docs/cli.md)** · **[GitHub Action →](docs/github-action.md)** · the full **[lint rules matrix →](docs/verifying-instruction-files.md#the-validation-rules--the-full-matrix)** lives with the linting guide.
-- **[Skills →](docs/skills.md)** — the skills `init` installs, and how the model-invocable ones trigger.
-- **[Ship plugins? The plugin-author guide →](docs/for-plugin-authors.md)** — scan a draft, make your skills fire, rank a whole marketplace — no key.
-- **[Docs index →](docs/README.md)** · **[API reference →](https://zernie.github.io/vigiles/)** · **[Related tools →](docs/related-tools.md)**.
-- **[Stability →](STABILITY.md)** — 0.x: the CLI is stable; the library API is still evolving.
-- **Not for you if** you want a model/capability benchmark or runtime guardrails in the request path — vigiles is build-/CI-time.
-- Companion to [Feedback Loop Is All You Need](https://zernie.com/blog/feedback-loop-is-all-you-need).
+**Docs** — **[What it catches and prevents →](docs/what-vigiles-catches.md)** · **[Verifying instruction files →](docs/verifying-instruction-files.md)** ([rules matrix](docs/verifying-instruction-files.md#the-validation-rules--the-full-matrix)) · **[Harness testing →](docs/harness-testing.md)** · **[Measuring skills →](docs/measuring-skills.md)** · **[CLI →](docs/cli.md)** · **[GitHub Action →](docs/github-action.md)** · **[Skills →](docs/skills.md)** · **[Plugin-author guide →](docs/for-plugin-authors.md)** · **[Docs index →](docs/README.md)** · **[API reference →](https://zernie.github.io/vigiles/)**
+
+**Project** — **[Stability →](STABILITY.md)** · **[Related tools →](docs/related-tools.md)** · companion to [Feedback Loop Is All You Need](https://zernie.com/blog/feedback-loop-is-all-you-need).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,18 @@
   understanding WHAT IT IS and wanting to run it — never scared off.
 
   HOOK = "VIBES → VERIFIED" (founder direction 2026-07). The bold tagline is the
-  dev-native emotional truth: "Your AI agent's harness is running on vibes"
-  (untested + unverified by default). It's CRAFT/self-aware bait, NOT enterprise
-  fear — this is an OSS dev tool, not a security product. The tagline draws the
-  eye; the verify-first SUBHEAD keeps the substance ("verify your CLAUDE.md,
-  skills, and hooks are real — and prove they work"). Do NOT revert to the old
+  review-parallel callout: "You review every PR. Nothing reviews your CLAUDE.md."
+  — dev-native CRAFT bait (you got disciplined about code; the harness didn't),
+  NOT enterprise fear (this is an OSS dev tool, not a security product). The
+  "vibes" energy then carries the INTRO ("that's not a system, that's vibes") and
+  the "vibes → verified" How-it-works section — so vibes doesn't double-hit in
+  the first breath. Arc: tagline (nothing reviews it) → intro (it's vibes) →
+  How it works (vibes → verified). The verify-first SUBHEAD keeps the substance
+  ("verify your CLAUDE.md, skills, and hooks are real — and prove they work").
+  CLAUDE.md stays in the tagline for punch; Codex/AGENTS.md is covered in the
+  intro + subhead (a two-filename tagline reads clunky). Do NOT revert to the old
   test-first "tests your skills never had" tagline. Stay coding-scoped (name
-  CC/Codex + CLAUDE.md/AGENTS.md/skills/hooks) so it's never mistaken for a
-  general-agent tool. NOT "observability" as the headline.
+  CC/Codex + CLAUDE.md/AGENTS.md/skills/hooks). NOT "observability" as the headline.
 
   CATEGORY = A TOOL YOU RUN, not a framework, not a lib-collection. The analogues
   are ESLint / Lighthouse / npm audit: one command, a report, an optional CI gate.
@@ -80,7 +84,7 @@
 <h1 align="center">vigiles</h1>
 
 <p align="center">
-  <strong>Your AI agent's harness is running on vibes.</strong>
+  <strong>You review every PR. Nothing reviews your CLAUDE.md.</strong>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -4,19 +4,22 @@
   in Claude Code / Codex. Optimize for a phone-skimmer who should come away
   understanding WHAT IT IS and wanting to run it — never scared off.
 
-  HOOK = "VIBES → VERIFIED" (founder direction 2026-07). The bold tagline is the
-  review-parallel callout: "You review every PR. Nothing reviews your CLAUDE.md."
-  — dev-native CRAFT bait (you got disciplined about code; the harness didn't),
-  NOT enterprise fear (this is an OSS dev tool, not a security product). The
-  "vibes" energy then carries the INTRO ("that's not a system, that's vibes") and
-  the "vibes → verified" How-it-works section — so vibes doesn't double-hit in
-  the first breath. Arc: tagline (nothing reviews it) → intro (it's vibes) →
-  How it works (vibes → verified). The verify-first SUBHEAD keeps the substance
-  ("verify your CLAUDE.md, skills, and hooks are real — and prove they work").
-  CLAUDE.md stays in the tagline for punch; Codex/AGENTS.md is covered in the
-  intro + subhead (a two-filename tagline reads clunky). Do NOT revert to the old
-  test-first "tests your skills never had" tagline. Stay coding-scoped (name
-  CC/Codex + CLAUDE.md/AGENTS.md/skills/hooks). NOT "observability" as the headline.
+  HOOK = FELT PAIN, then breadth (founder direction 2026-07). The bold tagline is
+  a SPECIFIC second-person pain the reader recognizes instantly: "You have a
+  CLAUDE.md rule your agent follows half the time. Time to fix that." Dev-native
+  CRAFT bait, NOT enterprise fear (this is an OSS dev tool, not a security
+  product). A specific pain stings harder than an abstract line — the risk is
+  looking narrow, so the report-card + 5 rings RIGHT BELOW immediately show the
+  breadth (the sting, then "oh it does way more"). The review-parallel callout
+  ("You review every PR. Nothing reviews your CLAUDE.md.") is now the INTRO bold
+  lead (broadens the one rule → the whole harness); "vibes" carries the intro body
+  ("that's not a system, that's vibes") + the "vibes → verified" How-it-works
+  section. Arc: tagline (one felt pain) → intro (nothing reviews any of it → it's
+  vibes) → How it works (vibes → verified). Keep the verify-first SUBHEAD for
+  substance. CLAUDE.md stays in the tagline/lead for punch; Codex/AGENTS.md is
+  covered in the intro + subhead. Do NOT revert to the old test-first "tests your
+  skills never had" tagline. Stay coding-scoped (CC/Codex + CLAUDE.md/AGENTS.md/
+  skills/hooks). NOT "observability" as the headline.
 
   CATEGORY = A TOOL YOU RUN, not a framework, not a lib-collection. The analogues
   are ESLint / Lighthouse / npm audit: one command, a report, an optional CI gate.
@@ -84,7 +87,7 @@
 <h1 align="center">vigiles</h1>
 
 <p align="center">
-  <strong>You review every PR. Nothing reviews your CLAUDE.md.</strong>
+  <strong>You have a CLAUDE.md rule your agent follows half the time. Time to fix that.</strong>
 </p>
 
 <p align="center">
@@ -99,7 +102,7 @@
 
 ---
 
-**You stopped vibe-coding. Your harness didn't.**
+**You review every PR. Nothing reviews your CLAUDE.md.**
 
 The CLAUDE.md, skills, and hooks meant to keep your agent on track are themselves unchecked — nobody verified they're real, nobody tested they work. That's not a system. That's vibes.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@
      End a section on the win, not the trade-off. A paragraph is ≤ ~3 lines.
   2. PROOF FIRST, mechanism second. The three instruments (Lint/Test/Eval) come
      AFTER the proof stack as "how it does it", not as a competing front door.
+     "How it works" OPENS with the audit/lint/test/eval verb-map table (what it
+     checks / needs-a-model? / when) — this is the load-bearing "one tool, not
+     four" fix (all 6 README-review personas named it their #1 change); KEEP it,
+     and keep the "audit + lint are one engine, two outputs" reconciliation.
+  2b. INSTRUCTION-NEUTRAL NOUNS: body copy says CLAUDE.md *or* AGENTS.md (never
+     CLAUDE.md alone) so Codex readers aren't second-class; the Lint header is
+     "your instructions stop lying", and Codex is surfaced in the intro + Quick
+     start, NOT only inside <details>. Don't revert headers to CLAUDE.md-only.
   3. SPEC-FIRST IS THE DEFAULT but easy — `init` ADOPTS your CLAUDE.md into a spec,
      skills edit it, you rarely hand-write .spec.ts. Give it ONE home (Quick start),
      not five scattered mentions. `eject` always reverses. Inline markdown is the
@@ -107,11 +115,11 @@
 
 ---
 
-**Your skills, hooks, and instructions are your agent's harness — the half you wrote, and the half nothing checks.**
+**Your skills, hooks, and instructions are your agent's harness.** You wrote all of it. Nothing checks any of it.
 
-A subagent wired to a tool that doesn't exist. A hook that looks like it blocks and doesn't. Two skills the agent can't tell apart. It all looks fine, and it breaks silently mid-task.
+A subagent (a helper your agent hands work to) wired to a tool that doesn't exist. A hook that looks like it blocks and doesn't. Two skills the agent can't tell apart. It all looks fine, and it breaks silently mid-task.
 
-vigiles checks your harness is _real_, not just well-formed:
+vigiles[^name] checks your harness is _real_, not just well-formed — for Claude Code (`CLAUDE.md`) and Codex (`AGENTS.md`) alike:
 
 ```bash
 npx vigiles audit
@@ -127,10 +135,16 @@ ship. ↓
 </p>
 
 **Like Google's Lighthouse, but for your agent harness.** Five categories, each scored
-A–F — Truthfulness, Triggering, Structure, Safety, Tested — with every fix shown inline.
+A–F, every fix shown inline:
+
+- **Truthfulness** — do the references resolve?
+- **Triggering** — do skills fire, without colliding?
+- **Structure** — are tool contracts and configs valid?
+- **Safety** — any way for the agent to leak your data?
+- **Tested** — does the harness ship tests?
 
 It runs locally and only reads, so it's safe on any repo and the same on every OS.
-For CI gating, use `vigiles lint` instead. **[Audit a harness →](docs/for-plugin-authors.md)**
+**[Audit a harness →](docs/for-plugin-authors.md)**
 
 ## Proof 1 — your agent can read your secrets and ship them out
 
@@ -166,9 +180,9 @@ fires the wrong one. The markdown is perfectly valid.
     → remove or correct it — it's silently dropped from the contract.
 ```
 
-This subagent — a helper your main agent hands a task to — declares a tool that
-doesn't exist. The harness drops it silently, so the agent loses a capability it
-thinks it has. vigiles catches it and gives you the **one-line fix**.
+This subagent declares a tool that doesn't exist. The harness drops it silently, so
+the agent loses a capability it thinks it has. vigiles catches it and gives you the
+**one-line fix**.
 
 That's the whole idea — it checks your harness against reality, not style. Every
 referenced tool, hook, file, script, and skill is verified to actually resolve — and
@@ -176,22 +190,33 @@ where you name a linter rule, it's checked to exist _and_ be enabled (ESLint, Ru
 Clippy and more).
 **[Full guide →](docs/verifying-instruction-files.md)**
 
-All three catches are free and need no model — and vigiles **prevents** other whole
-classes of bug by construction (a typed spec or compiled hook just won't compile).
+All three catches are free and need no model. vigiles also **prevents** whole classes
+of bug up front — once your instructions are a spec, a broken reference won't compile.
 **[Everything it catches and prevents →](docs/what-vigiles-catches.md)** · point `audit`
 at a whole marketplace and it ranks every plugin the same way.
 **[Audit a marketplace →](docs/for-plugin-authors.md)**
 
 ## How it works
 
-The model isn't yours to fix. Your harness is. `audit` shows you the problems — here's
-what fixes and proves each one, almost all of it with no model and no key.
+`audit` is the report. Three checks compute it — and go further than _does it exist_ to
+_does it work_. Almost none of it needs a model or a key.
 
-### 🔎 Lint — your CLAUDE.md stops lying
+| Command | Answers                       | Needs a model?           | When to run              |
+| ------- | ----------------------------- | ------------------------ | ------------------------ |
+| `audit` | The whole harness, graded A–F | No — read-only[^audit]   | Anytime; it's the report |
+| `lint`  | Are the references real?      | No                       | CI gate (pass/fail)      |
+| `test`  | Does the harness behave?      | No — a scripted stand-in | Every commit             |
+| `eval`  | Does a skill actually help?   | Yes — your subscription  | On demand                |
 
-Every path, script, symbol, and rule verified against reality — the catches above.
-You don't write the checks: `npx vigiles init` turns your CLAUDE.md, skills, and
-subagents into _specs_ (same content, plus a layer vigiles can verify). Non-destructive,
+`audit` and `lint` are one engine, two outputs: `audit` is the read-only report you run
+yourself, `lint` runs the same deterministic checks as a pass/fail gate in CI. `test` and
+`eval` go past existence to behaviour and value.
+
+### 🔎 Lint — your instructions stop lying
+
+Every path, script, symbol, and rule verified against reality — the catches above. You
+don't write the checks: `npx vigiles init` turns your `CLAUDE.md` or `AGENTS.md`, skills,
+and subagents into _specs_ (same content, plus a layer vigiles can verify). Non-destructive,
 edited by your agent in plain English, undone by `eject`.
 **[How →](docs/verifying-instruction-files.md)**
 
@@ -200,16 +225,18 @@ edited by your agent in plain English, undone by `eject`.
 A hook that blocks nothing, a skill that hijacks unrelated prompts, context that never
 reaches the model — each passes a naive "did it run?" check. vigiles tests the real
 thing: hooks **block**, skills **fire**, subagents **finish what they promised**, and a
-stray `git push` is caught before it happens. No model, no key, on every commit.
+stray `git push` is caught before it happens. It uses a scripted stand-in for the model,
+not a live call — so it needs no key and runs on every commit.
 **[How testing works →](docs/harness-testing.md)**
 
 ### 📊 Eval — does a skill help, or just cost more?
 
-_"65% fewer tokens." Says who?_ vigiles[^name] A/Bs the claim on real coding tasks and reports
+_"65% fewer tokens." Says who?_ vigiles A/Bs the claim on real coding tasks and reports
 the token bill, whether it hit its target, and whether the code still works. promptfoo
 and DeepEval bill **per token, every run**; vigiles runs on your own Claude Pro/Max
-subscription. Evals run locally — a committed lock then lets **CI catch stale results with no
-model call**. **[Measure a skill →](docs/measuring-skills.md)**
+subscription. Evals run locally; a committed lock file — like a `package-lock` — records
+the result, so **CI catches stale numbers without calling the model again**.
+**[Measure a skill →](docs/measuring-skills.md)**
 
 ## Quick start
 
@@ -237,6 +264,9 @@ npx vigiles init   # adopts your files (non-destructive — eject reverses), add
 
 Interactive in a terminal, non-interactive for agents/CI (or `--yes`).
 
+**Works with Claude Code and Codex** — vigiles verifies `CLAUDE.md` and `AGENTS.md` the
+same way. **[Codex setup →](docs/harnesses.md)**
+
 **Adoption is smooth: one command, then your agent does the rest.** `init` installs
 the **skills and hooks**, so a plain-English ask does the work — no specs to
 hand-write, no hooks to wire:
@@ -256,7 +286,7 @@ refresh a stale eval — so there are no chores to remember.
 - Adds `vigiles` to `devDependencies`; installs the Claude Code plugin (skills + hooks) via the marketplace — globally, never vendored.
 - Wires CI as a `zernie/vigiles@v1` workflow that posts a sticky PR comment + a `valid` output.
 
-Works with **Claude Code and Codex** ([`vigiles/codex`](docs/harnesses.md)) or
+Targets Claude Code and Codex out of the box, or
 [your own harness](docs/authoring-an-adapter.md). Prefer to write tests yourself?
 JS **or** TS (`*.harness.{mjs,ts}`) — run with `npx vigiles test`.
 
@@ -286,3 +316,5 @@ JS **or** TS (`*.harness.{mjs,ts}`) — run with `npx vigiles test`.
 [MIT](LICENSE)
 
 [^name]: **vigiles** — the watchmen of ancient Rome, who guarded the city (and fought its fires) by night. _Quis custodiet ipsos custodes?_ — "who watches the watchmen?" (Juvenal, _Satire VI_).
+
+[^audit]: `audit` reads only by default. Two deeper checks — live MCP connections and skill-firing — are opt-in and ask before they run.


### PR DESCRIPTION
## What & why

The README kept reading as "confusing / so much stuff / what even is it." This reworks the front door so a skimmer immediately gets that vigiles is **a tool you run** — not a framework — and isn't scared off. Docs-only: no code, API, or CLI changes.

## README

- **Category, stated plainly:** a tool you run (ESLint / Lighthouse / `npm audit` class), not a framework or a lib-collection. New FAQ entry answers "is this a framework?" head-on.
- **Pain-first hook → breadth:** a felt-pain tagline, then the Lighthouse-style A–F report card + five defined categories, then three real (anonymized) proofs.
- **"One tool, four verbs" funnel:** the `audit` / `lint` / `test` / `eval` verb-map table, framed _vibes → verified_.
- **Plain language:** "harness" defined on first use; "specs" made concrete (`CLAUDE.md.spec.ts` + the init→compile→CLAUDE.md chain); coined "false confidence."
- **Codex is first-class:** instruction-neutral nouns throughout (`CLAUDE.md` **or** `AGENTS.md`).
- **Accuracy fix:** the `audit`-vs-`lint` scope is now described one consistent way (lint = the CI gate on the deterministic checks; audit = those + the Safety ring + two opt-in live checks + the report).

All validated with a six-persona cold-read of the front door. `fmt:check` passes; every doc link and `vigiles <cmd>` reference resolves; body trimmed to ~187 lines.

## HANDOFF

- Refreshed the cross-session orientation for this work.
- Scrubbed vault-tier strategy that a prior HANDOFF had committed into this public file, replacing it with a compliant vault pointer (per the `doc-tiers` rule). Note: history still retains the old content — a `filter-repo` purge is tracked as a separate, deliberate op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WaWpG2t4n8ZNB1qNp8wdMa)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Docs**
- clarify what vigiles is — verb-map + first-class Codex in README
- rebuild README around a "vibes → verified" hook
- retune README tagline to the review-parallel hook
- lead README with a felt-pain tagline
- whole-README pass from a 6-persona review

**Chores**
- refresh HANDOFF for the README session + scrub leaked strategy
<!-- vigiles:pr-summary:end -->
