### PR TITLE
chore(api): regenerate API surface snapshots after #79

### DIFF
--- a/api-surface/vigiles-codex.api.md
+++ b/api-surface/vigiles-codex.api.md
@@ -7,6 +7,9 @@
 // @public
 export function buildCodexArgs(ctx: HarnessDriverContext): string[];
 
+// @public
+export const CODEX_TRIGGER_RATE_EXPERIMENTAL: string;
+
 // @public (undocumented)
 export const codexAdapter: HarnessAdapter;
 

--- a/api-surface/vigiles-testing.api.md
+++ b/api-surface/vigiles-testing.api.md
@@ -353,6 +353,7 @@ export function evalChecks<T>(target: T, checks: readonly Check<T>[]): CheckResu
 
 // @public
 export interface EvalDriver {
+    readonly experimental?: string;
     readonly harness?: string;
     // (undocumented)
     readonly parse: ModelOutputParser;
@@ -872,6 +873,7 @@ export interface Trace {
 export interface TriggerRateReport {
     readonly competitors: number;
     readonly errored?: number;
+    readonly experimental?: string;
     readonly falsePositiveRate?: number;
     readonly n: number;
     readonly perIrrelevant?: readonly PromptTriggerStat[];


### PR DESCRIPTION
## Why

The **API surface gate** has been failing on `main` since #79. That PR added the Codex-experimental caveat — additive public API — but never regenerated the committed `api-surface/*.api.md` snapshots, so the gate (which diffs the live `.d.ts` surface against the snapshots) fails every run until they're regenerated.

## What changed

`npm run api:report` output — purely additive, no exports removed (not breaking):

- **`vigiles/codex`** — new `CODEX_TRIGGER_RATE_EXPERIMENTAL` const.
- **`vigiles/testing`** — optional `experimental?: string` on `EvalDriver` and `TriggerRateReport`.

## Verification

`node scripts/api-extractor.mjs` (the gate) now passes locally after regenerating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016EkhbHBV7Vvt6xyduUyMfy)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Chores**
- regenerate API surface snapshots after #79
<!-- vigiles:pr-summary:end -->
