### PR TITLE
fix(site): deeplink CTA feedback + landing consistency

### DIFF
--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -1,4 +1,5 @@
 import { StickyCTA } from "@/components/StickyCTA";
+import { Toaster } from "@/components/ui/toaster";
 import { Hero } from "@/components/sections/Hero";
 import { Rings } from "@/components/sections/Rings";
 import { Wedge } from "@/components/sections/Wedge";
@@ -20,6 +21,7 @@ export function App() {
         <CTA />
         <Footer />
       </main>
+      <Toaster />
     </>
   );
 }

--- a/site/src/components/AuditWidget.tsx
+++ b/site/src/components/AuditWidget.tsx
@@ -1,7 +1,13 @@
 import { useState } from "react";
 import { ArrowRight, ShieldCheck, Terminal } from "lucide-react";
 import { CommandBlock } from "@/components/CommandBlock";
-import { deeplink, normalizeSlug } from "@/lib/deeplink";
+import {
+  FALLBACK_COMMAND,
+  deeplink,
+  normalizeSlug,
+  openDeeplink,
+} from "@/lib/deeplink";
+import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 
 /**
@@ -15,8 +21,23 @@ import { cn } from "@/lib/utils";
  */
 export function AuditWidget({ className }: { className?: string }) {
   const [repo, setRepo] = useState("");
+  const [fellBack, setFellBack] = useState(false);
   const slug = normalizeSlug(repo);
   const ready = slug !== null;
+
+  function grade(e: React.MouseEvent) {
+    e.preventDefault();
+    if (slug === null) return;
+    openDeeplink(slug, () => {
+      // Claude Code never opened (mobile, or no CLI installed). Do the useful
+      // thing anyway: copy the universal command and tell the user.
+      void navigator.clipboard?.writeText(FALLBACK_COMMAND).catch(() => {});
+      setFellBack(true);
+      toast(
+        "Claude Code didn’t open on this device. Copied “npx vigiles audit” — paste it in your terminal.",
+      );
+    });
+  }
 
   return (
     <div className={cn("w-full max-w-xl", className)}>
@@ -33,12 +54,16 @@ export function AuditWidget({ className }: { className?: string }) {
           aria-label="Your GitHub repo (owner/name)"
           placeholder="owner/repo"
           value={repo}
-          onChange={(e) => setRepo(e.target.value)}
+          onChange={(e) => {
+            setRepo(e.target.value);
+            setFellBack(false);
+          }}
           className="flex-1 rounded-xl border border-border bg-card px-4 py-3.5 text-center font-mono text-sm text-foreground placeholder:text-muted-foreground/70 transition-colors focus:border-accent/60 focus:outline-none focus:ring-2 focus:ring-accent/30 sm:text-left"
         />
         {ready ? (
           <a
             href={deeplink(slug)}
+            onClick={grade}
             className="inline-flex h-[50px] items-center justify-center gap-2 whitespace-nowrap rounded-xl bg-accent px-6 text-sm font-semibold text-accent-foreground no-underline transition-colors hover:bg-accent/90"
           >
             <Terminal className="h-4 w-4" aria-hidden />
@@ -57,6 +82,16 @@ export function AuditWidget({ className }: { className?: string }) {
           </button>
         )}
       </form>
+
+      {/* Fallback notice — shown when the deeplink couldn't open Claude Code. */}
+      {fellBack && (
+        <p className="mt-3 rounded-xl border border-accent/30 bg-accent/[0.07] px-4 py-3 text-sm text-foreground">
+          Claude Code isn’t available on this device — it runs on your computer,
+          not the browser. We copied{" "}
+          <span className="font-mono text-foreground">npx vigiles audit</span>{" "}
+          for you; run it in your terminal, or see it below.
+        </p>
+      )}
 
       {/* Security reassurance — the deeplink runs in the user's OWN Claude Code. */}
       <p className="mt-3 flex items-start justify-center gap-2 text-left text-sm text-muted-foreground">

--- a/site/src/components/sections/Hero.tsx
+++ b/site/src/components/sections/Hero.tsx
@@ -1,9 +1,66 @@
 import { Star } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { AuditWidget } from "@/components/AuditWidget";
+import { cn } from "@/lib/utils";
 import auditReport from "@/assets/vigiles-audit.png";
 
 const REPO = "https://github.com/zernie/vigiles";
+
+/** The five categories of the sample report — kept in sync with the screenshot. */
+const CATEGORIES: { name: string; score: number; band: "good" | "warn" }[] = [
+  { name: "Truthfulness", score: 100, band: "good" },
+  { name: "Triggering", score: 92, band: "good" },
+  { name: "Structure", score: 92, band: "good" },
+  { name: "Safety", score: 80, band: "warn" },
+  { name: "Tested", score: 88, band: "warn" },
+];
+
+/**
+ * A native, readable stand-in for the report screenshot on phones — the full
+ * PNG scales to unreadable ~6px text at 390px wide, so mobile gets the grade +
+ * the five category scores rendered at real size instead.
+ */
+function HeroReportCard() {
+  return (
+    <div className="reveal rounded-2xl border border-border bg-card p-5 shadow-2xl sm:hidden">
+      <div className="flex items-center gap-4">
+        <div className="flex h-16 w-16 shrink-0 flex-col items-center justify-center rounded-xl border-2 border-warn text-warn">
+          <span className="text-2xl font-extrabold leading-none">C</span>
+          <span className="mt-0.5 text-[10px] font-medium">77/100</span>
+        </div>
+        <div className="min-w-0">
+          <p className="text-base font-semibold leading-snug">
+            Two one-line fixes away from a B.
+          </p>
+          <p className="mt-1 font-mono text-xs text-muted-foreground">
+            my-plugin · claude-code
+          </p>
+        </div>
+      </div>
+      <ul className="mt-4 space-y-2 border-t border-border pt-4">
+        {CATEGORIES.map((c) => (
+          <li
+            key={c.name}
+            className="flex items-center justify-between text-sm"
+          >
+            <span className="text-muted-foreground">{c.name}</span>
+            <span
+              className={cn(
+                "font-mono font-semibold",
+                c.band === "good" ? "text-good" : "text-warn",
+              )}
+            >
+              {c.score}
+            </span>
+          </li>
+        ))}
+      </ul>
+      <p className="mt-4 text-center text-xs text-muted-foreground">
+        deterministic · no model · nothing leaves your machine
+      </p>
+    </div>
+  );
+}
 
 export function Hero() {
   return (
@@ -51,7 +108,9 @@ export function Hero() {
 
       {/* Product shot on the fold — the real audit report (README-parity). */}
       <div className="mx-auto w-full max-w-5xl px-6 pb-20 sm:pb-28">
-        <div className="reveal overflow-hidden rounded-2xl border border-border bg-card shadow-2xl">
+        {/* Phones get a native, readable summary; the full screenshot needs width. */}
+        <HeroReportCard />
+        <div className="reveal hidden overflow-hidden rounded-2xl border border-border bg-card shadow-2xl sm:block">
           <img
             src={auditReport}
             alt="A vigiles audit report for 'my-plugin': a verdict header, a C (77/100) grade, a five-category strip (Truthfulness, Triggering, Structure, Safety, Tested), ranked fix cards with '+N pts' impact badges, and broken-reference findings."

--- a/site/src/components/sections/RepoPicker.tsx
+++ b/site/src/components/sections/RepoPicker.tsx
@@ -12,7 +12,13 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { CommandBlock } from "@/components/CommandBlock";
-import { deeplink, normalizeSlug } from "@/lib/deeplink";
+import {
+  FALLBACK_COMMAND,
+  deeplink,
+  normalizeSlug,
+  openDeeplink,
+} from "@/lib/deeplink";
+import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 
 /** A single public repo as returned by the GitHub REST API (fields we use). */
@@ -109,6 +115,17 @@ export function RepoPicker() {
   const manualSlug = normalizeSlug(manual);
   // The active handoff target: an explicit manual entry wins over a list pick.
   const targetSlug = manualSlug ?? selected;
+
+  function handoff(e: React.MouseEvent) {
+    e.preventDefault();
+    if (targetSlug === null) return;
+    openDeeplink(targetSlug, () => {
+      void navigator.clipboard?.writeText(FALLBACK_COMMAND).catch(() => {});
+      toast(
+        "Claude Code didn’t open on this device. Copied “npx vigiles audit” — paste it in your terminal.",
+      );
+    });
+  }
 
   return (
     <section id="try" className="scroll-mt-8 border-t border-border bg-card/30">
@@ -331,6 +348,7 @@ export function RepoPicker() {
                 </p>
                 <Button
                   href={deeplink(targetSlug)}
+                  onClick={handoff}
                   variant="primary"
                   size="lg"
                   className="mt-3 w-full"

--- a/site/src/components/sections/Rings.tsx
+++ b/site/src/components/sections/Rings.tsx
@@ -11,27 +11,34 @@ const RINGS: {
 }[] = [
   {
     name: "Truthfulness",
-    score: 96,
+    score: 100,
     band: "good",
     blurb:
       "Do your references resolve? Every rule, path, and script — real and enabled.",
   },
   {
     name: "Triggering",
-    score: 74,
-    band: "warn",
+    score: 92,
+    band: "good",
     blurb: "Do your skills actually fire — and not collide with each other?",
   },
   {
     name: "Structure",
-    score: 88,
-    band: "warn",
+    score: 92,
+    band: "good",
     blurb: "Tool contracts, MCP servers, and frontmatter that hold together.",
   },
   {
+    name: "Safety",
+    score: 80,
+    band: "warn",
+    blurb:
+      "Could a prompt injection turn your own tools into an exfil path? Read from the tool-set alone.",
+  },
+  {
     name: "Tested",
-    score: 41,
-    band: "bad",
+    score: 88,
+    band: "warn",
     blurb: "Is any of it covered by a test or eval — or is it all on faith?",
   },
 ];
@@ -41,15 +48,15 @@ export function Rings() {
     <section className="mx-auto w-full max-w-6xl px-6 py-20 sm:py-28">
       <div className="mx-auto max-w-2xl text-center">
         <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
-          Four rings. One score.
+          Five rings. One score.
         </h2>
         <p className="mt-4 text-lg text-muted-foreground">
-          One command, four deterministic categories, weighted A–F — plus every
+          One command, five deterministic categories, weighted A–F — plus every
           finding&apos;s fix, inline.
         </p>
       </div>
 
-      <div className="mt-14 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="mt-14 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-5">
         {RINGS.map((ring) => (
           <Card
             key={ring.name}

--- a/site/src/components/sections/Wedge.tsx
+++ b/site/src/components/sections/Wedge.tsx
@@ -42,7 +42,7 @@ export function Wedge() {
       <div className="mx-auto w-full max-w-6xl px-6 py-20 sm:py-28">
         <div className="mx-auto max-w-2xl text-center">
           <Badge variant="signal" className="mb-5">
-            The wedge
+            The problem
           </Badge>
           <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
             &ldquo;Valid&rdquo; is not &ldquo;true.&rdquo;

--- a/site/src/components/ui/toaster.tsx
+++ b/site/src/components/ui/toaster.tsx
@@ -1,0 +1,34 @@
+import { useSyncExternalStore } from "react";
+import { Terminal } from "lucide-react";
+import { getToasts, subscribeToasts } from "@/lib/toast";
+
+/**
+ * Renders the active toasts. Mount once (in App). Fixed to the bottom on mobile
+ * (thumb-reachable, clear of the top address bar) and stacks upward.
+ */
+export function Toaster() {
+  const toasts = useSyncExternalStore(subscribeToasts, getToasts, getToasts);
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div
+      className="pointer-events-none fixed inset-x-0 bottom-4 z-50 flex flex-col items-center gap-2 px-4"
+      role="status"
+      aria-live="polite"
+    >
+      {toasts.map((t) => (
+        <div
+          key={t.id}
+          className="pointer-events-auto flex max-w-md items-start gap-2.5 rounded-xl border border-border bg-card px-4 py-3 text-sm text-foreground shadow-lg"
+        >
+          <Terminal
+            className="mt-0.5 h-4 w-4 shrink-0 text-accent"
+            aria-hidden
+          />
+          <span>{t.message}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/site/src/lib/deeplink.ts
+++ b/site/src/lib/deeplink.ts
@@ -37,3 +37,38 @@ export function deeplink(slug: string): string {
     slug,
   )}&q=${encodeURIComponent(PROMPT)}`;
 }
+
+/** The universal fallback command anyone can run without Claude Code. */
+export const FALLBACK_COMMAND = "npx vigiles audit";
+
+/**
+ * Open the Claude Code deeplink for `slug`, with a fallback for the (common)
+ * case where nothing handles the `claude-cli://` scheme.
+ *
+ * Custom URL schemes fail SILENTLY when unregistered — every mobile browser,
+ * Claude Code Web (#19023), and any desktop without Claude Code installed — so
+ * the tap looks completely dead (the "click doesn't do anything" report). We
+ * arm a detector: when the OS hands off to the app the page hides / loses
+ * focus, so if we're still visible a beat later the app never launched and we
+ * call `onUnhandled` (copy the command, toast, reveal the fallback).
+ */
+export function openDeeplink(slug: string, onUnhandled: () => void): void {
+  let launched = false;
+  const markLaunched = () => {
+    launched = true;
+  };
+  // App launch blurs/hides the page; either signal means the scheme resolved.
+  window.addEventListener("blur", markLaunched, { once: true });
+  window.addEventListener("pagehide", markLaunched, { once: true });
+  document.addEventListener("visibilitychange", markLaunched, { once: true });
+
+  window.setTimeout(() => {
+    window.removeEventListener("blur", markLaunched);
+    window.removeEventListener("pagehide", markLaunched);
+    document.removeEventListener("visibilitychange", markLaunched);
+    if (!launched && document.visibilityState === "visible") onUnhandled();
+  }, 1400);
+
+  // Trigger the scheme. Unhandled schemes no-op here (no throw, no navigation).
+  window.location.href = deeplink(slug);
+}

--- a/site/src/lib/toast.ts
+++ b/site/src/lib/toast.ts
@@ -1,0 +1,36 @@
+/**
+ * A tiny dependency-free toast store (external store + useSyncExternalStore).
+ * One `<Toaster />` is mounted in App; anything can fire `toast(message)` —
+ * used to give the deeplink CTA visible feedback when Claude Code can't open.
+ */
+
+export type Toast = { id: number; message: string };
+
+let toasts: Toast[] = [];
+const listeners = new Set<() => void>();
+let nextId = 1;
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}
+
+/** Show a transient notification. Returns nothing; auto-dismisses after `ttl`. */
+export function toast(message: string, ttl = 4000): void {
+  const id = nextId++;
+  toasts = [...toasts, { id, message }];
+  emit();
+  window.setTimeout(() => {
+    toasts = toasts.filter((t) => t.id !== id);
+    emit();
+  }, ttl);
+}
+
+export function subscribeToasts(callback: () => void): () => void {
+  listeners.add(callback);
+  return () => listeners.delete(callback);
+}
+
+/** Stable snapshot: the same array reference until `emit` reassigns it. */
+export function getToasts(): Toast[] {
+  return toasts;
+}


### PR DESCRIPTION
## What & why

Fixes a dead primary CTA plus three landing-page issues surfaced by a blind design review.

### 1. "Grade it" deeplink gave no feedback (the reported "click doesn't do anything")
The hero CTA was a bare `<a href="claude-cli://…">`. Custom URL schemes fail **silently** when unhandled — every mobile browser, Claude Code Web, and any desktop without Claude Code — so the tap looked completely dead.

- New `openDeeplink()` still triggers the scheme (desktop-with-CLI users are unaffected) but arms a visibility/blur detector; if the page is still visible ~1.4s later the app never launched → run a fallback.
- Fallback copies `npx vigiles audit` to the clipboard, shows a toast, and reveals an inline notice explaining Claude Code runs on the user's computer, not the browser.
- Wired through both deeplink CTAs (hero `AuditWidget` + `RepoPicker`); added a tiny dependency-free toast store + `<Toaster />`.

### 2. Rings section contradicted itself (4 vs 5)
Said "Four rings" with four cards (Safety missing) while the hero caption/screenshot show five categories. Now five, with scores aligned to the real sample report (Truthfulness 100, Triggering 92, Structure 92, Safety 80, Tested 88).

### 3. Report screenshot unreadable on mobile
The full PNG scales to ~6px text at 390px. Mobile now gets a native, readable summary card (grade + five category scores); the screenshot is kept for wider viewports.

### 4. Internal vocabulary on the public page
Renamed the "The wedge" badge → "The problem".

## Verification
- Site builds clean (`vite build`), Prettier clean.
- Headless-Chromium interaction test: clicking "Grade it" with an unresolvable scheme fires the toast + inline notice and copies the command to the clipboard; the `href` still carries the real deeplink for CLI users.
- Screenshotted mobile fold (native card readable) and desktop rings ("Five rings", all five categories) and the renamed badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016EkhbHBV7Vvt6xyduUyMfy)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Fixes**
- make the "Grade it" deeplink CTA give feedback when Claude Code can't open
- landing consistency — five rings, readable mobile hero, rename badge
<!-- vigiles:pr-summary:end -->
