### PR TITLE
docs(site): link the API reference from the landing footer

### DIFF
--- a/site/src/components/Footer.tsx
+++ b/site/src/components/Footer.tsx
@@ -1,4 +1,4 @@
-import { Github } from "lucide-react";
+import { Github, BookText } from "lucide-react";
 
 const REPO = "https://github.com/zernie/vigiles";
 
@@ -34,6 +34,13 @@ export function Footer() {
             >
               <Github className="h-4 w-4" aria-hidden />
               github.com/zernie/vigiles
+            </a>
+            <a
+              href="./api/"
+              className="inline-flex items-center gap-2 text-muted-foreground no-underline transition-colors hover:text-foreground"
+            >
+              <BookText className="h-4 w-4" aria-hidden />
+              API reference
             </a>
             <a
               href="https://vigiles.sh"


### PR DESCRIPTION
The combined Pages deploy publishes the TypeDoc API reference at `/api`, but nothing on the landing pointed to it — undiscoverable. Adds a small "API reference" link (BookText icon) to the footer link column, using a relative `./api/` href so it resolves at both `vigiles.sh/api/` and the `github.io/vigiles/api/` path.

Docs-only (no npm release); redeploys Pages so the link goes live.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJVywjrttVEMLQgu7j53JQ)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Docs**
- link the API reference from the landing footer
<!-- vigiles:pr-summary:end -->
