### PR TITLE
fix(site): no clipboard prompt on deeplink fallback; surface public-repo picker

### DIFF
--- a/site/src/components/AuditWidget.tsx
+++ b/site/src/components/AuditWidget.tsx
@@ -1,12 +1,7 @@
 import { useState } from "react";
-import { ArrowRight, ShieldCheck, Terminal } from "lucide-react";
+import { ArrowRight, Github, ShieldCheck, Terminal } from "lucide-react";
 import { CommandBlock } from "@/components/CommandBlock";
-import {
-  FALLBACK_COMMAND,
-  deeplink,
-  normalizeSlug,
-  openDeeplink,
-} from "@/lib/deeplink";
+import { deeplink, normalizeSlug, openDeeplink } from "@/lib/deeplink";
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 
@@ -29,12 +24,12 @@ export function AuditWidget({ className }: { className?: string }) {
     e.preventDefault();
     if (slug === null) return;
     openDeeplink(slug, () => {
-      // Claude Code never opened (mobile, or no CLI installed). Do the useful
-      // thing anyway: copy the universal command and tell the user.
-      void navigator.clipboard?.writeText(FALLBACK_COMMAND).catch(() => {});
+      // Claude Code never opened (mobile, or no CLI installed). Point the user
+      // at the terminal command below — no auto-clipboard write (it triggers a
+      // scary "wants to see your clipboard" permission prompt on mobile).
       setFellBack(true);
       toast(
-        "Claude Code didn’t open on this device. Copied “npx vigiles audit” — paste it in your terminal.",
+        "Claude Code runs on your computer, not the browser. Run npx vigiles audit in a terminal — the command’s just below.",
       );
     });
   }
@@ -87,9 +82,9 @@ export function AuditWidget({ className }: { className?: string }) {
       {fellBack && (
         <p className="mt-3 rounded-xl border border-accent/30 bg-accent/[0.07] px-4 py-3 text-sm text-foreground">
           Claude Code isn’t available on this device — it runs on your computer,
-          not the browser. We copied{" "}
+          not the browser. Copy{" "}
           <span className="font-mono text-foreground">npx vigiles audit</span>{" "}
-          for you; run it in your terminal, or see it below.
+          below and run it in your terminal.
         </p>
       )}
 
@@ -120,14 +115,18 @@ export function AuditWidget({ className }: { className?: string }) {
 
       <p className="mt-4 text-center text-sm text-muted-foreground">
         <span className="font-mono text-foreground/80">audit</span> runs
-        anywhere and auto-detects Claude Code or Codex.{" "}
-        <a
-          href="#try"
-          className="whitespace-nowrap font-medium text-foreground/80 underline-offset-4 hover:text-foreground hover:underline"
-        >
-          browse my repos →
-        </a>
+        anywhere and auto-detects Claude Code or Codex.
       </p>
+
+      {/* Secondary path — list your public repos and pick one (the RepoPicker). */}
+      <a
+        href="#try"
+        className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-border bg-card/60 px-4 py-3 text-sm font-medium text-foreground no-underline transition-colors hover:border-accent/50 hover:bg-card"
+      >
+        <Github className="h-4 w-4" aria-hidden />
+        Browse my public repos
+        <ArrowRight className="h-4 w-4" aria-hidden />
+      </a>
     </div>
   );
 }

--- a/site/src/components/sections/RepoPicker.tsx
+++ b/site/src/components/sections/RepoPicker.tsx
@@ -12,12 +12,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { CommandBlock } from "@/components/CommandBlock";
-import {
-  FALLBACK_COMMAND,
-  deeplink,
-  normalizeSlug,
-  openDeeplink,
-} from "@/lib/deeplink";
+import { deeplink, normalizeSlug, openDeeplink } from "@/lib/deeplink";
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 
@@ -120,9 +115,8 @@ export function RepoPicker() {
     e.preventDefault();
     if (targetSlug === null) return;
     openDeeplink(targetSlug, () => {
-      void navigator.clipboard?.writeText(FALLBACK_COMMAND).catch(() => {});
       toast(
-        "Claude Code didn’t open on this device. Copied “npx vigiles audit” — paste it in your terminal.",
+        "Claude Code runs on your computer, not the browser. Run npx vigiles audit in a terminal — the command’s just below.",
       );
     });
   }

--- a/site/src/lib/deeplink.ts
+++ b/site/src/lib/deeplink.ts
@@ -38,9 +38,6 @@ export function deeplink(slug: string): string {
   )}&q=${encodeURIComponent(PROMPT)}`;
 }
 
-/** The universal fallback command anyone can run without Claude Code. */
-export const FALLBACK_COMMAND = "npx vigiles audit";
-
 /**
  * Open the Claude Code deeplink for `slug`, with a fallback for the (common)
  * case where nothing handles the `claude-cli://` scheme.


### PR DESCRIPTION
## Two mobile issues

### 1. Scary clipboard permission prompt
The deeplink fallback auto-wrote `npx vigiles audit` to the clipboard. On some mobile browsers that pops a **"vigiles.sh wants to see text and images copied to the clipboard"** permission dialog — alarming and unexpected right after tapping "Grade it".

**Fix:** drop the auto-copy entirely. The fallback now just shows the toast + inline notice and points at the always-visible `npx vigiles audit` command, which has its own copy-on-tap button (a normal, expected user gesture — no permission prompt).

### 2. The public-repo picker was hard to find
The "list my public repos" flow (the RepoPicker's **Find repos** button) was reachable only through a tiny `browse my repos →` text link. **Fix:** promote it to a visible **"Browse my public repos"** button under the hero command, which jumps to the picker.

## Verification
- Build + Prettier clean.
- Headless mobile (390px): tapping "Grade it" fires the toast + notice with **no clipboard prompt**; the new "Browse my public repos" button is visible and scrolls to the "Grade your harness" picker with its "Find repos" button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016EkhbHBV7Vvt6xyduUyMfy)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Fixes**
- drop auto-clipboard write on deeplink fallback; surface the public-repo picker
<!-- vigiles:pr-summary:end -->
