### PR TITLE
feat(scan): support non-plugin skills repos + FP-safe bundled-resource refs

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -19,12 +19,23 @@ ADOPTION FIXES, not cost analysis) → **PR #66 OPEN, merging-when-green.** This
 on a skills-monorepo FIELD REPORT (a team ran vigiles on a 46-skill CI library with no
 `plugin.json` and hit blockers) — all 7 feedback points fixed.
 
-**MERGE STATE (resume here first):** PR #66 open; **subscribed to its activity**; a `send_later`
-check-in (trigger `trig_01En7d7f4vRqfCg1fqFTtHkv`, ~13:30Z) re-checks CI and **squash-merges into
-main with a CLEAN message (NO session link / model-id) when green**, else re-arms. If resuming:
-`get_check_runs` for #66 → merge if green, then **unsubscribe**. Latest SHA `f923cad`. Two CI
-fixes already landed this round: api-extractor surface report (`etc/*.api.md`) + one eslint error
-(`no-confusing-void-expression`) in the new test.
+**MERGE STATE (resume here first):** PR #66 open, **merging-when-green**; **subscribed to its
+activity**; a `send_later` check-in (trigger `trig_01HgpKfkov7BQAJNzHtMNEoq`, ~14:44Z) re-checks CI
+and **squash-merges into main with a CLEAN message (NO session link / model-id) when all 6 jobs
+green**, else re-arms. If resuming: `get_check_runs` for #66 → merge if green, then **unsubscribe**.
+Latest SHA `aa5526d` (a HANDOFF-refresh commit sits on top). CI jobs: validate/describe/check/test/
+e2e/harness; `test` runs ~5-7 min and is always last. The lone allowed failure anywhere is env-only
+`dialect-drift` (CI pins CC, so it passes in CI).
+
+**CODE-REVIEW LOOP (done):** Codex-bot reviewed every pushed commit and found **13 real P2 bugs
+across 5 rounds — ALL fixed + tested** (api-extractor surface, eslint void-expr, single-skill bundled
+resources, root-SKILL.md coverage + colocation, sharedDirs-from-repo-root, scoped harness detection,
+per-surface→repo-level fallback, hook-only + hooks-convention plugin shape, loadable-only surface
+count, foreign-repo sharedDirs root, query-suffix vs glob-skip). Codex then **hit its usage quota**
+(no more reviews incoming) — the loop ends by quota, NOT by proof of correctness. WATCH-OUT: the
+single-skill-dir targeting + `.claude`-fallback subsystem generated most siblings; classes are now
+closed + tested, but if a NEW real bug there surfaces, prefer a redesign or NARROWING the PR (drop
+single-skill-dir) over another patch.
 
 **Shipped (branch — `feat(scan)` + `fix(lint)` + docs):**
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -14,70 +14,47 @@
 
 ## RESUME HERE
 
-**Branch `claude/readme-eval-docs-fjwhhu`** → **PR #63 OPEN, merging-when-green.** This
-session: README eval-cost clarity + the **EXPERIMENTAL R3 disposable-service tier** + a
-**promptfoo migration path** + a hard **safety pass** + a **parse-don't-validate refactor** +
-a **code-quality dev skill**. Goal: "let a team run real side-effect + behavior skill evals on
-vigiles (on the sub) instead of promptfoo."
+**Branch `claude/vigiles-cost-analysis-9ko9mv`** (name is misleading — the work is
+ADOPTION FIXES, not cost analysis) → **PR #66 OPEN, merging-when-green.** This session acted
+on a skills-monorepo FIELD REPORT (a team ran vigiles on a 46-skill CI library with no
+`plugin.json` and hit blockers) — all 7 feedback points fixed.
 
-**MERGE STATE (resume here first):** PR #63 (`feat(experimental): R3 disposable-service eval
-tier + promptfoo migration guide`) is open; a scheduled **send_later check-in** (trigger
-`trig_01Vx1d6ziy5dyjc2fmXfp3Md`, ~23:06Z) re-checks CI and **squash-merges with a CLEAN message
-(NO session link) when all checks are green**, else re-arms. Session is **subscribed to PR #63
-activity**. If resuming: check `get_check_runs` for #63 — merge if green, else let the check-in
-handle it. Codex-bot posted 2 P2 review comments (both real, both FIXED — see below).
+**MERGE STATE (resume here first):** PR #66 open; **subscribed to its activity**; a `send_later`
+check-in (trigger `trig_01En7d7f4vRqfCg1fqFTtHkv`, ~13:30Z) re-checks CI and **squash-merges into
+main with a CLEAN message (NO session link / model-id) when green**, else re-arms. If resuming:
+`get_check_runs` for #66 → merge if green, then **unsubscribe**. Latest SHA `f923cad`. Two CI
+fixes already landed this round: api-extractor surface report (`etc/*.api.md`) + one eslint error
+(`no-confusing-void-expression`) in the new test.
 
-**Shipped (commits on the branch):**
+**Shipped (branch — `feat(scan)` + `fix(lint)` + docs):**
 
-- `docs` (4c73cf8): README eval section leads with the caveman COST case + a real measured
-  verdict (762→842 out tok, +11%, correctness intact, $0 on sub).
-- `feat(experimental)` (1c52083): R3 tier under the quarantined **`vigiles/experimental`**
-  subpath (`experimental_` prefix + `@experimental` JSDoc + STABILITY note + api-extractor
-  tracked). `experimental_startServices` + `ServiceSpec`/`ServiceHandle`/`ServiceSession`/
-  `ContainerRuntime` port (`src/services.ts`) + a REAL Docker backend `makeDockerRuntime` /
-  `experimental_dockerRuntime` (`src/services-docker.ts`: pure builders + injected
-  `DockerExec`/`NetProbe` seams, mirroring `sandbox.ts`). PLUS the promptfoo migration guide
-  (`docs/migrating-from-promptfoo.md`) + example (`examples/harness/from-promptfoo.mjs`).
-- `feat(experimental)` (196b43e): `experimental_withServices` scope helper + measureArms
-  example (`examples/harness/measure-with-service.mjs`) + the **SAFETY pass** — fixed a
-  false-safety **egress OVERCLAIM** (egress is NOT pinned in the eval tier; the wall is
-  deferred), added loud safety warnings in docs + JSDoc + examples.
-- `test(experimental)` (305b77c): real-tcp readiness test + `examples-syntax.test.ts`.
-- `test` (59d4b1e): **graduated** `services.ts`/`services-docker.ts` into the 100% coverage
-  allowlist (real-daemon seams `v8 ignore`'d) + a real **integration tier**
-  (`src/services.integration.test.ts` — real Postgres migration, gated/skips without Docker).
-- `refactor(experimental)` (6b90895): **parse-don't-validate + irrepresentable illegal states**
-  — `parseDockerPort → number|undefined`, `ServiceReady` parsed once into a tagged `ReadyProbe`,
-  `ServiceHandle.port?/url?` (no magic `0`/`""`), exhaustive `switch`+`assertNever`.
-- `feat(dev)` (ebbb9d3): **code-quality dev skill** (`dev/skills/code-quality/`, in the
-  `vigiles-dev` plugin, NOT shipped) — SKILL.md + 5 technique references (parse-don't-validate,
-  illegal-states, exhaustive-matching, pure-functions, public-API), each grounded in the refactor.
-- `fix(experimental)` (407b289): the 2 Codex P2 fixes — `measure()` is SINGLE-arg
-  (checks/trials inside the one MeasureSpec; the example/doc wrongly passed a 2nd object) +
-  tcp readiness now honors the DECLARED port (`ReadyProbe.containerPort`).
-- `chore` (65f99de): removed a stray `.tmp-genh-cli-*` test dir + gitignored the scratch patterns.
+- **P0-1** `loadPlugin` recognizes THREE repo shapes — published plugin / bare `skills/*` library /
+  plain `.claude/skills` user repo — via a new optional `PluginLayout.userSurfaceRoot` (`.claude`
+  in the CC adapter; core stays agnostic, `.claude` literal only in the adapter). Root `skills/`
+  WINS over `.claude/skills`. A single skill dir works. `LoadedPlugin.sources` maps each
+  materialized key → its real on-disk path. Reads the PROJECT `.claude` only, never `~/.claude`.
+- **P0-2** `vigiles lint` now SCOPES to an explicit dir arg (was: ignored the path, scanned the
+  whole repo → reported foreign surfaces). `runLint` resolves ONE `scanRoot` (single existing dir →
+  narrow; file / several / none → cwd, so **bare `lint` is byte-identical**) threaded into all 21
+  surface appliers (replaced `process.cwd()`). Bugfix — only `lint <dir>` changes.
+- **P1-3** skill-resources skips glob / placeholder refs (`* ? { } < >`) + `~/` home paths.
+- **P1-4** OPT-IN `sharedDirs` config — a ref whose first segment is a declared shared dir also
+  resolves at the repo root; scoped so nothing outside it is masked; default byte-identical.
+- **P2-6** lethal-trifecta advisory collapsed to one line per unit. **P2-7** `docs/skills-monorepo.md`.
 
-Design record: `research/r3-disposable-services.md`. Public guide: `docs/measuring-skills.md`
-§ Experimental + § Safety. Migration: `docs/migrating-from-promptfoo.md`.
+Files: `src/plugin-loader.ts`, `src/core/layout.ts`, `src/adapters/claude-code/layout.ts`,
+`src/scan.ts`, `src/core/skill-resources.ts`, `src/core/types.ts` (`sharedDirs`), `src/cli.ts`
+(scanRoot). Tests: `src/scan.test.ts`, `src/core/skill-resources.test.ts`, `src/scan-cli.test.ts`
+(lint-scoping e2e), `src/adapters/claude-code/plugin-loader.test.ts`.
 
-**DONE this session (was the open question):** graduated `src/services.ts` +
-`src/services-docker.ts` into the vitest **100% coverage allowlist** (real-daemon seams
-`v8 ignore`'d like `sandbox.ts`). Coverage gate passes locally.
+**NEXT (not blocking):** the feedback is fully addressed. The field report's exact "global
+`~/.claude` skills appeared" symptom couldn't be reproduced from code (their env) — P0-2's
+correct rooting closes it either way. Possible follow-up: the `init` ADOPT/untested discovery
+also walks cwd; P0-2 scopes the lint appliers, adopt-discovery is a separate pass.
 
-**NEXT STEPS (the R3 loop, deferred + documented, not blocking):**
-
-- per-trial container reset (needs an eval-loop hook in `eval.ts`; today services live
-  per-RUN → make the task self-contained or `trials: 1`).
-- the egress wall (skill reaches only model + service) — until it lands, R3 safety story is
-  "run in an isolated env + keep real creds out (recommend `ephemeralEnv`)".
-- first-class `services` option on `measureArms` + `ctx.service(name)` (today: compose via
-  `experimental_withServices`).
-- safe-default credential-scrub; a write-don't-run OSS-skill-through-R3 dogfood.
-
-**TEST STATUS:** Linux real-docker integration RUNS in CI (`ubuntu-latest` has Docker) via a
-gated `describe.skipIf(!dockerUp)` real-redis test. macOS UNTESTED (docs say Linux-first). No
-OSS-skill-through-R3 dogfood (inherently needs model auth). Experimental files sit OUTSIDE the
-100% coverage gate (deliberate — see the OPEN item).
+**TEST STATUS:** full vitest **2074 passed** locally; the only failure is env-only
+`dialect-drift.test.ts` (installed vs pinned CC — CI pins it). eslint/tsc/test:types/fmt/api all
+green locally.
 
 ## Don't re-read unless the task needs it
 
@@ -116,6 +93,16 @@ OSS-skill-through-R3 dogfood (inherently needs model auth). Experimental files s
 
 ## Decisions of record (don't relitigate)
 
+- **`sharedDirs` is OPT-IN by design** (P1-4). Resolving a bundled `SKILL.md` ref against the repo
+  root BY DEFAULT can mask a genuinely-missing bundled resource (a same-named file at root → false
+  negative). So only a ref whose first segment is a repo-DECLARED shared dir gets root resolution;
+  a repo that sets no `sharedDirs` is byte-identical to before.
+- **`lint <dir>` scoping is a BUGFIX, not a breaking change** (P0-2). The path was silently ignored;
+  now a single explicit dir narrows the scan. Bare `vigiles lint` (the CI-common case) stays
+  whole-repo / byte-identical. Only someone who passed a dir AND relied on the accidental whole-repo
+  scan sees narrower coverage.
+- **`userSurfaceRoot` / `.claude/skills` reading is PROJECT-only** — never `~/.claude`. Keeps CI
+  reproducible. The `.claude` literal lives in the CC adapter layout, not core (`core ⊄ adapter`).
 - Repo is PUBLIC → strategy is VAULT-ONLY (`doc-tiers`). HANDOFF/research/CLAUDE.md/README = public.
   **Never name a specific user/company/$ figure in the repo** — one such mention was scrubbed from
   branch history this session via `git reset --soft` + force-push-with-lease.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ How-to and reference docs for using vigiles. New here? Start with the
 ## Verify your instruction files (layer 1)
 
 - [`verifying-instruction-files.md`](verifying-instruction-files.md) — the full guide: the markdown→typed-spec ladder, the three rule types (`enforce` / `guidance` / `guard`), verified references + marks, and the before/after tables.
+- [`skills-monorepo.md`](skills-monorepo.md) — adopt vigiles in a CI-tested skill library or a plain `.claude/` repo (no `plugin.json`): the three repo shapes it loads, the `sharedDirs` opt-in, and what a `SKILL.md` body ref resolves.
 
 ## Guard the harness — compiled hooks
 

--- a/docs/skills-monorepo.md
+++ b/docs/skills-monorepo.md
@@ -1,0 +1,95 @@
+# Adopting vigiles in a skills monorepo (no `plugin.json`)
+
+> The [README](../README.md) has the pitch; this is the how-to for a repo that is
+> **not** a published `.claude-plugin/` marketplace — a CI-tested skill library, or
+> a plain Claude Code repo where your skills live under `.claude/`. If `audit`
+> reported `F (0/100) — no loadable plugin surface`, this page is for you.
+
+## The three repo shapes vigiles recognizes
+
+You do **not** need a `plugin.json` or a marketplace layout. vigiles loads any of
+these as first-class:
+
+| Shape                      | Where skills live                                                                           | Typical repo                     |
+| -------------------------- | ------------------------------------------------------------------------------------------- | -------------------------------- |
+| **Published plugin**       | `skills/<name>/SKILL.md` + `.claude-plugin/plugin.json`                                     | a marketplace plugin             |
+| **Skills library**         | `skills/<name>/SKILL.md` at the repo root, no manifest                                      | a CI-tested skill monorepo       |
+| **Plain Claude Code repo** | `.claude/skills/<name>/SKILL.md` (+ `.claude/agents`, `.claude/settings.json`, `CLAUDE.md`) | a normal user repo, not a plugin |
+
+Point `audit`/`lint` at the repo root and vigiles reads whichever shape it finds.
+You can also point it at a **single skill directory** (the dir holding one
+`SKILL.md`) and it scans just that skill.
+
+```bash
+npx vigiles audit .                      # the whole repo
+npx vigiles audit skills/rca-investigation   # one skill dir
+```
+
+ℹ️ **Repo-root `skills/` wins over `.claude/skills/`.** If a repo has both, the
+root `skills/` is used — so a plugin author's own local `.claude/skills` dev skills
+never pollute the audit of what the plugin ships. A plain user (no root `skills/`)
+is read from `.claude/skills` as expected.
+
+⚠️ vigiles reads your **project** `.claude/` only. It never scans the machine-global
+`~/.claude/` install — CI results stay reproducible and independent of the runner's
+home dir.
+
+## Shared `scripts/` / `references/` trees — `sharedDirs`
+
+Many skill libraries keep **one** top-level `scripts/` (or `references/`) tree that
+several skills point at, instead of a copy beside every `SKILL.md`:
+
+```
+repo/
+  skills/eval-generator/SKILL.md   # body references `scripts/promptfoo/leak_scan.py`
+  scripts/promptfoo/leak_scan.py   # ...which lives HERE, at the repo root
+```
+
+By default a bundled reference resolves against the skill's **own** directory, so
+the ref above would be reported as a missing bundled resource. Declare your shared
+dirs in `.vigilesrc.json` and vigiles **also** resolves those refs against the repo
+root:
+
+```json
+{
+  "sharedDirs": ["scripts", "references"]
+}
+```
+
+- ✅ **Opt-in.** A repo that omits `sharedDirs` behaves exactly as before
+  (skill-dir-only resolution) — no change.
+- ✅ **Scoped.** Only a ref whose **first path segment** is a declared shared dir
+  gets repo-root resolution. A ref outside those dirs is never masked by a
+  same-named file at the repo root, so a genuinely-missing bundled resource is
+  still flagged.
+
+## What resolves and what's skipped in a `SKILL.md` body
+
+The bundled-resource check is deliberately high-precision (it won't cry wolf on a
+legitimate authoring style):
+
+| In the body                                                | Treated as                                 |
+| ---------------------------------------------------------- | ------------------------------------------ |
+| `scripts/run.sh`, `[api](references/api.md)`               | a concrete ref — checked                   |
+| `references/*.md`, `scripts/tests/test_<target>_*.py`      | a glob / placeholder — **skipped**         |
+| `references/linter-cards/{trivial,contextual}/<linter>.md` | a template placeholder — **skipped**       |
+| `Read ~/.claude/docs/x.md`                                 | an external home/global path — **skipped** |
+| `${CLAUDE_PLUGIN_ROOT}/x`, `https://…`, `/abs/path`        | var / URL / absolute — **skipped**         |
+
+## Which surfaces gate CI
+
+`audit` is a **local report** (like Lighthouse). For CI, use `vigiles lint` — the
+deterministic gate. The lethal-trifecta findings are summarized with a count (one
+line per unit); gate on "no NEW trifecta" via the `lethal-trifecta` lint rule
+rather than eyeballing the list.
+
+> **Known limitation.** When you pass an explicit path to `vigiles lint`
+> (e.g. `vigiles lint skills/one`), the surface rules (subagent contracts, skill
+> resources, MCP, …) currently scan the whole repo from the working directory, not
+> only that path. Run `lint` from the repo root and use `.vigilesrc.json` `exclude`
+> globs to scope out fixtures. Tightening per-path scoping is tracked.
+
+## See also
+
+- [Measuring skills](measuring-skills.md) — A/B a skill on your subscription.
+- [Verifying instruction files](verifying-instruction-files.md) — the lint rules.

--- a/docs/skills-monorepo.md
+++ b/docs/skills-monorepo.md
@@ -83,11 +83,11 @@ deterministic gate. The lethal-trifecta findings are summarized with a count (on
 line per unit); gate on "no NEW trifecta" via the `lethal-trifecta` lint rule
 rather than eyeballing the list.
 
-> **Known limitation.** When you pass an explicit path to `vigiles lint`
-> (e.g. `vigiles lint skills/one`), the surface rules (subagent contracts, skill
-> resources, MCP, …) currently scan the whole repo from the working directory, not
-> only that path. Run `lint` from the repo root and use `.vigilesrc.json` `exclude`
-> globs to scope out fixtures. Tightening per-path scoping is tracked.
+**Scoping.** `vigiles lint` (no path) lints the whole repo — the normal CI call.
+Pass a single directory (`vigiles lint packages/foo`) to scope every surface rule
+to just that subtree; a file, several paths, or none falls back to the whole repo.
+A surface outside the path you pass — and the machine-global `~/.claude` — never
+enters the report.
 
 ## See also
 

--- a/docs/verifying-instruction-files.md
+++ b/docs/verifying-instruction-files.md
@@ -275,4 +275,5 @@ Everything vigiles compiles and lints is **deterministic** — same input, same 
 - [Linter support](linter-support.md) — the 7 catalogs + `generate-types` / `generate-schema`.
 - [CLI & CI reference](cli.md) · [Agent setup](agent-setup.md).
 - [Compiled hooks](compiled-hooks.md) — the deterministic **gate** instrument: author a hook that can't be wrong.
+- [Skills monorepo adoption](skills-monorepo.md) — a CI-tested skill library or a plain `.claude/` repo (no `plugin.json`).
 - [Testing your harness](harness-testing.md) — Layer 2.

--- a/etc/vigiles-adapter.api.md
+++ b/etc/vigiles-adapter.api.md
@@ -136,6 +136,7 @@ export interface PluginLayout {
     readonly settingsPath: string;
     readonly skillDir: string;
     readonly surfaceDirs: readonly string[];
+    readonly userSurfaceRoot?: string;
 }
 
 // @public

--- a/etc/vigiles-claude-code.api.md
+++ b/etc/vigiles-claude-code.api.md
@@ -97,6 +97,7 @@ export interface LoadedPlugin {
     readonly settings: {
         hooks?: unknown;
     };
+    readonly sources: Record<string, string>;
     readonly warnings: readonly string[];
 }
 

--- a/src/adapters/claude-code/layout.ts
+++ b/src/adapters/claude-code/layout.ts
@@ -13,6 +13,10 @@ export const claudeCodeLayout: PluginLayout = {
   settingsFormat: "json",
   instructionFile: "CLAUDE.md",
   surfaceDirs: ["skills", "agents", "commands"],
+  // A plain Claude Code USER keeps skills/agents/commands under `.claude/`, not at
+  // the repo root (that's the published-plugin shape). Read both so a normal repo
+  // isn't seen as an empty machine.
+  userSurfaceRoot: ".claude",
   skillDir: "skills",
   agentDir: "agents",
   commandDir: "commands",

--- a/src/adapters/claude-code/plugin-loader.test.ts
+++ b/src/adapters/claude-code/plugin-loader.test.ts
@@ -6,7 +6,7 @@
 import { test } from "vitest";
 import assert from "node:assert/strict";
 import { writeFileSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { join, basename } from "node:path";
 
 import { loadPlugin, resolveHarness } from "./plugin-loader.js";
 import { makeTmpDir, cleanupTmpDir } from "../../core/test-utils.js";
@@ -396,6 +396,85 @@ test("a fully-covered plugin (hooks + CLAUDE.md + skills) has no warnings", () =
   const root = makePlugin();
   try {
     assert.deepEqual(loadPlugin(root).warnings, []);
+  } finally {
+    cleanupTmpDir(root);
+  }
+});
+
+test("loadPlugin loads an end-user repo's .claude/skills (no plugin.json)", () => {
+  // The MAJORITY shape: a plain Claude Code user, skills under `.claude/skills/`,
+  // not a published plugin. Before this the loader saw an empty machine here.
+  const root = makeTmpDir("userrepo");
+  try {
+    writeFileSync(join(root, "CLAUDE.md"), "# my project\n");
+    mkdirSync(join(root, ".claude", "skills", "rca"), { recursive: true });
+    writeFileSync(
+      join(root, ".claude", "skills", "rca", "SKILL.md"),
+      "---\nname: rca\ndescription: Investigate an incident\n---\n# rca\n",
+    );
+    const loaded = loadPlugin(root);
+    // materialized under the SAME canonical key as a repo-root skill would be
+    const key = join(".claude", "skills", "rca", "SKILL.md");
+    assert.ok(loaded.files[key], "the .claude/skills skill is loaded");
+    // real on-disk source recorded (the file lives UNDER .claude/, not repo root)
+    assert.equal(
+      loaded.sources[key],
+      join(root, ".claude", "skills", "rca", "SKILL.md"),
+    );
+    // not an empty machine
+    assert.ok(!loaded.warnings.some((w) => w.includes("nothing was loaded")));
+  } finally {
+    cleanupTmpDir(root);
+  }
+});
+
+test("loadPlugin prefers a repo-root skills/ over .claude/skills when both exist", () => {
+  // A plugin/library author's OWN local `.claude/skills` dev skills must not
+  // pollute the audit of what the plugin ships — the repo-root `skills/` wins.
+  const root = makeTmpDir("bothshapes");
+  try {
+    mkdirSync(join(root, "skills", "lib-skill"), { recursive: true });
+    writeFileSync(join(root, "skills", "lib-skill", "SKILL.md"), "# lib\n");
+    mkdirSync(join(root, ".claude", "skills", "user-skill"), {
+      recursive: true,
+    });
+    writeFileSync(
+      join(root, ".claude", "skills", "user-skill", "SKILL.md"),
+      "# user\n",
+    );
+    const { files } = loadPlugin(root);
+    assert.equal(
+      files[join(".claude", "skills", "lib-skill", "SKILL.md")],
+      "# lib\n",
+      "the repo-root skill is loaded",
+    );
+    assert.equal(
+      files[join(".claude", "skills", "user-skill", "SKILL.md")],
+      undefined,
+      "the .claude/skills fallback is skipped when repo-root skills/ exists",
+    );
+  } finally {
+    cleanupTmpDir(root);
+  }
+});
+
+test("loadPlugin loads a single skill directory (SKILL.md at the target root)", () => {
+  // Pointing `audit`/`test` at ONE skill dir — the natural thing to do — used to
+  // yield "no loadable surface". Now it materializes as a skill named by the dir.
+  const root = makeTmpDir("one-skill");
+  try {
+    writeFileSync(
+      join(root, "SKILL.md"),
+      "---\nname: solo\ndescription: A solo skill\n---\n# solo\n",
+    );
+    const loaded = loadPlugin(root);
+    const key = join(".claude", "skills", basename(root), "SKILL.md");
+    assert.ok(
+      loaded.files[key],
+      "the sole SKILL.md is materialized as a skill",
+    );
+    assert.equal(loaded.sources[key], join(root, "SKILL.md"));
+    assert.ok(!loaded.warnings.some((w) => w.includes("nothing was loaded")));
   } finally {
     cleanupTmpDir(root);
   }

--- a/src/adapters/claude-code/plugin-loader.test.ts
+++ b/src/adapters/claude-code/plugin-loader.test.ts
@@ -595,3 +595,30 @@ test("loadPlugin does NOT fall back to .claude for a manifest-backed (hook-only)
     cleanupTmpDir(root);
   }
 });
+
+test("loadPlugin treats a hooks/hooks.json convention plugin as plugin-shaped (no .claude fallback)", () => {
+  // A hook-only plugin via the `hooks/hooks.json` convention (no manifest, no root
+  // surfaces) is still a plugin — its project-local `.claude/skills` is dev-only.
+  const root = makeTmpDir("hooksconv-plugin");
+  try {
+    mkdirSync(join(root, "hooks"), { recursive: true });
+    writeFileSync(
+      join(root, "hooks", "hooks.json"),
+      JSON.stringify({
+        hooks: { Stop: [{ hooks: [{ type: "command", command: "exit 0" }] }] },
+      }),
+    );
+    mkdirSync(join(root, ".claude", "skills", "dev"), { recursive: true });
+    writeFileSync(
+      join(root, ".claude", "skills", "dev", "SKILL.md"),
+      "---\nname: dev\ndescription: a local dev skill\n---\nbody\n",
+    );
+    const { files } = loadPlugin(root);
+    assert.ok(
+      !files[join(".claude", "skills", "dev", "SKILL.md")],
+      "a hooks-convention plugin's project-local .claude/skills is NOT materialized",
+    );
+  } finally {
+    cleanupTmpDir(root);
+  }
+});

--- a/src/adapters/claude-code/plugin-loader.test.ts
+++ b/src/adapters/claude-code/plugin-loader.test.ts
@@ -492,3 +492,27 @@ test("loadPlugin reads the in-repo vigiles plugin (dogfood)", () => {
   );
   assert.ok(typeof loaded.files["CLAUDE.md"] === "string", "CLAUDE.md loaded");
 });
+
+test("loadPlugin materializes a single skill dir's WHOLE subtree (bundled resources)", () => {
+  // Pointing at one skill dir must ship its bundled resources too, not just
+  // SKILL.md — else a single-skill harness test/eval runs against a harness
+  // missing the skill's own scripts/references.
+  const root = makeTmpDir("solo-skill");
+  try {
+    writeFileSync(
+      join(root, "SKILL.md"),
+      "---\nname: solo\ndescription: a solo skill\n---\nRun scripts/run.sh\n",
+    );
+    mkdirSync(join(root, "scripts"), { recursive: true });
+    writeFileSync(join(root, "scripts", "run.sh"), "#!/usr/bin/env bash\n");
+    const { files, sources } = loadPlugin(root);
+    const name = basename(root);
+    const skillKey = join(".claude", "skills", name, "SKILL.md");
+    const resKey = join(".claude", "skills", name, "scripts", "run.sh");
+    assert.ok(files[skillKey], "SKILL.md materialized");
+    assert.ok(files[resKey], "bundled script materialized (not just SKILL.md)");
+    assert.equal(sources[resKey], join(root, "scripts", "run.sh"));
+  } finally {
+    cleanupTmpDir(root);
+  }
+});

--- a/src/adapters/claude-code/plugin-loader.test.ts
+++ b/src/adapters/claude-code/plugin-loader.test.ts
@@ -566,3 +566,32 @@ test("loadPlugin does NOT import project-local .claude/agents into a plugin", ()
     cleanupTmpDir(root);
   }
 });
+
+test("loadPlugin does NOT fall back to .claude for a manifest-backed (hook-only) plugin", () => {
+  // A hook-only plugin has a manifest + hooks but no root surface dirs; its
+  // project-local `.claude/skills` is dev-only and must not be imported as shipped
+  // just because there's no root `skills/`.
+  const root = makeTmpDir("hookonly-plugin");
+  try {
+    mkdirSync(join(root, ".claude-plugin"), { recursive: true });
+    writeFileSync(
+      join(root, ".claude-plugin", "plugin.json"),
+      JSON.stringify({
+        name: "hookonly",
+        hooks: { Stop: [{ hooks: [{ type: "command", command: "exit 0" }] }] },
+      }),
+    );
+    mkdirSync(join(root, ".claude", "skills", "dev"), { recursive: true });
+    writeFileSync(
+      join(root, ".claude", "skills", "dev", "SKILL.md"),
+      "---\nname: dev\ndescription: a local dev skill\n---\nbody\n",
+    );
+    const { files } = loadPlugin(root);
+    assert.ok(
+      !files[join(".claude", "skills", "dev", "SKILL.md")],
+      "a manifest-backed plugin's project-local .claude/skills is NOT materialized",
+    );
+  } finally {
+    cleanupTmpDir(root);
+  }
+});

--- a/src/adapters/claude-code/plugin-loader.test.ts
+++ b/src/adapters/claude-code/plugin-loader.test.ts
@@ -516,3 +516,53 @@ test("loadPlugin materializes a single skill dir's WHOLE subtree (bundled resour
     cleanupTmpDir(root);
   }
 });
+
+test("loadPlugin falls back to .claude/skills when the root skills/ is EMPTY", () => {
+  // An empty (or unrelated) root `skills/` must NOT shadow real `.claude/skills`
+  // — else a plain user repo is reported empty (the F/0 this change fixes).
+  const root = makeTmpDir("empty-root-skills");
+  try {
+    mkdirSync(join(root, "skills"), { recursive: true }); // present but EMPTY
+    mkdirSync(join(root, ".claude", "skills", "rca"), { recursive: true });
+    writeFileSync(
+      join(root, ".claude", "skills", "rca", "SKILL.md"),
+      "---\nname: rca\ndescription: a real user skill\n---\nbody\n",
+    );
+    const { files } = loadPlugin(root);
+    assert.ok(
+      files[join(".claude", "skills", "rca", "SKILL.md")],
+      "the real .claude/skills skill is read despite an empty root skills/",
+    );
+  } finally {
+    cleanupTmpDir(root);
+  }
+});
+
+test("loadPlugin does NOT import project-local .claude/agents into a plugin", () => {
+  // A plugin/library repo (has a shipped root `skills/`) must not materialize a
+  // developer's local `.claude/agents` as if the plugin ships them.
+  const root = makeTmpDir("plugin-devagents");
+  try {
+    mkdirSync(join(root, "skills", "foo"), { recursive: true });
+    writeFileSync(
+      join(root, "skills", "foo", "SKILL.md"),
+      "---\nname: foo\ndescription: a shipped skill\n---\nbody\n",
+    );
+    mkdirSync(join(root, ".claude", "agents"), { recursive: true });
+    writeFileSync(
+      join(root, ".claude", "agents", "dev.md"),
+      "---\nname: dev\ndescription: a local dev agent\n---\nbody\n",
+    );
+    const { files } = loadPlugin(root);
+    assert.ok(
+      files[join(".claude", "skills", "foo", "SKILL.md")],
+      "the shipped root skill is loaded",
+    );
+    assert.ok(
+      !files[join(".claude", "agents", "dev.md")],
+      "a plugin's project-local .claude/agents dev agent is NOT materialized",
+    );
+  } finally {
+    cleanupTmpDir(root);
+  }
+});

--- a/src/adapters/claude-code/plugin-loader.test.ts
+++ b/src/adapters/claude-code/plugin-loader.test.ts
@@ -622,3 +622,26 @@ test("loadPlugin treats a hooks/hooks.json convention plugin as plugin-shaped (n
     cleanupTmpDir(root);
   }
 });
+
+test("loadPlugin ignores a stray non-loadable file in root skills/ (falls back to .claude/skills)", () => {
+  // A plain user repo may have a `skills/README.md` (or `.gitkeep`) but no real
+  // root skill; that stray file must NOT mark the root populated and shadow the
+  // real `.claude/skills` — only a `<name>/SKILL.md` counts as loadable.
+  const root = makeTmpDir("stray-root-skills");
+  try {
+    mkdirSync(join(root, "skills"), { recursive: true });
+    writeFileSync(join(root, "skills", "README.md"), "# not a skill\n");
+    mkdirSync(join(root, ".claude", "skills", "rca"), { recursive: true });
+    writeFileSync(
+      join(root, ".claude", "skills", "rca", "SKILL.md"),
+      "---\nname: rca\ndescription: a real user skill\n---\nbody\n",
+    );
+    const { files } = loadPlugin(root);
+    assert.ok(
+      files[join(".claude", "skills", "rca", "SKILL.md")],
+      "a stray skills/README.md must not shadow the real .claude/skills",
+    );
+  } finally {
+    cleanupTmpDir(root);
+  }
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3798,6 +3798,9 @@ function checkSkillResourceResolves(
   try {
     found = scanPlugin(scanRoot, adapter.layout, adapter.dialect, {
       sharedDirs: config?.sharedDirs,
+      // sharedDirs live at the repo root (config location = cwd), which may be a
+      // PARENT of a scoped scanRoot (`lint packages/foo`) — resolve them there.
+      sharedDirsRoot: process.cwd(),
     }).skillResourceIssues;
   } catch {
     return { issues: 0, errors: 0 };
@@ -6482,6 +6485,7 @@ async function main(): Promise<void> {
           : det.adapter;
         const report = scanPlugin(targets[0], adapter.layout, adapter.dialect, {
           sharedDirs: config.sharedDirs,
+          sharedDirsRoot: process.cwd(),
         });
         if (!json) {
           console.log(`Detected harness: ${adapter.name}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1394,6 +1394,20 @@ async function runLint(
   });
   const adapter = lintSelection.adapter;
 
+  // P0-2: scope the surface checks (subagent contracts, skill resources, MCP, …)
+  // to an explicit DIRECTORY target when one is given, instead of always scanning
+  // the whole working dir and reporting surfaces the user didn't point at. Only a
+  // SINGLE existing directory narrows; a file / several paths / none → cwd, so
+  // bare `vigiles lint` (the CI-common case) stays byte-identical. scanPlugin
+  // reads only under this root, so a surface outside it can never enter the report.
+  const positional = restArgs.filter((a) => !a.startsWith("--"));
+  const scanRoot =
+    positional.length === 1 &&
+    existsSync(positional[0]) &&
+    lstatSync(positional[0]).isDirectory()
+      ? resolve(positional[0])
+      : process.cwd();
+
   // 1. Verify hashes and structure
   if (!silent) {
     if (files.length > 0) {
@@ -1464,91 +1478,141 @@ async function runLint(
   // 7b. Untested-surface check — skills/agents/hooks shipping without a test or
   // eval. Warning by default (a nudge, exit 0); set rules.untested-{skill,agent,
   // hook} to "error" to gate CI. See src/test-coverage.ts and docs/rules/.
-  const untested = checkUntestedSurfaces(config, silent, adapter);
+  const untested = checkUntestedSurfaces(config, silent, adapter, scanRoot);
 
   // 7c. Subagent tool-contract check — cross-reference each subagent's `tools:`
   // rail against the harness catalog (the moat). n/a on a harness with no
   // subagents. Off by default unless a severity is configured; warning surfaces
   // a typo/never-available tool, error gates CI.
-  const toolContract = checkSubagentToolContracts(config, silent, adapter);
+  const toolContract = checkSubagentToolContracts(
+    config,
+    silent,
+    adapter,
+    scanRoot,
+  );
 
   // 7d. Hook-event check — a hook registered under an event the harness doesn't
   // define never fires. High-precision (close typos only). Off unless configured.
-  const hookEvents = checkHookEvents(config, silent, adapter);
+  const hookEvents = checkHookEvents(config, silent, adapter, scanRoot);
 
   // 7e. Subagent-frontmatter check — a subagent missing required frontmatter
   // (name + description) won't register. n/a on a harness with no subagents.
-  const frontmatter = checkFrontmatterSchema(config, silent, adapter);
+  const frontmatter = checkFrontmatterSchema(config, silent, adapter, scanRoot);
 
   // 7f. MCP-config check — a declared MCP server with no command/url can't start.
-  const mcpConfig = checkMcpConfig(config, silent, adapter);
+  const mcpConfig = checkMcpConfig(config, silent, adapter, scanRoot);
 
   // 7g. Skill-frontmatter — RECOMMEND explicit name/description on skills (a
   // reliable trigger surface). Best-practice nudge; skills load without it.
-  const skillFm = checkSkillFrontmatter(config, silent, adapter);
+  const skillFm = checkSkillFrontmatter(config, silent, adapter, scanRoot);
 
   // 7h. MCP tool-resolution — an `mcp__server__tool` in a contract whose server
   // the plugin doesn't declare can't resolve (the MCP half of the tool moat).
-  const mcpToolResolves = checkMcpToolResolves(config, silent, adapter);
+  const mcpToolResolves = checkMcpToolResolves(
+    config,
+    silent,
+    adapter,
+    scanRoot,
+  );
 
   // 7i. Hook-script existence — a hook command referencing a missing script file
   // never runs (matches Anthropic's own `claude plugin validate`).
-  const hookScripts = checkHookScriptExists(config, silent, adapter);
+  const hookScripts = checkHookScriptExists(config, silent, adapter, scanRoot);
 
   // 7j. Disallowed-tools — a `disallowedTools:` block-list typo blocks nothing
   // (the deny-side mirror of subagent-tool-contract; close-typo only).
-  const disallowedTools = checkDisallowedTools(config, silent, adapter);
+  const disallowedTools = checkDisallowedTools(
+    config,
+    silent,
+    adapter,
+    scanRoot,
+  );
 
   // 7k. Description-overlap — two model-invocable skills with near-identical
   // descriptions collide in the selector (deterministic NCD precision proxy).
-  const descriptionOverlap = checkDescriptionOverlap(config, silent, adapter);
+  const descriptionOverlap = checkDescriptionOverlap(
+    config,
+    silent,
+    adapter,
+    scanRoot,
+  );
 
   // 7k². Skill-description-budget — a model-invocable skill whose description is
   // so long the trigger signal is buried (heuristic proxy; degrades recall +
   // precision). Generous 500-char budget; warn-tier, never gates.
-  const descriptionBudget = checkDescriptionBudget(config, silent, adapter);
+  const descriptionBudget = checkDescriptionBudget(
+    config,
+    silent,
+    adapter,
+    scanRoot,
+  );
 
   // 7l. Frontmatter-valid — a `---` block that isn't valid YAML (warn; js-yaml is
   // stricter than some loaders, so verify before enforcing).
-  const frontmatterValid = checkFrontmatterValid(config, silent, adapter);
+  const frontmatterValid = checkFrontmatterValid(
+    config,
+    silent,
+    adapter,
+    scanRoot,
+  );
 
   // 7m. MCP hook-target — a `type: mcp_tool` hook action that's incomplete or
   // targets an undeclared server (the moat applied to the hook surface).
-  const mcpHookTargets = checkMcpHookTargets(config, silent, adapter);
+  const mcpHookTargets = checkMcpHookTargets(config, silent, adapter, scanRoot);
 
   // 7n. Prefer-compiled-hooks — ONE discovery nudge (not per-hook) toward
   // compiled `vigiles/hook` artifacts when hand-written hooks ship. Recommendation.
-  const preferCompiledHooks = checkPreferCompiledHooks(config, silent, adapter);
+  const preferCompiledHooks = checkPreferCompiledHooks(
+    config,
+    silent,
+    adapter,
+    scanRoot,
+  );
 
   // 7o. Lethal-trifecta — a unit (subagent / model-invocable skill) whose tools
   // hold all three legs (read-private + ingest-untrusted + exfiltrate) is a
   // prompt-injection exfil path (Rule of Two). Capability SET-intersection.
-  const lethalTrifecta = checkLethalTrifecta(config, silent, adapter);
+  const lethalTrifecta = checkLethalTrifecta(config, silent, adapter, scanRoot);
 
   // 7p. Skill-resource — a SKILL.md body referencing a bundled file that doesn't
   // exist on disk under the skill dir (the agent gets nothing). FP-safe.
-  const skillResources = checkSkillResourceResolves(config, silent, adapter);
+  const skillResources = checkSkillResourceResolves(
+    config,
+    silent,
+    adapter,
+    scanRoot,
+  );
 
   // 7q. Skill-missing-fence — a SKILL.md opening with `name:`/`description:` but no
   // `---` fence loads as plain body (invisible — no name/description/trigger).
-  const skillFence = checkSkillMissingFence(config, silent, adapter);
+  const skillFence = checkSkillMissingFence(config, silent, adapter, scanRoot);
 
   // 7r. Plugin-dir-layout — functional surface dirs (skills/agents/commands) nested
   // inside the `.claude-plugin/` manifest dir where the harness can't see them.
-  const pluginLayout = checkPluginDirLayout(config, silent, adapter);
+  const pluginLayout = checkPluginDirLayout(config, silent, adapter, scanRoot);
 
   // 7s. Delegation-trifecta — a lethal trifecta that emerges across a delegation
   // edge (a subagent's own ∪ delegated-to capability) though no single unit trips it.
-  const delegationTrifecta = checkDelegationTrifecta(config, silent, adapter);
+  const delegationTrifecta = checkDelegationTrifecta(
+    config,
+    silent,
+    adapter,
+    scanRoot,
+  );
 
   // 7t. Hook-block-ineffective — a hook that looks like it blocks but silently
   // doesn't (block decision on a non-blocking event, or the legacy `decision`
   // field on a permission-gated event). The #1 verified hook pain (#19009).
-  const hookBlock = checkHookBlockIneffective(config, silent, adapter);
+  const hookBlock = checkHookBlockIneffective(
+    config,
+    silent,
+    adapter,
+    scanRoot,
+  );
 
   // 7u. Hook-matcher — a hook `matcher` that never fires (tool-name typo, or a
   // malformed/undeclared MCP form).
-  const hookMatcher = checkHookMatcher(config, silent, adapter);
+  const hookMatcher = checkHookMatcher(config, silent, adapter, scanRoot);
 
   // 8. Validate vigiles builder calls inside markdown code blocks. Default
   // is to validate every ref; illustrative blocks opt out via
@@ -3197,6 +3261,7 @@ function checkUntestedSurfaces(
   config: VigilesConfig | undefined,
   silent: boolean,
   adapter: HarnessAdapter,
+  scanRoot: string,
 ): { untested: number; errors: number } {
   const rules = config?.rules;
   const skillSev = ruleSeverity(rules?.["untested-skill"]);
@@ -3214,7 +3279,7 @@ function checkUntestedSurfaces(
     ...ruleOptions<TestCoverageConfig>(rules?.["untested-hook"]),
   };
   const report = findUntestedSurfaces({
-    basePath: process.cwd(),
+    basePath: scanRoot,
     layout: adapter.layout,
     skills: skillSev !== false,
     agents: agentSev !== false,
@@ -3273,6 +3338,7 @@ function checkSubagentToolContracts(
   config: VigilesConfig | undefined,
   silent: boolean,
   adapter: HarnessAdapter,
+  scanRoot: string,
 ): { issues: number; errors: number } {
   const sev = ruleSeverity(config?.rules?.["subagent-tool-contract"]);
   if (!sev) return { issues: 0, errors: 0 };
@@ -3293,7 +3359,7 @@ function checkSubagentToolContracts(
     toolIssues: readonly { message: string }[];
   }[];
   try {
-    agents = scanPlugin(process.cwd(), adapter.layout, adapter.dialect).agents;
+    agents = scanPlugin(scanRoot, adapter.layout, adapter.dialect).agents;
   } catch {
     return { issues: 0, errors: 0 };
   }
@@ -3332,6 +3398,7 @@ function checkHookEvents(
   config: VigilesConfig | undefined,
   silent: boolean,
   adapter: HarnessAdapter,
+  scanRoot: string,
 ): { issues: number; errors: number } {
   const sev = ruleSeverity(config?.rules?.["hook-events"]);
   if (!sev) return { issues: 0, errors: 0 };
@@ -3342,7 +3409,7 @@ function checkHookEvents(
   let found: readonly { message: string }[];
   try {
     found = scanPlugin(
-      process.cwd(),
+      scanRoot,
       adapter.layout,
       adapter.dialect,
     ).hookEventIssues;
@@ -3370,6 +3437,7 @@ function checkFrontmatterSchema(
   config: VigilesConfig | undefined,
   silent: boolean,
   adapter: HarnessAdapter,
+  scanRoot: string,
 ): { issues: number; errors: number } {
   const sev = ruleSeverity(config?.rules?.["subagent-frontmatter"]);
   if (!sev) return { issues: 0, errors: 0 };
@@ -3384,7 +3452,7 @@ function checkFrontmatterSchema(
   }
   let found: readonly { message: string; path: string }[];
   try {
-    const r = scanPlugin(process.cwd(), adapter.layout, adapter.dialect);
+    const r = scanPlugin(scanRoot, adapter.layout, adapter.dialect);
     found = [...r.frontmatterIssues, ...r.frontmatterValueIssues];
   } catch {
     return { issues: 0, errors: 0 };
@@ -3415,13 +3483,14 @@ function checkSkillFrontmatter(
   config: VigilesConfig | undefined,
   silent: boolean,
   adapter: HarnessAdapter,
+  scanRoot: string,
 ): { issues: number; errors: number } {
   const sev = ruleSeverity(config?.rules?.["skill-frontmatter"]);
   if (!sev) return { issues: 0, errors: 0 };
   let found: readonly { message: string; path: string }[];
   try {
     found = scanPlugin(
-      process.cwd(),
+      scanRoot,
       adapter.layout,
       adapter.dialect,
     ).skillMetaIssues;
@@ -3453,13 +3522,14 @@ function checkPreferCompiledHooks(
   config: VigilesConfig | undefined,
   silent: boolean,
   adapter: HarnessAdapter,
+  scanRoot: string,
 ): { issues: number; errors: number } {
   const sev = ruleSeverity(config?.rules?.["prefer-compiled-hooks"]);
   if (!sev) return { issues: 0, errors: 0 };
   let count: number;
   try {
     count = scanPlugin(
-      process.cwd(),
+      scanRoot,
       adapter.layout,
       adapter.dialect,
     ).manualHookCount;
@@ -3485,16 +3555,13 @@ function checkMcpConfig(
   config: VigilesConfig | undefined,
   silent: boolean,
   adapter: HarnessAdapter,
+  scanRoot: string,
 ): { issues: number; errors: number } {
   const sev = ruleSeverity(config?.rules?.["mcp-config"]);
   if (!sev) return { issues: 0, errors: 0 };
   let found: readonly { message: string }[];
   try {
-    found = scanPlugin(
-      process.cwd(),
-      adapter.layout,
-      adapter.dialect,
-    ).mcpIssues;
+    found = scanPlugin(scanRoot, adapter.layout, adapter.dialect).mcpIssues;
   } catch {
     return { issues: 0, errors: 0 };
   }
@@ -3519,6 +3586,7 @@ function checkDisallowedTools(
   config: VigilesConfig | undefined,
   silent: boolean,
   adapter: HarnessAdapter,
+  scanRoot: string,
 ): { issues: number; errors: number } {
   const sev = ruleSeverity(config?.rules?.["disallowed-tools-contract"]);
   if (!sev) return { issues: 0, errors: 0 };
@@ -3529,7 +3597,7 @@ function checkDisallowedTools(
   let found: { message: string; path: string }[];
   try {
     found = scanPlugin(
-      process.cwd(),
+      scanRoot,
       adapter.layout,
       adapter.dialect,
     ).agents.flatMap((a) =>
@@ -3566,13 +3634,14 @@ function checkFrontmatterValid(
   config: VigilesConfig | undefined,
   silent: boolean,
   adapter: HarnessAdapter,
+  scanRoot: string,
 ): { issues: number; errors: number } {
   const sev = ruleSeverity(config?.rules?.["frontmatter-valid"]);
   if (!sev) return { issues: 0, errors: 0 };
   let found: readonly { message: string; path: string }[];
   try {
     found = scanPlugin(
-      process.cwd(),
+      scanRoot,
       adapter.layout,
       adapter.dialect,
     ).malformedFrontmatter;
@@ -3604,13 +3673,14 @@ function checkDescriptionOverlap(
   config: VigilesConfig | undefined,
   silent: boolean,
   adapter: HarnessAdapter,
+  scanRoot: string,
 ): { issues: number; errors: number } {
   const sev = ruleSeverity(config?.rules?.["description-overlap"]);
   if (!sev) return { issues: 0, errors: 0 };
   let found: readonly { message: string }[];
   try {
     found = scanPlugin(
-      process.cwd(),
+      scanRoot,
       adapter.layout,
       adapter.dialect,
     ).descriptionOverlaps;
@@ -3638,13 +3708,14 @@ function checkDescriptionBudget(
   config: VigilesConfig | undefined,
   silent: boolean,
   adapter: HarnessAdapter,
+  scanRoot: string,
 ): { issues: number; errors: number } {
   const sev = ruleSeverity(config?.rules?.["skill-description-budget"]);
   if (!sev) return { issues: 0, errors: 0 };
   let found: readonly { message: string }[];
   try {
     found = scanPlugin(
-      process.cwd(),
+      scanRoot,
       adapter.layout,
       adapter.dialect,
     ).descriptionBudgetIssues;
@@ -3674,6 +3745,7 @@ function checkLethalTrifecta(
   config: VigilesConfig | undefined,
   silent: boolean,
   adapter: HarnessAdapter,
+  scanRoot: string,
 ): { issues: number; errors: number } {
   const sev = ruleSeverity(config?.rules?.["lethal-trifecta"]);
   if (!sev) return { issues: 0, errors: 0 };
@@ -3685,7 +3757,7 @@ function checkLethalTrifecta(
   }[];
   try {
     found = scanPlugin(
-      process.cwd(),
+      scanRoot,
       adapter.layout,
       adapter.dialect,
     ).trifectaFindings;
@@ -3714,6 +3786,7 @@ function checkSkillResourceResolves(
   config: VigilesConfig | undefined,
   silent: boolean,
   adapter: HarnessAdapter,
+  scanRoot: string,
 ): { issues: number; errors: number } {
   const sev = ruleSeverity(config?.rules?.["skill-resource-resolves"]);
   if (!sev) return { issues: 0, errors: 0 };
@@ -3723,7 +3796,7 @@ function checkSkillResourceResolves(
     finding: { ref: string; line: number };
   }[];
   try {
-    found = scanPlugin(process.cwd(), adapter.layout, adapter.dialect, {
+    found = scanPlugin(scanRoot, adapter.layout, adapter.dialect, {
       sharedDirs: config?.sharedDirs,
     }).skillResourceIssues;
   } catch {
@@ -3751,6 +3824,7 @@ function checkSkillMissingFence(
   config: VigilesConfig | undefined,
   silent: boolean,
   adapter: HarnessAdapter,
+  scanRoot: string,
 ): { issues: number; errors: number } {
   const sev = ruleSeverity(config?.rules?.["skill-missing-fence"]);
   if (!sev) return { issues: 0, errors: 0 };
@@ -3761,7 +3835,7 @@ function checkSkillMissingFence(
   }[];
   try {
     found = scanPlugin(
-      process.cwd(),
+      scanRoot,
       adapter.layout,
       adapter.dialect,
     ).skillFenceIssues;
@@ -3790,13 +3864,14 @@ function checkPluginDirLayout(
   config: VigilesConfig | undefined,
   silent: boolean,
   adapter: HarnessAdapter,
+  scanRoot: string,
 ): { issues: number; errors: number } {
   const sev = ruleSeverity(config?.rules?.["plugin-dir-layout"]);
   if (!sev) return { issues: 0, errors: 0 };
   let found: readonly { dir: string; message: string }[];
   try {
     found = scanPlugin(
-      process.cwd(),
+      scanRoot,
       adapter.layout,
       adapter.dialect,
     ).pluginLayoutIssues;
@@ -3825,6 +3900,7 @@ function checkDelegationTrifecta(
   config: VigilesConfig | undefined,
   silent: boolean,
   adapter: HarnessAdapter,
+  scanRoot: string,
 ): { issues: number; errors: number } {
   const sev = ruleSeverity(config?.rules?.["delegation-trifecta"]);
   if (!sev) return { issues: 0, errors: 0 };
@@ -3834,7 +3910,7 @@ function checkDelegationTrifecta(
   }[];
   try {
     found = scanPlugin(
-      process.cwd(),
+      scanRoot,
       adapter.layout,
       adapter.dialect,
     ).delegationTrifecta;
@@ -3863,6 +3939,7 @@ function checkHookBlockIneffective(
   config: VigilesConfig | undefined,
   silent: boolean,
   adapter: HarnessAdapter,
+  scanRoot: string,
 ): { issues: number; errors: number } {
   const sev = ruleSeverity(config?.rules?.["hook-block-ineffective"]);
   if (!sev) return { issues: 0, errors: 0 };
@@ -3877,7 +3954,7 @@ function checkHookBlockIneffective(
   }[];
   try {
     found = scanPlugin(
-      process.cwd(),
+      scanRoot,
       adapter.layout,
       adapter.dialect,
     ).hookBlockFindings;
@@ -3910,6 +3987,7 @@ function checkHookMatcher(
   config: VigilesConfig | undefined,
   silent: boolean,
   adapter: HarnessAdapter,
+  scanRoot: string,
 ): { issues: number; errors: number } {
   const sev = ruleSeverity(config?.rules?.["hook-matcher"]);
   if (!sev) return { issues: 0, errors: 0 };
@@ -3920,7 +3998,7 @@ function checkHookMatcher(
   let found: readonly { message: string }[];
   try {
     found = scanPlugin(
-      process.cwd(),
+      scanRoot,
       adapter.layout,
       adapter.dialect,
     ).hookMatcherFindings;
@@ -3948,6 +4026,7 @@ function checkMcpHookTargets(
   config: VigilesConfig | undefined,
   silent: boolean,
   adapter: HarnessAdapter,
+  scanRoot: string,
 ): { issues: number; errors: number } {
   const sev = ruleSeverity(config?.rules?.["mcp-hook-target-resolves"]);
   if (!sev) return { issues: 0, errors: 0 };
@@ -3962,11 +4041,7 @@ function checkMcpHookTargets(
   }
   let found: readonly { message: string }[];
   try {
-    found = scanPlugin(
-      process.cwd(),
-      adapter.layout,
-      adapter.dialect,
-    ).mcpHookIssues;
+    found = scanPlugin(scanRoot, adapter.layout, adapter.dialect).mcpHookIssues;
   } catch {
     return { issues: 0, errors: 0 };
   }
@@ -3992,6 +4067,7 @@ function checkHookScriptExists(
   config: VigilesConfig | undefined,
   silent: boolean,
   adapter: HarnessAdapter,
+  scanRoot: string,
 ): { issues: number; errors: number } {
   const sev = ruleSeverity(config?.rules?.["hook-script-exists"]);
   if (!sev) return { issues: 0, errors: 0 };
@@ -4007,7 +4083,7 @@ function checkHookScriptExists(
   let missing: { script: string }[];
   try {
     missing = scanPlugin(
-      process.cwd(),
+      scanRoot,
       adapter.layout,
       adapter.dialect,
     ).hooks.filter((h) => h.status === "missing");
@@ -4039,6 +4115,7 @@ function checkMcpToolResolves(
   config: VigilesConfig | undefined,
   silent: boolean,
   adapter: HarnessAdapter,
+  scanRoot: string,
 ): { issues: number; errors: number } {
   const sev = ruleSeverity(config?.rules?.["mcp-tool-resolves"]);
   if (!sev) return { issues: 0, errors: 0 };
@@ -4054,7 +4131,7 @@ function checkMcpToolResolves(
   let found: { message: string; path: string }[];
   try {
     found = scanPlugin(
-      process.cwd(),
+      scanRoot,
       adapter.layout,
       adapter.dialect,
     ).agents.flatMap((a) =>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3723,11 +3723,9 @@ function checkSkillResourceResolves(
     finding: { ref: string; line: number };
   }[];
   try {
-    found = scanPlugin(
-      process.cwd(),
-      adapter.layout,
-      adapter.dialect,
-    ).skillResourceIssues;
+    found = scanPlugin(process.cwd(), adapter.layout, adapter.dialect, {
+      sharedDirs: config?.sharedDirs,
+    }).skillResourceIssues;
   } catch {
     return { issues: 0, errors: 0 };
   }
@@ -6405,7 +6403,9 @@ async function main(): Promise<void> {
         const adapter = harnessFlag
           ? resolveAdapter(root, harnessFlag)
           : det.adapter;
-        const report = scanPlugin(targets[0], adapter.layout, adapter.dialect);
+        const report = scanPlugin(targets[0], adapter.layout, adapter.dialect, {
+          sharedDirs: config.sharedDirs,
+        });
         if (!json) {
           console.log(`Detected harness: ${adapter.name}`);
           if (!harnessFlag && det.ambiguousWith.length > 0) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,7 +21,7 @@ import {
   lstatSync,
   type Dirent,
 } from "node:fs";
-import { resolve, dirname, basename, relative } from "node:path";
+import { resolve, dirname, basename, relative, isAbsolute } from "node:path";
 import { globSync } from "glob";
 import { generateTypes } from "./core/generate-types.js";
 import {
@@ -1371,6 +1371,22 @@ function verifyMarkdownModeRules(
  *   --summary   Print a single-line summary (for SessionStart hooks)
  *   --json      Print structured JSON report (for CI integration)
  */
+/**
+ * The repo root that `sharedDirs` resolve against. The caller's cwd (where
+ * `.vigilesrc.json` lives) is used ONLY when the scan target is INSIDE it — e.g.
+ * `lint packages/foo` from the repo root, where the shared tree is an ancestor of
+ * the scoped subdir. When the target is NOT under cwd (`lint path/to/other-repo`),
+ * we resolve against the TARGET itself, so a foreign-repo lint never lets the
+ * caller's own files satisfy the target's bundled resources (scoped-lint integrity).
+ */
+function sharedDirsRootFor(scanTarget: string): string {
+  const cwd = process.cwd();
+  const target = resolve(scanTarget);
+  const rel = relative(cwd, target);
+  const underCwd = rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+  return underCwd ? cwd : target;
+}
+
 async function runLint(
   restArgs: string[],
   flags: string[],
@@ -3802,9 +3818,9 @@ function checkSkillResourceResolves(
   try {
     found = scanPlugin(scanRoot, adapter.layout, adapter.dialect, {
       sharedDirs: config?.sharedDirs,
-      // sharedDirs live at the repo root (config location = cwd), which may be a
-      // PARENT of a scoped scanRoot (`lint packages/foo`) — resolve them there.
-      sharedDirsRoot: process.cwd(),
+      // sharedDirs live at the repo root that OWNS the scan target — cwd for a
+      // scoped subdir of this repo, the target itself for a foreign-repo lint.
+      sharedDirsRoot: sharedDirsRootFor(scanRoot),
     }).skillResourceIssues;
   } catch {
     return { issues: 0, errors: 0 };
@@ -6489,7 +6505,7 @@ async function main(): Promise<void> {
           : det.adapter;
         const report = scanPlugin(targets[0], adapter.layout, adapter.dialect, {
           sharedDirs: config.sharedDirs,
-          sharedDirsRoot: process.cwd(),
+          sharedDirsRoot: sharedDirsRootFor(targets[0]),
         });
         if (!json) {
           console.log(`Detected harness: ${adapter.name}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1382,24 +1382,14 @@ async function runLint(
 
   const files = findInstructionFiles(restArgs, config?.exclude);
 
-  // Resolve the active harness ONCE so the harness-specific checks below run
-  // against the right adapter's dialect (tool/event catalogs) and surfaces —
-  // not a hard-coded Claude Code default. A subagent-surface rule reports n/a
-  // on a harness without subagents (Codex) rather than scanning nothing.
-  const harnessFlag = harnessFlagFrom(flags);
-  const lintSelection = resolveHarnessSelection({
-    root: process.cwd(),
-    flag: harnessFlag,
-    configHarness: normalizeHarnessList(config?.harness),
-  });
-  const adapter = lintSelection.adapter;
-
   // P0-2: scope the surface checks (subagent contracts, skill resources, MCP, …)
   // to an explicit DIRECTORY target when one is given, instead of always scanning
   // the whole working dir and reporting surfaces the user didn't point at. Only a
   // SINGLE existing directory narrows; a file / several paths / none → cwd, so
   // bare `vigiles lint` (the CI-common case) stays byte-identical. scanPlugin
   // reads only under this root, so a surface outside it can never enter the report.
+  // Computed BEFORE the harness resolves so auto-detection keys on the TARGET, not
+  // cwd — `lint path/to/codex-repo` picks that repo's harness, not the caller's.
   const positional = restArgs.filter((a) => !a.startsWith("--"));
   const scanRoot =
     positional.length === 1 &&
@@ -1407,6 +1397,20 @@ async function runLint(
     lstatSync(positional[0]).isDirectory()
       ? resolve(positional[0])
       : process.cwd();
+
+  // Resolve the active harness ONCE so the harness-specific checks below run
+  // against the right adapter's dialect (tool/event catalogs) and surfaces —
+  // not a hard-coded Claude Code default. A subagent-surface rule reports n/a
+  // on a harness without subagents (Codex) rather than scanning nothing. Detect
+  // against `scanRoot` (the target), so a scoped scan of another-harness repo
+  // uses that repo's layout/dialect.
+  const harnessFlag = harnessFlagFrom(flags);
+  const lintSelection = resolveHarnessSelection({
+    root: scanRoot,
+    flag: harnessFlag,
+    configHarness: normalizeHarnessList(config?.harness),
+  });
+  const adapter = lintSelection.adapter;
 
   // 1. Verify hashes and structure
   if (!silent) {

--- a/src/core/layout.ts
+++ b/src/core/layout.ts
@@ -29,6 +29,17 @@ export interface PluginLayout {
   readonly instructionFile: string;
   /** Surface dirs materialized into the sandbox, e.g. skills/agents/commands. */
   readonly surfaceDirs: readonly string[];
+  /**
+   * Project-level dir under which an END-USER (not a plugin author) keeps the
+   * same surfaces, e.g. `.claude` → `.claude/skills`, `.claude/agents`. When set,
+   * the loader reads each surface from BOTH `<root>/<surface>` (the plugin /
+   * skills-library shape) AND `<root>/<userSurfaceRoot>/<surface>` (the shape a
+   * plain Claude Code user has), normalizing to the same materialized key. Most
+   * Claude Code users are NOT publishing a plugin — their skills live here, so
+   * without this the loader would see an empty machine for a normal repo.
+   * Undefined ⇒ only the primary location is read (backwards-compatible).
+   */
+  readonly userSurfaceRoot?: string;
   // Where each model surface lives, by KIND — repo-relative dir names so the
   // scan/lint surface classifiers and the subagent-rule globs are layout-driven,
   // not hard-coded to Claude Code's `skills`/`agents`/`commands`. A harness that

--- a/src/core/skill-resources.test.ts
+++ b/src/core/skill-resources.test.ts
@@ -146,4 +146,65 @@ describe("skillResourceIssues", () => {
     expect(run(body, existsOnly("references/api.md"))).toEqual([]);
     expect(run(body, existsOnly())[0]?.resolved).toBe("references/api.md");
   });
+
+  it("skips a glob pattern (not a concrete file) — P1-3", () => {
+    // `references/*.md` is a directory convention, not a literal path. Both the
+    // inline-span and markdown-link forms must be skipped, never "missing".
+    const body = [
+      "All refs live under `references/*.md`.",
+      "See [the cards](references/*.md) for the list.",
+    ].join("\n");
+    expect(run(body, existsOnly())).toEqual([]);
+  });
+
+  it("skips angle-bracket + brace template placeholders — P1-3", () => {
+    const body = [
+      "Each linter has `references/linter-cards/{trivial,contextual}/<linter>.md`.",
+      "Tests live at `scripts/tests/test_assert_<target>_x.py`.",
+    ].join("\n");
+    expect(run(body, existsOnly())).toEqual([]);
+  });
+
+  it("skips a `~/`-rooted home/global ref (external to the repo) — P1-5", () => {
+    const body =
+      "Route via [docs](~/.claude/docs/foo.md) and `~/.claude/rules/bar.md`.";
+    expect(run(body, existsOnly())).toEqual([]);
+  });
+
+  it("resolves a declared shared-dir ref against the repo root — P1-4 (opt-in)", () => {
+    // `scripts/promptfoo/x.py` lives at the REPO ROOT, not beside the SKILL.md —
+    // the shared-tree shape. Only when `scripts` is a DECLARED shared dir does it
+    // resolve against the repo root; without that opt-in it's still "missing".
+    const REPO_ROOT = "/plugin";
+    const body = "Run `scripts/promptfoo/baseline_leak_scan.py` to check.";
+    const existsAtRepoRoot = (p: string): boolean =>
+      p === resolve(REPO_ROOT, "scripts/promptfoo/baseline_leak_scan.py");
+    // default (no sharedDirs) → unchanged, flagged missing
+    expect(run(body, existsAtRepoRoot)).toHaveLength(1);
+    // opt-in: `scripts` declared shared → resolves against repo root, not flagged
+    expect(
+      skillResourceIssues(body, SKILL_DIR, {
+        existsSync: existsAtRepoRoot,
+        repoRoot: REPO_ROOT,
+        sharedDirs: ["scripts", "references"],
+      }),
+    ).toEqual([]);
+  });
+
+  it("does NOT mask a ref outside a declared shared dir — P1-4 safety", () => {
+    // Even with `scripts` shared, a ref under a DIFFERENT top dir (`references/`)
+    // that only exists at the repo root stays flagged — the opt-in can't silently
+    // suppress a genuinely-missing bundled resource outside the declared dirs.
+    const REPO_ROOT = "/plugin";
+    const body = "See `references/api.md`.";
+    const existsAtRepoRoot = (p: string): boolean =>
+      p === resolve(REPO_ROOT, "references/api.md");
+    expect(
+      skillResourceIssues(body, SKILL_DIR, {
+        existsSync: existsAtRepoRoot,
+        repoRoot: REPO_ROOT,
+        sharedDirs: ["scripts"], // references NOT declared shared
+      }),
+    ).toHaveLength(1);
+  });
 });

--- a/src/core/skill-resources.test.ts
+++ b/src/core/skill-resources.test.ts
@@ -171,6 +171,18 @@ describe("skillResourceIssues", () => {
     expect(run(body, existsOnly())).toEqual([]);
   });
 
+  it("checks a bundled ref with a ?query suffix (not skipped as a glob) — P1-3", () => {
+    // `references/schema.json?raw=1` is a real bundled file with a query suffix;
+    // the `?` must NOT trigger the glob-skip — the file is still resolved/flagged.
+    const body = "See [schema](references/schema.json?raw=1) for the shape.";
+    // missing under the skill dir → flagged (resolves to the stripped path)
+    const flagged = run(body, existsOnly());
+    expect(flagged).toHaveLength(1);
+    expect(flagged[0].resolved).toBe("references/schema.json");
+    // present → resolves, not flagged
+    expect(run(body, existsOnly("references/schema.json"))).toEqual([]);
+  });
+
   it("resolves a declared shared-dir ref against the repo root — P1-4 (opt-in)", () => {
     // `scripts/promptfoo/x.py` lives at the REPO ROOT, not beside the SKILL.md —
     // the shared-tree shape. Only when `scripts` is a DECLARED shared dir does it

--- a/src/core/skill-resources.ts
+++ b/src/core/skill-resources.ts
@@ -50,6 +50,22 @@ export interface SkillResourceFinding {
 export interface SkillResourceOptions {
   /** Injectable existence check (default: node:fs existsSync). */
   readonly existsSync?: (p: string) => boolean;
+  /**
+   * Repo root, used only together with `sharedDirs` (below). Off by default.
+   */
+  readonly repoRoot?: string;
+  /**
+   * OPT-IN shared-resource dirs — top-level dir names a repo shares across skills
+   * (`.vigilesrc.json` `sharedDirs`, e.g. `["scripts", "references"]`). Many skill
+   * libraries keep ONE top-level `scripts/` tree instead of a copy beside every
+   * SKILL.md, so a ref like `scripts/promptfoo/x.py` lives at the repo root. When
+   * a ref's FIRST path segment is a declared shared dir, it may ALSO resolve
+   * against `repoRoot`. Scoped to declared dirs on PURPOSE: a repo that sets no
+   * `sharedDirs` is byte-identical to before (skill-dir-only), and even with it a
+   * ref OUTSIDE a shared dir still can't be masked by a same-named repo-root file.
+   * The controlled fix for feedback P1-4 (opt-in, never a default behavior change).
+   */
+  readonly sharedDirs?: readonly string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -97,6 +113,17 @@ function localResourceTarget(rawTarget: string): string | null {
   // SKIP: variable tokens (`${CLAUDE_PLUGIN_ROOT}/x`, `$VAR/x`) — uncheckable,
   // and almost always a plugin-root or runtime path, not a bundled file.
   if (target.includes("$")) return null;
+  // SKIP: `~/`-rooted paths — the user's home / machine-global config, referenced
+  // intentionally from OUTSIDE the repo (JIT routing like `Read ~/.claude/docs/x.md`).
+  // Not a repo-bundled resource; unverifiable from the repo and never a "broken ref".
+  if (target === "~" || target.startsWith("~/")) return null;
+  // SKIP: globs and template placeholders — a ref carrying a glob metacharacter
+  // (`*`, `?`) or a brace/angle-bracket placeholder (`{trivial,…}`, `<linter>`) is a
+  // directory CONVENTION or an example, not a concrete file (`references/*.md`,
+  // `references/linter-cards/{a,b}/<linter>.md`). Resolving it as a literal path and
+  // reporting "missing" is a false positive — the biggest source of ref noise on a
+  // real authoring style (feedback P1-3).
+  if (/[*?{}<>]/.test(target)) return null;
 
   // Drop a URL fragment / query suffix so `references/api.md#auth` resolves to
   // the file. (Only after the scheme check above, so we never mangle a URL.)
@@ -176,6 +203,19 @@ export function skillResourceIssues(
   opts: SkillResourceOptions = {},
 ): SkillResourceFinding[] {
   const exists = opts.existsSync ?? nodeExistsSync;
+  const sharedDirs = new Set(opts.sharedDirs ?? []);
+  // A ref resolves if it exists under the skill's own dir. If (and only if) its
+  // first segment is a DECLARED shared dir, it may also resolve against the repo
+  // root — the opt-in shared-tree case. No shared dirs → skill-dir-only (unchanged).
+  const resolvesAnywhere = (rel: string): boolean => {
+    if (exists(resolve(skillDir, rel))) return true;
+    const firstSeg = rel.split("/")[0];
+    return (
+      opts.repoRoot !== undefined &&
+      sharedDirs.has(firstSeg) &&
+      exists(resolve(opts.repoRoot, rel))
+    );
+  };
   const findings: SkillResourceFinding[] = [];
   const seen = new Set<string>();
 
@@ -189,8 +229,7 @@ export function skillResourceIssues(
     if (inFence) continue;
 
     for (const c of candidatesInLine(lines[i], i + 1)) {
-      const full = resolve(skillDir, c.resolved);
-      if (exists(full)) continue;
+      if (resolvesAnywhere(c.resolved)) continue;
       // De-dupe the same missing file referenced several times in the body.
       const key = `${c.kind}:${c.resolved}`;
       if (seen.has(key)) continue;

--- a/src/core/skill-resources.ts
+++ b/src/core/skill-resources.ts
@@ -117,18 +117,22 @@ function localResourceTarget(rawTarget: string): string | null {
   // intentionally from OUTSIDE the repo (JIT routing like `Read ~/.claude/docs/x.md`).
   // Not a repo-bundled resource; unverifiable from the repo and never a "broken ref".
   if (target === "~" || target.startsWith("~/")) return null;
-  // SKIP: globs and template placeholders — a ref carrying a glob metacharacter
-  // (`*`, `?`) or a brace/angle-bracket placeholder (`{trivial,…}`, `<linter>`) is a
-  // directory CONVENTION or an example, not a concrete file (`references/*.md`,
-  // `references/linter-cards/{a,b}/<linter>.md`). Resolving it as a literal path and
-  // reporting "missing" is a false positive — the biggest source of ref noise on a
-  // real authoring style (feedback P1-3).
-  if (/[*?{}<>]/.test(target)) return null;
-
-  // Drop a URL fragment / query suffix so `references/api.md#auth` resolves to
-  // the file. (Only after the scheme check above, so we never mangle a URL.)
+  // Drop a URL fragment / query suffix so `references/api.md#auth` AND
+  // `references/schema.json?raw=1` resolve to the file. Done BEFORE the glob skip
+  // below so a legitimate `?query` suffix on a real bundled ref isn't mistaken for
+  // a glob `?` and wrongly skipped — the file must still be checked. (Only after
+  // the scheme check above, so we never mangle a URL.)
   const path = target.replace(/[?#].*$/, "");
   if (path.length === 0) return null;
+
+  // SKIP: globs and template placeholders — a ref carrying a glob metacharacter
+  // (`*`) or a brace/angle-bracket placeholder (`{trivial,…}`, `<linter>`) is a
+  // directory CONVENTION or an example, not a concrete file (`references/*.md`,
+  // `references/linter-cards/{a,b}/<linter>.md`). Resolving it as a literal path and
+  // reporting "missing" is a false positive (feedback P1-3). `?` is intentionally
+  // NOT in this class — it's the query separator stripped above; a genuine `?`-glob
+  // truncates to an extensionless path and is dropped by HAS_EXT below anyway.
+  if (/[*{}<>]/.test(path)) return null;
 
   // SKIP: a `../` escape OUT of the skill dir — undecidable / not a bundled
   // resource (it points at a sibling skill or the repo). A leading `./` is fine.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -367,6 +367,18 @@ export interface VigilesConfig {
    */
   exclude?: readonly string[];
   /**
+   * Top-level dir names shared across skills, e.g. `["scripts", "references"]`.
+   * OPT-IN: many skill libraries keep ONE top-level `scripts/`/`references/` tree
+   * rather than a copy beside every `SKILL.md`, so a bundled ref like
+   * `scripts/promptfoo/x.py` lives at the REPO ROOT. When a `SKILL.md` body ref's
+   * first path segment is a declared shared dir, `skill-resource-resolves` / audit
+   * ALSO resolves it against the repo root, not only the skill's own dir. Scoped
+   * to declared dirs on purpose: a repo that omits this key behaves exactly as
+   * before (skill-dir-only resolution), and a ref outside a shared dir is never
+   * masked by a same-named repo-root file. See feedback P1-4.
+   */
+  sharedDirs?: readonly string[];
+  /**
    * The harness(es) this repo targets — selects the compile dialect / skill
    * frontmatter profile / instruction-file shape, instead of sniffing the cwd.
    * A single name (`"codex"`) for the common single-harness repo, or an array

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -216,19 +216,33 @@ function materializeSurfaces(
   const counts: Record<string, number> = {};
   const isDir = (p: string): boolean =>
     existsSync(p) && statSync(p).isDirectory();
+  // Read each ROOT-level surface tree once (keys relative to the surface dir).
+  const rootTrees = new Map<string, Record<string, string>>();
   for (const surface of layout.surfaceDirs) {
-    const primary = join(root, surface);
-    const userDir = layout.userSurfaceRoot
-      ? join(root, layout.userSurfaceRoot, surface)
-      : null;
-    // Primary wins; fall back to the user location only when the primary is absent.
-    const dir = isDir(primary)
-      ? primary
-      : userDir && isDir(userDir)
-        ? userDir
-        : null;
-    if (!dir) continue;
-    const tree = readTree(dir, dir); // keys relative to the surface dir itself
+    const dir = join(root, surface);
+    if (isDir(dir)) rootTrees.set(surface, readTree(dir, dir));
+  }
+  // Decide the surface ROOT once, at the REPO level (NOT per surface): a repo that
+  // ships ANY root-level surface WITH ENTRIES is a plugin/library — read ONLY its
+  // root surfaces, so a plugin author's dev `.claude/agents` / `.claude/skills`
+  // never leak into the audit as if shipped. A repo with NO root-surface content
+  // falls back to the user surface (`<userSurfaceRoot>/…`, the plain Claude Code
+  // user shape) — so an EMPTY or unrelated root `skills/` doesn't shadow the real
+  // `.claude/skills`, and a per-surface mix can't half-import project-local dirs.
+  const rootHasEntries = [...rootTrees.values()].some(
+    (t) => Object.keys(t).length > 0,
+  );
+  const userRoot = !rootHasEntries ? layout.userSurfaceRoot : undefined;
+  for (const surface of layout.surfaceDirs) {
+    let dir: string;
+    let tree: Record<string, string>;
+    if (userRoot !== undefined) {
+      dir = join(root, userRoot, surface);
+      tree = isDir(dir) ? readTree(dir, dir) : {};
+    } else {
+      dir = join(root, surface);
+      tree = rootTrees.get(surface) ?? {};
+    }
     for (const [rel, content] of Object.entries(tree)) {
       const key = join(layout.materializeRoot, surface, rel);
       files[key] = content;

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -232,7 +232,14 @@ function materializeSurfaces(
   const rootHasEntries = [...rootTrees.values()].some(
     (t) => Object.keys(t).length > 0,
   );
-  const userRoot = !rootHasEntries ? layout.userSurfaceRoot : undefined;
+  // A manifest-backed plugin (`.claude-plugin/plugin.json`) is NEVER a plain user
+  // repo — even a HOOK-ONLY plugin with no root surface dirs ships from its
+  // manifest, not from a developer's project-local `.claude/`. Gate the user-
+  // surface fallback on BOTH no root-surface content AND no plugin manifest, so a
+  // plugin's dev `.claude/skills` / `.claude/agents` are never imported as shipped.
+  const isPluginShaped = existsSync(join(root, layout.manifestPath));
+  const userRoot =
+    !rootHasEntries && !isPluginShaped ? layout.userSurfaceRoot : undefined;
   for (const surface of layout.surfaceDirs) {
     let dir: string;
     let tree: Record<string, string>;

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -319,7 +319,11 @@ function materializeSurfaces(
               ? readTree(dir, dir)
               : {};
         for (const [rel, content] of Object.entries(tree)) {
-          add(join(layout.materializeRoot, surface, rel), content, join(dir, rel));
+          add(
+            join(layout.materializeRoot, surface, rel),
+            content,
+            join(dir, rel),
+          );
         }
         counts[surface] = Object.keys(tree).length;
       }
@@ -327,6 +331,7 @@ function materializeSurfaces(
     }
     case "none":
       break;
+    /* v8 ignore next 2 -- exhaustiveness guard, unreachable given SurfaceSource */
     default:
       assertNever(source);
   }

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -229,8 +229,21 @@ function materializeSurfaces(
   // falls back to the user surface (`<userSurfaceRoot>/…`, the plain Claude Code
   // user shape) — so an EMPTY or unrelated root `skills/` doesn't shadow the real
   // `.claude/skills`, and a per-surface mix can't half-import project-local dirs.
-  const rootHasEntries = [...rootTrees.values()].some(
-    (t) => Object.keys(t).length > 0,
+  // A surface counts as POPULATED only if it holds a LOADABLE file — a skill loads
+  // from `<name>/SKILL.md`, an agent/command from a `.md` file. A stray non-surface
+  // file (`skills/README.md`, `.gitkeep`) must NOT mark the root populated, else it
+  // shadows a plain user's real `.claude/skills` (recreating the F/0 this fixes).
+  const hasLoadable = (
+    surface: string,
+    tree: Record<string, string>,
+  ): boolean => {
+    const keys = Object.keys(tree);
+    return surface === layout.skillDir
+      ? keys.some((k) => basename(k) === "SKILL.md")
+      : keys.some((k) => k.endsWith(".md"));
+  };
+  const rootHasEntries = layout.surfaceDirs.some((s) =>
+    hasLoadable(s, rootTrees.get(s) ?? {}),
   );
   // A plugin is NEVER a plain user repo — even a HOOK-ONLY plugin with no root
   // surface dirs ships from its manifest / hooks convention, not from a

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -232,12 +232,16 @@ function materializeSurfaces(
   const rootHasEntries = [...rootTrees.values()].some(
     (t) => Object.keys(t).length > 0,
   );
-  // A manifest-backed plugin (`.claude-plugin/plugin.json`) is NEVER a plain user
-  // repo — even a HOOK-ONLY plugin with no root surface dirs ships from its
-  // manifest, not from a developer's project-local `.claude/`. Gate the user-
-  // surface fallback on BOTH no root-surface content AND no plugin manifest, so a
-  // plugin's dev `.claude/skills` / `.claude/agents` are never imported as shipped.
-  const isPluginShaped = existsSync(join(root, layout.manifestPath));
+  // A plugin is NEVER a plain user repo — even a HOOK-ONLY plugin with no root
+  // surface dirs ships from its manifest / hooks convention, not from a
+  // developer's project-local `.claude/`. Gate the user-surface fallback on BOTH
+  // no root-surface content AND no plugin shape, so a plugin's dev `.claude/skills`
+  // / `.claude/agents` are never imported as shipped. Plugin shape = a manifest
+  // (`.claude-plugin/plugin.json`) OR the hooks convention (`hooks/hooks.json`) —
+  // the same files `readHooks` treats as plugin content.
+  const isPluginShaped =
+    existsSync(join(root, layout.manifestPath)) ||
+    existsSync(join(root, layout.hooksConventionPath));
   const userRoot =
     !rootHasEntries && !isPluginShaped ? layout.userSurfaceRoot : undefined;
   for (const surface of layout.surfaceDirs) {

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -29,7 +29,7 @@
  * to preserve `loadPlugin(dir)` ergonomics and the public `vigiles/*` exports).
  */
 import { readFileSync, existsSync, readdirSync, statSync } from "node:fs";
-import { resolve, join, relative } from "node:path";
+import { resolve, join, relative, basename } from "node:path";
 
 import { parse as parseToml } from "@iarna/toml";
 
@@ -48,6 +48,15 @@ export interface LoadedPlugin {
    * read it in a test, or just to know what the deterministic run won't reach.
    */
   readonly warnings: readonly string[];
+  /**
+   * Map from a materialized `files` key to the ABSOLUTE on-disk path it was read
+   * from. A surface can be materialized under a canonical key (`.claude/skills/
+   * foo/SKILL.md`) while living on disk at a different root (the repo-root
+   * `skills/` OR the project-level `.claude/skills/`), so a consumer that needs
+   * the real dir (e.g. resolving a skill's bundled resources) must reverse-map
+   * through this instead of guessing from the key. Present for every surface file.
+   */
+  readonly sources: Record<string, string>;
 }
 
 const MAX_SKILL_FILE_BYTES = 256 * 1024;
@@ -164,31 +173,86 @@ export function loadPlugin(
     : undefined;
 
   const files: Record<string, string> = {};
+  const sources: Record<string, string> = {};
   const instructions = join(root, layout.instructionFile);
   if (existsSync(instructions)) {
     files[layout.instructionFile] = readFileSync(instructions, "utf-8");
+    sources[layout.instructionFile] = instructions;
   }
-  // Materialize each project-level surface under the materialize root so the
-  // assembled context is present in the sandbox (best-effort — headless
-  // activation of plugin skills/subagents/commands is not guaranteed; the body
-  // is present for the agent to read either way). Counting what we materialize
-  // also lets us warn about surfaces the deterministic tier can't drive.
-  const counts: Record<string, number> = {};
-  for (const surface of layout.surfaceDirs) {
-    const dir = join(root, surface);
-    if (!existsSync(dir) || !statSync(dir).isDirectory()) continue;
-    const tree = readTree(dir, root);
-    for (const [rel, content] of Object.entries(tree)) {
-      files[join(layout.materializeRoot, rel)] = content;
-    }
-    counts[surface] = Object.keys(tree).length;
-  }
+  const counts = materializeSurfaces(root, layout, files, sources);
 
   return {
     settings: resolvedHooks ? { hooks: resolvedHooks } : {},
     files,
+    sources,
     warnings: pluginWarnings(root, counts, resolvedHooks, files, layout),
   };
+}
+
+/**
+ * Materialize every model surface (skills/agents/commands) into `files`, keyed by
+ * a canonical `<materializeRoot>/<surface>/…` path, and record each file's real
+ * on-disk path in `sources`. Best-effort (headless activation of plugin
+ * skills/subagents/commands is not guaranteed; the body is present to read).
+ *
+ * Each surface is read from ONE of the two locations the layout knows about,
+ * primary-first: `<root>/<surface>` (the published-plugin / skills-library shape)
+ * when it exists, ELSE — when the layout declares one — the project-level
+ * `<root>/<userSurfaceRoot>/<surface>` (the shape a PLAIN Claude Code user has,
+ * not a plugin author). Preferring the primary means a plugin author's own local
+ * `.claude/skills` dev skills don't pollute the audit of what their plugin
+ * actually ships, while a plain user (no repo-root `skills/`) is still read. Plus
+ * the single-skill-directory case (`<root>/SKILL.md`), so pointing at one skill
+ * dir works. Whichever location is used normalizes to the same canonical key, so
+ * the classifier and every downstream detector see one shape regardless of where
+ * it lives on disk. Returns the per-surface counts (drives the surface warnings).
+ */
+function materializeSurfaces(
+  root: string,
+  layout: PluginLayout,
+  files: Record<string, string>,
+  sources: Record<string, string>,
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  const isDir = (p: string): boolean =>
+    existsSync(p) && statSync(p).isDirectory();
+  for (const surface of layout.surfaceDirs) {
+    const primary = join(root, surface);
+    const userDir = layout.userSurfaceRoot
+      ? join(root, layout.userSurfaceRoot, surface)
+      : null;
+    // Primary wins; fall back to the user location only when the primary is absent.
+    const dir = isDir(primary)
+      ? primary
+      : userDir && isDir(userDir)
+        ? userDir
+        : null;
+    if (!dir) continue;
+    const tree = readTree(dir, dir); // keys relative to the surface dir itself
+    for (const [rel, content] of Object.entries(tree)) {
+      const key = join(layout.materializeRoot, surface, rel);
+      files[key] = content;
+      sources[key] = join(dir, rel);
+    }
+    counts[surface] = (counts[surface] ?? 0) + Object.keys(tree).length;
+  }
+  // The target IS a single skill directory (`<root>/SKILL.md`) — the natural
+  // thing to point `audit`/`test` at for one skill. Materialize it under the
+  // canonical skills key (named by the dir) so the classifier + resource checks
+  // see it; its bundled resources resolve against `root` via `sources`.
+  const soleSkill = join(root, "SKILL.md");
+  if (layout.skillDir && existsSync(soleSkill)) {
+    const key = join(
+      layout.materializeRoot,
+      layout.skillDir,
+      basename(root),
+      "SKILL.md",
+    );
+    files[key] = readFileSync(soleSkill, "utf-8");
+    sources[key] = soleSkill;
+    counts[layout.skillDir] = (counts[layout.skillDir] ?? 0) + 1;
+  }
+  return counts;
 }
 
 /**

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -33,6 +33,7 @@ import { resolve, join, relative, basename } from "node:path";
 
 import { parse as parseToml } from "@iarna/toml";
 
+import { assertNever } from "./core/hash.js";
 import type { PluginLayout } from "./core/layout.js";
 
 export interface LoadedPlugin {
@@ -207,6 +208,68 @@ export function loadPlugin(
  * the classifier and every downstream detector see one shape regardless of where
  * it lives on disk. Returns the per-surface counts (drives the surface warnings).
  */
+/**
+ * WHERE a repo's model surfaces (skills/agents/commands) live — PARSED from the
+ * repo's shape ONCE (parse-don't-validate) so materialization never re-infers it
+ * from a pile of ad-hoc booleans (the tangle that spawned repeated edge-case
+ * bugs: empty dir, stray file, hook-only plugin, single-skill target). A tagged
+ * union, one variant per real shape; a NEW shape is a new variant the exhaustive
+ * `switch` below won't compile without handling — the whole point.
+ */
+type SurfaceSource =
+  | { readonly kind: "single-skill"; readonly skillName: string } // `<root>/SKILL.md` — the target IS one skill
+  | { readonly kind: "root" } // plugin / library / any root-surface content — read `<root>/<surface>`
+  | { readonly kind: "user"; readonly sub: string } // plain user repo — read `<root>/<sub>/<surface>`
+  | { readonly kind: "none" }; // nothing loadable anywhere
+
+/**
+ * A surface holds a LOADABLE file — a `<name>/SKILL.md` for skills, a `.md` for
+ * agents/commands. A stray non-surface file (`skills/README.md`, `.gitkeep`) does
+ * NOT count, else it would mark the root populated and shadow a plain user's real
+ * `.claude/skills`.
+ */
+function surfaceHasLoadable(
+  layout: PluginLayout,
+  surface: string,
+  tree: Record<string, string>,
+): boolean {
+  const keys = Object.keys(tree);
+  return surface === layout.skillDir
+    ? keys.some((k) => basename(k) === "SKILL.md")
+    : keys.some((k) => k.endsWith(".md"));
+}
+
+/**
+ * Classify the repo shape from disk, with EXPLICIT precedence:
+ *  1. a `<root>/SKILL.md` → the target IS one skill dir (single-skill).
+ *  2. any root-surface with LOADABLE content, OR a plugin manifest / hooks
+ *     convention → read the ROOT surfaces. A plugin ships from its manifest even
+ *     with no root surface dirs, so its dev `.claude/…` is never a fallback.
+ *  3. else, if the layout declares a user-surface root → a plain user repo.
+ *  4. else → nothing loadable.
+ * Pure over the pre-read `rootTrees` + a few existence checks — one place to test.
+ */
+function classifySurfaceSource(
+  root: string,
+  layout: PluginLayout,
+  rootTrees: ReadonlyMap<string, Record<string, string>>,
+): SurfaceSource {
+  if (layout.skillDir && existsSync(join(root, "SKILL.md"))) {
+    return { kind: "single-skill", skillName: basename(root) };
+  }
+  const rootHasLoadable = layout.surfaceDirs.some((s) =>
+    surfaceHasLoadable(layout, s, rootTrees.get(s) ?? {}),
+  );
+  const isPluginShaped =
+    existsSync(join(root, layout.manifestPath)) ||
+    existsSync(join(root, layout.hooksConventionPath));
+  if (rootHasLoadable || isPluginShaped) return { kind: "root" };
+  if (layout.userSurfaceRoot !== undefined) {
+    return { kind: "user", sub: layout.userSurfaceRoot };
+  }
+  return { kind: "none" };
+}
+
 function materializeSurfaces(
   root: string,
   layout: PluginLayout,
@@ -222,75 +285,50 @@ function materializeSurfaces(
     const dir = join(root, surface);
     if (isDir(dir)) rootTrees.set(surface, readTree(dir, dir));
   }
-  // Decide the surface ROOT once, at the REPO level (NOT per surface): a repo that
-  // ships ANY root-level surface WITH ENTRIES is a plugin/library — read ONLY its
-  // root surfaces, so a plugin author's dev `.claude/agents` / `.claude/skills`
-  // never leak into the audit as if shipped. A repo with NO root-surface content
-  // falls back to the user surface (`<userSurfaceRoot>/…`, the plain Claude Code
-  // user shape) — so an EMPTY or unrelated root `skills/` doesn't shadow the real
-  // `.claude/skills`, and a per-surface mix can't half-import project-local dirs.
-  // A surface counts as POPULATED only if it holds a LOADABLE file — a skill loads
-  // from `<name>/SKILL.md`, an agent/command from a `.md` file. A stray non-surface
-  // file (`skills/README.md`, `.gitkeep`) must NOT mark the root populated, else it
-  // shadows a plain user's real `.claude/skills` (recreating the F/0 this fixes).
-  const hasLoadable = (
-    surface: string,
-    tree: Record<string, string>,
-  ): boolean => {
-    const keys = Object.keys(tree);
-    return surface === layout.skillDir
-      ? keys.some((k) => basename(k) === "SKILL.md")
-      : keys.some((k) => k.endsWith(".md"));
+  const add = (key: string, content: string, onDisk: string): void => {
+    files[key] = content;
+    sources[key] = onDisk;
   };
-  const rootHasEntries = layout.surfaceDirs.some((s) =>
-    hasLoadable(s, rootTrees.get(s) ?? {}),
-  );
-  // A plugin is NEVER a plain user repo — even a HOOK-ONLY plugin with no root
-  // surface dirs ships from its manifest / hooks convention, not from a
-  // developer's project-local `.claude/`. Gate the user-surface fallback on BOTH
-  // no root-surface content AND no plugin shape, so a plugin's dev `.claude/skills`
-  // / `.claude/agents` are never imported as shipped. Plugin shape = a manifest
-  // (`.claude-plugin/plugin.json`) OR the hooks convention (`hooks/hooks.json`) —
-  // the same files `readHooks` treats as plugin content.
-  const isPluginShaped =
-    existsSync(join(root, layout.manifestPath)) ||
-    existsSync(join(root, layout.hooksConventionPath));
-  const userRoot =
-    !rootHasEntries && !isPluginShaped ? layout.userSurfaceRoot : undefined;
-  for (const surface of layout.surfaceDirs) {
-    let dir: string;
-    let tree: Record<string, string>;
-    if (userRoot !== undefined) {
-      dir = join(root, userRoot, surface);
-      tree = isDir(dir) ? readTree(dir, dir) : {};
-    } else {
-      dir = join(root, surface);
-      tree = rootTrees.get(surface) ?? {};
+
+  const source = classifySurfaceSource(root, layout, rootTrees);
+  switch (source.kind) {
+    case "single-skill": {
+      // Materialize the WHOLE skill dir under the canonical skills key, so its
+      // bundled resources (scripts/references/assets) ship too, not just SKILL.md.
+      const tree = readTree(root, root);
+      for (const [rel, content] of Object.entries(tree)) {
+        add(
+          join(layout.materializeRoot, layout.skillDir, source.skillName, rel),
+          content,
+          join(root, rel),
+        );
+      }
+      counts[layout.skillDir] = Object.keys(tree).length;
+      break;
     }
-    for (const [rel, content] of Object.entries(tree)) {
-      const key = join(layout.materializeRoot, surface, rel);
-      files[key] = content;
-      sources[key] = join(dir, rel);
+    case "root":
+    case "user": {
+      const base = source.kind === "user" ? join(root, source.sub) : root;
+      for (const surface of layout.surfaceDirs) {
+        const dir = join(base, surface);
+        // Root surfaces were pre-read; user surfaces are read fresh here.
+        const tree =
+          source.kind === "root"
+            ? (rootTrees.get(surface) ?? {})
+            : isDir(dir)
+              ? readTree(dir, dir)
+              : {};
+        for (const [rel, content] of Object.entries(tree)) {
+          add(join(layout.materializeRoot, surface, rel), content, join(dir, rel));
+        }
+        counts[surface] = Object.keys(tree).length;
+      }
+      break;
     }
-    counts[surface] = (counts[surface] ?? 0) + Object.keys(tree).length;
-  }
-  // The target IS a single skill directory (`<root>/SKILL.md`) — the natural
-  // thing to point `audit`/`test` at for one skill. Materialize the WHOLE skill
-  // dir under the canonical skills key (named by the dir), mirroring the
-  // `skills/<name>/` subtree readTree above — so its bundled resources
-  // (`scripts/`, `references/`, `assets/`) are present too, not just SKILL.md, and
-  // a single-skill harness test/eval runs against the skill's shipped files.
-  const soleSkill = join(root, "SKILL.md");
-  if (layout.skillDir && existsSync(soleSkill)) {
-    const name = basename(root);
-    const tree = readTree(root, root); // keys relative to the skill dir itself
-    for (const [rel, content] of Object.entries(tree)) {
-      const key = join(layout.materializeRoot, layout.skillDir, name, rel);
-      files[key] = content;
-      sources[key] = join(root, rel);
-    }
-    counts[layout.skillDir] =
-      (counts[layout.skillDir] ?? 0) + Object.keys(tree).length;
+    case "none":
+      break;
+    default:
+      assertNever(source);
   }
   return counts;
 }

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -237,20 +237,22 @@ function materializeSurfaces(
     counts[surface] = (counts[surface] ?? 0) + Object.keys(tree).length;
   }
   // The target IS a single skill directory (`<root>/SKILL.md`) — the natural
-  // thing to point `audit`/`test` at for one skill. Materialize it under the
-  // canonical skills key (named by the dir) so the classifier + resource checks
-  // see it; its bundled resources resolve against `root` via `sources`.
+  // thing to point `audit`/`test` at for one skill. Materialize the WHOLE skill
+  // dir under the canonical skills key (named by the dir), mirroring the
+  // `skills/<name>/` subtree readTree above — so its bundled resources
+  // (`scripts/`, `references/`, `assets/`) are present too, not just SKILL.md, and
+  // a single-skill harness test/eval runs against the skill's shipped files.
   const soleSkill = join(root, "SKILL.md");
   if (layout.skillDir && existsSync(soleSkill)) {
-    const key = join(
-      layout.materializeRoot,
-      layout.skillDir,
-      basename(root),
-      "SKILL.md",
-    );
-    files[key] = readFileSync(soleSkill, "utf-8");
-    sources[key] = soleSkill;
-    counts[layout.skillDir] = (counts[layout.skillDir] ?? 0) + 1;
+    const name = basename(root);
+    const tree = readTree(root, root); // keys relative to the skill dir itself
+    for (const [rel, content] of Object.entries(tree)) {
+      const key = join(layout.materializeRoot, layout.skillDir, name, rel);
+      files[key] = content;
+      sources[key] = join(root, rel);
+    }
+    counts[layout.skillDir] =
+      (counts[layout.skillDir] ?? 0) + Object.keys(tree).length;
   }
   return counts;
 }

--- a/src/scan-cli.test.ts
+++ b/src/scan-cli.test.ts
@@ -814,3 +814,42 @@ describe("lint scopes surface checks to an explicit directory (P0-2)", () => {
     );
   });
 });
+
+describe("lint of a foreign repo does not satisfy target refs from the caller's cwd", () => {
+  let caller: string;
+  let target: string;
+  beforeAll(() => {
+    // The CALLER's repo declares sharedDirs and HAS scripts/foo.py.
+    caller = mkdtempSync(join(tmpdir(), "vig-caller-"));
+    mkdirSync(join(caller, "scripts"), { recursive: true });
+    writeFileSync(join(caller, "scripts", "foo.py"), "# caller's file\n");
+    writeFileSync(
+      join(caller, ".vigilesrc.json"),
+      JSON.stringify({
+        sharedDirs: ["scripts"],
+        rules: { "skill-resource-resolves": "warn" },
+      }),
+    );
+    // The TARGET repo (elsewhere) has a skill referencing scripts/foo.py, which
+    // is MISSING in the target. The caller's file must not satisfy it.
+    target = mkdtempSync(join(tmpdir(), "vig-target-"));
+    mkdirSync(join(target, "skills", "rca"), { recursive: true });
+    writeFileSync(
+      join(target, "skills", "rca", "SKILL.md"),
+      "---\nname: rca\ndescription: references a shared script\n---\nRun `scripts/foo.py`.\n",
+    );
+  });
+  afterAll(() => {
+    rmSync(caller, { recursive: true, force: true });
+    rmSync(target, { recursive: true, force: true });
+  });
+
+  it("flags the target's missing scripts/foo.py (not satisfied by the caller's copy)", () => {
+    const r = run(`lint ${target}`, caller);
+    assert.match(
+      r.stdout,
+      /foo\.py/,
+      "a foreign-repo lint resolves shared refs against the TARGET, not the caller's cwd",
+    );
+  });
+});

--- a/src/scan-cli.test.ts
+++ b/src/scan-cli.test.ts
@@ -775,3 +775,40 @@ describe("audit default artifacts (html + json) written to cwd", () => {
     assert.ok(!existsSync(join(root, "vigiles-report.json")), "no json");
   });
 });
+
+describe("lint scopes surface checks to an explicit directory (P0-2)", () => {
+  let repo: string;
+  beforeAll(() => {
+    repo = mkdtempSync(join(tmpdir(), "vig-lint-scope-"));
+    // pkgA ships a subagent with a typo'd tool → subagent-tool-contract fires.
+    mkdirSync(join(repo, "pkgA", "agents"), { recursive: true });
+    writeFileSync(
+      join(repo, "pkgA", "agents", "bad.md"),
+      "---\nname: bad\ndescription: A reviewer subagent for pkgA here\ntools: Reat\n---\nReview.\n",
+    );
+    // pkgB is clean.
+    mkdirSync(join(repo, "pkgB", "agents"), { recursive: true });
+    writeFileSync(
+      join(repo, "pkgB", "agents", "ok.md"),
+      "---\nname: ok\ndescription: A clean reviewer subagent for pkgB here\ntools: Read\n---\nReview.\n",
+    );
+    writeFileSync(
+      join(repo, ".vigilesrc.json"),
+      JSON.stringify({ rules: { "subagent-tool-contract": "warn" } }),
+    );
+  });
+  afterAll(() => rmSync(repo, { recursive: true, force: true }));
+
+  it("lint pkgA reports pkgA's typo'd subagent tool", () => {
+    const r = run("lint pkgA", repo);
+    assert.match(r.stdout, /Reat/, "the scoped dir's own issue is reported");
+  });
+
+  it("lint pkgB does NOT leak pkgA's issue (scoped away)", () => {
+    const r = run("lint pkgB", repo);
+    assert.ok(
+      !/Reat/.test(r.stdout),
+      "a surface outside the passed dir must never enter the report",
+    );
+  });
+});

--- a/src/scan-cli.test.ts
+++ b/src/scan-cli.test.ts
@@ -797,7 +797,9 @@ describe("lint scopes surface checks to an explicit directory (P0-2)", () => {
       JSON.stringify({ rules: { "subagent-tool-contract": "warn" } }),
     );
   });
-  afterAll(() => rmSync(repo, { recursive: true, force: true }));
+  afterAll(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
 
   it("lint pkgA reports pkgA's typo'd subagent tool", () => {
     const r = run("lint pkgA", repo);

--- a/src/scan.test.ts
+++ b/src/scan.test.ts
@@ -96,6 +96,76 @@ function fixture(): string {
   return dir;
 }
 
+test("scanPlugin discovers skills in an end-user .claude/skills repo (not a plugin)", () => {
+  // The majority shape: a plain CC user, skills under `.claude/skills/`, no
+  // plugin.json. Before this the report was empty (F/0 "no loadable surface").
+  const dir = makeTmpDir("scan-userrepo");
+  try {
+    write(dir, "CLAUDE.md", "# proj\n");
+    write(
+      dir,
+      ".claude/skills/rca/SKILL.md",
+      "---\nname: rca\ndescription: Investigate an incident with two signals\n---\n# rca\n",
+    );
+    write(
+      dir,
+      ".claude/agents/reviewer.md",
+      "---\nname: reviewer\ntools: Read\n---\nbody\n",
+    );
+    const r = scanPlugin(dir);
+    assert.equal(r.skills.length, 1, "the .claude/skills skill is discovered");
+    assert.equal(r.skills[0].name, "rca");
+    assert.ok(r.skills[0].hasDescription);
+    assert.equal(
+      r.agents.length,
+      1,
+      "the .claude/agents subagent is discovered",
+    );
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});
+
+test("scanPlugin resolves a .claude/skills skill's bundled resource on real disk", () => {
+  // A `.claude/skills` skill materializes under the same canonical key as a
+  // repo-root one; its bundled resource must resolve against its REAL dir
+  // (`.claude/skills/rca/`), not a reverse-guessed `skills/rca/`.
+  const dir = makeTmpDir("scan-userres");
+  try {
+    write(dir, "CLAUDE.md", "# proj\n");
+    write(
+      dir,
+      ".claude/skills/rca/SKILL.md",
+      "---\nname: rca\ndescription: RCA with a helper script bundled beside it\n---\nRun `scripts/run.sh` first.\n",
+    );
+    write(dir, ".claude/skills/rca/scripts/run.sh", "#!/usr/bin/env bash\n");
+    const r = scanPlugin(dir);
+    assert.equal(
+      r.skills[0].resourceIssues.length,
+      0,
+      "the bundled scripts/run.sh resolves against the real .claude dir",
+    );
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});
+
+test("scanPlugin loads a single skill directory passed directly", () => {
+  const dir = makeTmpDir("scan-oneskill");
+  try {
+    write(
+      dir,
+      "SKILL.md",
+      "---\nname: solo\ndescription: A single skill pointed at directly here\n---\n# solo\n",
+    );
+    const r = scanPlugin(dir);
+    assert.equal(r.skills.length, 1, "the sole SKILL.md is scanned as a skill");
+    assert.equal(r.skills[0].name, "solo");
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});
+
 test("subagent classification is layout-driven (ready for new harnesses)", () => {
   // A harness whose subagents live somewhere other than `agents/` — e.g.
   // OpenCode's `.opencode/agent`. Here: a flat `subagents/` dir, declared via

--- a/src/scan.test.ts
+++ b/src/scan.test.ts
@@ -166,6 +166,39 @@ test("scanPlugin loads a single skill directory passed directly", () => {
   }
 });
 
+test("sharedDirs resolve against sharedDirsRoot, not a scoped subdir (P1-4 + P0-2)", () => {
+  // The skill lives in a subdir; the shared `scripts/` tree is at the REPO root.
+  // A scoped scan (scanRoot = the subdir) must still resolve the shared ref
+  // against the repo root, not the subdir — else the two features conflict.
+  const repo = makeTmpDir("scan-shared-scoped");
+  try {
+    write(
+      repo,
+      "packages/foo/skills/rca/SKILL.md",
+      "---\nname: rca\ndescription: uses a shared script tree\n---\nRun `scripts/leak.py`.\n",
+    );
+    write(repo, "scripts/leak.py", "# shared tree at the repo root\n");
+    const sub = join(repo, "packages", "foo");
+    // With sharedDirsRoot = repo root → the shared ref resolves, no false flag.
+    const ok = scanPlugin(sub, undefined, undefined, {
+      sharedDirs: ["scripts"],
+      sharedDirsRoot: repo,
+    });
+    assert.equal(
+      ok.skills[0].resourceIssues.length,
+      0,
+      "scripts/leak.py resolves against the repo root, not the scoped subdir",
+    );
+    // Without sharedDirsRoot the subdir scan can't see the top-level tree → flags.
+    const bad = scanPlugin(sub, undefined, undefined, {
+      sharedDirs: ["scripts"],
+    });
+    assert.equal(bad.skills[0].resourceIssues.length, 1);
+  } finally {
+    cleanupTmpDir(repo);
+  }
+});
+
 test("subagent classification is layout-driven (ready for new harnesses)", () => {
   // A harness whose subagents live somewhere other than `agents/` — e.g.
   // OpenCode's `.opencode/agent`. Here: a flat `subagents/` dir, declared via

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -505,6 +505,15 @@ interface SkillScanContext {
   readonly root: string;
   readonly materializeRoot: string;
   readonly dialect: HarnessDialect;
+  /**
+   * Materialized-key → real on-disk path (from `loadPlugin`). A surface can be
+   * materialized under a canonical key while living at a different root (repo-root
+   * `skills/` vs project-level `.claude/skills/`), so bundled-resource resolution
+   * uses the true dir from here rather than reverse-guessing from the key.
+   */
+  readonly sources?: Record<string, string>;
+  /** OPT-IN top-level shared-resource dirs (`.vigilesrc.json` `sharedDirs`). */
+  readonly sharedDirs?: readonly string[];
 }
 
 function scanSkills(
@@ -512,10 +521,13 @@ function scanSkills(
   cls: SurfaceClassifier,
   ctx: SkillScanContext,
 ): ScanSkill[] {
-  const { root, materializeRoot, dialect } = ctx;
+  const { root, materializeRoot, dialect, sharedDirs } = ctx;
   const out: ScanSkill[] = [];
   for (const [path, md] of Object.entries(files)) {
     if (!cls.isSkill(path)) continue;
+    // Prefer the real on-disk dir (a `.claude/skills/…` skill materializes under
+    // the same canonical key as a repo-root one, but lives elsewhere on disk).
+    const onDiskDir = ctx.sources?.[path];
     const fm = frontmatter(md);
     // A skill's trigger surface is its frontmatter `description` OR — when that's
     // absent — Claude Code's fallback to the first body paragraph. Only when
@@ -526,8 +538,18 @@ function scanSkills(
     // Bundled-resource refs resolve against the skill's OWN dir (resources ship
     // beside the SKILL.md), built from the plugin root + the file's ON-DISK dir
     // (the materialize-root prefix the loader added is stripped back off).
-    const skillDir = resolve(root, dirname(onDiskPath(path, materializeRoot)));
-    const resourceIssues = skillResourceIssues(skillBody(md), skillDir);
+    const skillDir = onDiskDir
+      ? dirname(onDiskDir)
+      : resolve(root, dirname(onDiskPath(path, materializeRoot)));
+    // Bundled refs resolve against the skill's OWN dir. A repo that shares a
+    // top-level tree across skills (`sharedDirs` in .vigilesrc.json) ALSO resolves
+    // a ref under one of those declared dirs against the repo root — OPT-IN, so a
+    // repo that doesn't set it is byte-identical to before (no masking of a real
+    // missing bundled resource). See feedback P1-4.
+    const resourceIssues = skillResourceIssues(skillBody(md), skillDir, {
+      repoRoot: root,
+      sharedDirs,
+    });
     // The lethal trifecta is a property of what a unit CAN do, which for a skill is
     // its declared `allowed-tools` (the CC skill tool contract). Only a model-
     // invocable skill can be hijacked by attacker content, so a user-invoked one is
@@ -1147,6 +1169,7 @@ export function scanPlugin(
   dir: string,
   layout?: PluginLayout,
   dialect: HarnessDialect = claudeCodeDialect,
+  opts: { sharedDirs?: readonly string[] } = {},
 ): ScanReport {
   const lay = layout ?? claudeCodeLayout;
   const cls = makeClassifier(lay);
@@ -1188,6 +1211,8 @@ export function scanPlugin(
     root: resolve(dir),
     materializeRoot: lay.materializeRoot,
     dialect,
+    sources: loaded.sources,
+    sharedDirs: opts.sharedDirs,
   });
   const puritySummary = summarizePurity(agents);
   const { trifectaFindings, skillResourceFindings, skillFenceFindings } =
@@ -1515,10 +1540,17 @@ export function formatScanReport(r: ScanReport): string {
   out.push(
     ...section(
       "Lethal trifecta (prompt-injection exfil risk)",
-      r.trifectaFindings.map(
-        (t) =>
-          `  ${t.finding.severity === "hard" ? "✗" : "⚠"} ${t.kind} ${t.name} (${t.path}): ${t.finding.message}`,
-      ),
+      // The section header already carries the count. HARD findings name their
+      // specific legs (keep the message). ADVISORY (inherits-all) findings all
+      // carry the SAME boilerplate paragraph — at bulk that's a wall of identical
+      // text, so collapse each to a one-liner (feedback P2-6). Gate on "no NEW
+      // trifecta" with `vigiles lint` (the lethal-trifecta rule), not by eyeballing.
+      r.trifectaFindings.map((t) => {
+        const mark = t.finding.severity === "hard" ? "✗" : "⚠";
+        return t.finding.severity === "hard"
+          ? `  ${mark} ${t.kind} ${t.name} (${t.path}): ${t.finding.message}`
+          : `  ${mark} ${t.kind} ${t.name} (${t.path}) — inherits-all contract holds all three legs (declare a tools list dropping one)`;
+      }),
     ),
   );
 

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -514,6 +514,14 @@ interface SkillScanContext {
   readonly sources?: Record<string, string>;
   /** OPT-IN top-level shared-resource dirs (`.vigilesrc.json` `sharedDirs`). */
   readonly sharedDirs?: readonly string[];
+  /**
+   * The REPO root the `sharedDirs` are declared relative to (where `.vigilesrc.json`
+   * lives) — distinct from the scan `root`, which may be a scoped SUBDIR (e.g.
+   * `lint packages/foo`). A shared-dir ref resolves against THIS, not the subdir,
+   * so a scoped scan doesn't false-flag the top-level shared tree. Defaults to
+   * `root` (unchanged when scanning the repo root itself).
+   */
+  readonly sharedDirsRoot?: string;
 }
 
 function scanSkills(
@@ -522,6 +530,10 @@ function scanSkills(
   ctx: SkillScanContext,
 ): ScanSkill[] {
   const { root, materializeRoot, dialect, sharedDirs } = ctx;
+  // `sharedDirs` are declared relative to the REPO root (config location), which
+  // is `root` for a whole-repo scan but a PARENT when the scan is scoped to a
+  // subdir. Resolve them against that, not the scoped subdir.
+  const sharedDirsRoot = ctx.sharedDirsRoot ?? root;
   const out: ScanSkill[] = [];
   for (const [path, md] of Object.entries(files)) {
     if (!cls.isSkill(path)) continue;
@@ -547,7 +559,7 @@ function scanSkills(
     // repo that doesn't set it is byte-identical to before (no masking of a real
     // missing bundled resource). See feedback P1-4.
     const resourceIssues = skillResourceIssues(skillBody(md), skillDir, {
-      repoRoot: root,
+      repoRoot: sharedDirsRoot,
       sharedDirs,
     });
     // The lethal trifecta is a property of what a unit CAN do, which for a skill is
@@ -1169,7 +1181,7 @@ export function scanPlugin(
   dir: string,
   layout?: PluginLayout,
   dialect: HarnessDialect = claudeCodeDialect,
-  opts: { sharedDirs?: readonly string[] } = {},
+  opts: { sharedDirs?: readonly string[]; sharedDirsRoot?: string } = {},
 ): ScanReport {
   const lay = layout ?? claudeCodeLayout;
   const cls = makeClassifier(lay);
@@ -1213,6 +1225,7 @@ export function scanPlugin(
     dialect,
     sources: loaded.sources,
     sharedDirs: opts.sharedDirs,
+    sharedDirsRoot: opts.sharedDirsRoot,
   });
   const puritySummary = summarizePurity(agents);
   const { trifectaFindings, skillResourceFindings, skillFenceFindings } =

--- a/src/test-coverage.test.ts
+++ b/src/test-coverage.test.ts
@@ -256,3 +256,16 @@ test("formatUntestedReport: clean vs flagged, suggestedTestPath", () => {
   assert.ok(formatUntestedReport(clean).startsWith("✓"));
   cleanupTmpDir(dir);
 });
+
+test("discovers a bare SKILL.md AT the base (single-skill-dir target)", () => {
+  // When lint/audit is pointed at one skill dir, the SKILL.md is at the base
+  // itself, not under `skills/*/`. Without this the untested-skill check would
+  // silently vanish for exactly that target.
+  const dir = makeTmpDir("cov-solo");
+  write(dir, "SKILL.md", "---\nname: solo\ndescription: x\n---\nbody\n");
+  const report = findUntestedSurfaces({ basePath: dir });
+  const found = report.untested.find((s) => s.kind === "skill");
+  assert.ok(found, "the root SKILL.md is reported as an untested skill");
+  assert.equal(found.path, "SKILL.md");
+  cleanupTmpDir(dir);
+});

--- a/src/test-coverage.test.ts
+++ b/src/test-coverage.test.ts
@@ -269,3 +269,19 @@ test("discovers a bare SKILL.md AT the base (single-skill-dir target)", () => {
   assert.equal(found.path, "SKILL.md");
   cleanupTmpDir(dir);
 });
+
+test("a root SKILL.md is COVERED by a colocated eval (single-skill-dir target)", () => {
+  // A colocated `solo.eval.mjs` beside a root SKILL.md must count as coverage —
+  // globSync returns it without a "./" prefix, which the colocation check now
+  // handles for a "." dir. Else the documented single-skill target false-fails CI.
+  const dir = makeTmpDir("cov-solo-eval");
+  write(dir, "SKILL.md", "---\nname: solo\ndescription: x\n---\nbody\n");
+  write(dir, "solo.eval.mjs", "// colocated eval\n");
+  const report = findUntestedSurfaces({ basePath: dir });
+  assert.equal(
+    report.untested.filter((s) => s.kind === "skill").length,
+    0,
+    "the colocated solo.eval.mjs covers the root SKILL.md",
+  );
+  cleanupTmpDir(dir);
+});

--- a/src/test-coverage.ts
+++ b/src/test-coverage.ts
@@ -269,7 +269,13 @@ function discoverTests(
 /** Colocated: a test inside a skill dir, or a name-prefixed sibling of an agent/hook. */
 function isColocated(surface: Surface, testPath: string): boolean {
   if (surface.kind === "skill") {
-    return testPath.startsWith(`${dirname(surface.path)}/`);
+    const dir = dirname(surface.path);
+    // A root `SKILL.md` (single-skill-dir target) lives at ".", so any TOP-LEVEL
+    // test is colocated — globSync returns those without a "./" prefix, which a
+    // bare `startsWith("./")` would miss (false "untested").
+    return dir === "."
+      ? dirname(testPath) === "."
+      : testPath.startsWith(`${dir}/`);
   }
   return (
     dirname(testPath) === dirname(surface.path) &&
@@ -330,10 +336,14 @@ export function findUntestedSurfaces(
 
 /** Suggested colocated test path for an untested surface (shown in the warning). */
 export function suggestedTestPath(surface: Surface): string {
+  // A root skill lives at ".", so drop the "./" prefix — the suggested path then
+  // matches what globSync actually discovers at the top level.
+  const dir = dirname(surface.path);
+  const prefix = dir === "." ? "" : `${dir}/`;
   if (surface.kind === "skill") {
-    return `${dirname(surface.path)}/${surface.name}.eval.mjs`;
+    return `${prefix}${surface.name}.eval.mjs`;
   }
-  return `${dirname(surface.path)}/${surface.name}.harness.mjs`;
+  return `${prefix}${surface.name}.harness.mjs`;
 }
 
 /** Format an untested-surface report as human-readable text. */

--- a/src/test-coverage.ts
+++ b/src/test-coverage.ts
@@ -148,6 +148,22 @@ function discoverSkills(
       ignored: content.includes(IGNORE_MARKER),
     });
   }
+  // Single-skill-directory target: a bare `SKILL.md` AT the base (the dir you
+  // pointed lint/audit at). The globs above only match `<skillDir>/*/SKILL.md`
+  // NESTED under the base, so without this the untested-skill check would silently
+  // vanish for exactly the single-skill target that scoping now supports.
+  const rootSkill = join(basePath, "SKILL.md");
+  if (existsSync(rootSkill)) {
+    const name = basename(basePath);
+    const content = read(rootSkill);
+    out.push({
+      kind: "skill",
+      path: "SKILL.md",
+      name,
+      tokens: [`${layout.skillDir}/${name}`, `:${name}`],
+      ignored: content.includes(IGNORE_MARKER),
+    });
+  }
   return out;
 }
 


### PR DESCRIPTION
Adoption fixes from a **skills-monorepo field report**: a team running vigiles on a CI-tested 46-skill library (no `plugin.json`) hit blockers that made the tool unusable on their repo shape, plus a high false-positive rate on a legitimate authoring style. vigiles assumed a published-plugin / marketplace layout.

**All additive except the P0-2 lint scoping, whose only behavior change is `lint <explicit-dir>` (bugfix — the path was silently ignored). Bare `vigiles lint` is byte-identical.**

## P0 — recognize the shapes real users have (not just published plugins)

| Shape | Skills at |
| --- | --- |
| Published plugin | `skills/<name>/SKILL.md` + `.claude-plugin/plugin.json` |
| Skills library | `skills/<name>/SKILL.md` at repo root, no manifest |
| Plain Claude Code repo | `.claude/skills/<name>/SKILL.md` |

- `loadPlugin` reads a project-level `.claude/skills` / `.claude/agents` via a new optional `PluginLayout.userSurfaceRoot` (`.claude` for Claude Code; unset for other harnesses → unchanged). The `.claude` literal stays in the CC adapter — core stays harness-agnostic (`core ⊄ adapter`).
- Repo-root `skills/` **wins** when both exist, so a plugin author's local `.claude/skills` dev skills don't pollute the audit.
- Pointing at a **single skill directory** (`<root>/SKILL.md`) now works.
- New `LoadedPlugin.sources` maps each materialized key → its real on-disk path, so a `.claude/skills` skill's bundled resources resolve against their true dir.
- **Only the project `.claude/` is read — never the global `~/.claude`.**

### P0-2 — lint scopes to the path you pass

The surface rules (subagent contracts, skill resources, MCP, hook events, …) all scanned `process.cwd()`, ignoring the positional path — so `vigiles lint skills/one` scanned the whole repo and reported surfaces the user never pointed at.

- `runLint` resolves a single `scanRoot` once from the positional args: a lone existing **directory** narrows to it; a **file / several paths / none → cwd**. Bare `vigiles lint` (the CI-common case) is byte-identical.
- Every surface applier now takes `scanRoot` and passes it to `scanPlugin` / `findUntestedSurfaces` instead of reading cwd. scanPlugin reads only under its root, so a surface outside the passed dir — or the global `~/.claude` — can never enter the report.

## P1 — high-precision bundled-resource refs (kill the false "missing" noise)

- `skill-resources` skips globs / template placeholders (`*`, `?`, `{a,b}`, `<name>`) and `~/`-rooted home/global paths.
- **Opt-in** `sharedDirs` config: a ref under a **declared** shared top-level dir (e.g. `scripts`) also resolves against the repo root. Scoped to declared dirs so a genuinely-missing resource outside them is still flagged (no silent masking); a repo that omits the key is unchanged.

## P2

- Lethal-trifecta report collapses the identical inherits-all *advisory* paragraph to one line per unit (the count already lives in the section header); *hard* findings keep their specific legs.
- New `docs/skills-monorepo.md` — adopting vigiles without a `plugin.json`.

## Tests

- Loader: end-user `.claude/skills` repo, single skill dir, `sources` correctness, primary-wins-over-`.claude`.
- Scan: end-user repo discovered (not F/0), `.claude/skills` bundled-resource resolution, single skill dir.
- skill-resources: glob/placeholder/`~/` skips, `sharedDirs` opt-in + the safety case.
- lint scoping: `lint pkgA` reports pkgA's typo'd subagent tool; `lint pkgB` does not leak it.
- Full suite green — 2074 passed. The one failing `dialect-drift.test.ts` is the pre-existing installed-vs-pinned-CC environment check (pinned in CI), unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Features**
- support non-plugin skills repos + FP-safe bundled-resource refs

**Fixes**
- scope surface checks to an explicit path arg (feedback P0-2)
- address Codex review — single-skill-dir + scoped sharedDirs gaps
- address Codex review round 2 — surface-selection + scoped edge cases
- don't import project-local .claude surfaces into a manifest-backed plugin
- query-suffix refs + hooks-convention plugin shape (Codex round 4)
- loadable-surface fallback + foreign-repo sharedDirs root (Codex round 5)

**Refactors**
- parse repo shape into a tagged union (kill the fallback tangle)

**Docs**
- skills-monorepo lint scoping now works (P0-2 landed)

**Tests**
- brace afterAll cleanup arrow (no-confusing-void-expression)
- v8-ignore the exhaustiveness guard in materializeSurfaces (100% coverage gate)

**Chores**
- update API surface reports for userSurfaceRoot + LoadedPlugin.sources
- refresh HANDOFF for PR #66 adoption fixes
<!-- vigiles:pr-summary:end -->









