### PR TITLE
feat(site): command-first hero; deeplink demoted to a desktop-only repo audit

### DIFF
--- a/site/src/components/AuditWidget.tsx
+++ b/site/src/components/AuditWidget.tsx
@@ -1,123 +1,42 @@
-import { useState } from "react";
-import { ArrowRight, Github, ShieldCheck, Terminal } from "lucide-react";
+import { ArrowRight, ShieldCheck } from "lucide-react";
 import { CommandBlock } from "@/components/CommandBlock";
-import { deeplink, normalizeSlug, openDeeplink } from "@/lib/deeplink";
-import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 
 /**
- * The merged audit CTA: one widget, two entry points to the SAME audit.
- * - Primary: type `owner/repo` → a Claude Code deeplink that runs vigiles on
- *   the user's own machine + subscription (the "grade my repo" wow).
- * - Fallback: `npx vigiles audit`, always visible, for anyone without Claude
- *   Code (or on the web, where the deeplink can't fire).
- * The richer "browse my public repos by username" flow lives in the RepoPicker
- * section (#try) — this links down to it rather than duplicating it.
+ * The hero CTA — command-first. The one action that works for EVERYONE (any
+ * OS, any terminal, mobile included as "run it on your computer") is
+ * `npx vigiles audit`, so that's the star. The Claude-Code-specific "grade a
+ * specific repo in one click" flow (a desktop-only deeplink) lives lower in the
+ * RepoPicker section (#try) — this just links down to it, rather than leading
+ * with a button that dead-ends on mobile / without Claude Code.
  */
 export function AuditWidget({ className }: { className?: string }) {
-  const [repo, setRepo] = useState("");
-  const [fellBack, setFellBack] = useState(false);
-  const slug = normalizeSlug(repo);
-  const ready = slug !== null;
-
-  function grade(e: React.MouseEvent) {
-    e.preventDefault();
-    if (slug === null) return;
-    openDeeplink(slug, () => {
-      // Claude Code never opened (mobile, or no CLI installed). Point the user
-      // at the terminal command below — no auto-clipboard write (it triggers a
-      // scary "wants to see your clipboard" permission prompt on mobile).
-      setFellBack(true);
-      toast(
-        "Claude Code runs on your computer, not the browser. Run npx vigiles audit in a terminal — the command’s just below.",
-      );
-    });
-  }
-
   return (
-    <div className={cn("w-full max-w-xl", className)}>
-      {/* Primary — repo → Claude Code deeplink */}
-      <form
-        className="flex flex-col gap-2.5 sm:flex-row"
-        onSubmit={(e) => e.preventDefault()}
-      >
-        <input
-          type="text"
-          autoCapitalize="off"
-          autoCorrect="off"
-          spellCheck={false}
-          aria-label="Your GitHub repo (owner/name)"
-          placeholder="owner/repo"
-          value={repo}
-          onChange={(e) => {
-            setRepo(e.target.value);
-            setFellBack(false);
-          }}
-          className="flex-1 rounded-xl border border-border bg-card px-4 py-3.5 text-center font-mono text-sm text-foreground placeholder:text-muted-foreground/70 transition-colors focus:border-accent/60 focus:outline-none focus:ring-2 focus:ring-accent/30 sm:text-left"
-        />
-        {ready ? (
-          <a
-            href={deeplink(slug)}
-            onClick={grade}
-            className="inline-flex h-[50px] items-center justify-center gap-2 whitespace-nowrap rounded-xl bg-accent px-6 text-sm font-semibold text-accent-foreground no-underline transition-colors hover:bg-accent/90"
-          >
-            <Terminal className="h-4 w-4" aria-hidden />
-            Grade it
-            <ArrowRight className="h-4 w-4" aria-hidden />
-          </a>
-        ) : (
-          <button
-            type="button"
-            disabled
-            className="inline-flex h-[50px] cursor-not-allowed items-center justify-center gap-2 whitespace-nowrap rounded-xl bg-accent px-6 text-sm font-semibold text-accent-foreground opacity-50"
-          >
-            <Terminal className="h-4 w-4" aria-hidden />
-            Grade it
-            <ArrowRight className="h-4 w-4" aria-hidden />
-          </button>
-        )}
-      </form>
+    <div
+      className={cn("flex w-full max-w-xl flex-col items-center", className)}
+    >
+      {/* Primary action — the universal command. */}
+      <CommandBlock
+        command="npx vigiles audit"
+        className="w-full justify-center py-4 text-base"
+      />
 
-      {/* Fallback notice — shown when the deeplink couldn't open Claude Code. */}
-      {fellBack && (
-        <p className="mt-3 rounded-xl border border-accent/30 bg-accent/[0.07] px-4 py-3 text-sm text-foreground">
-          Claude Code isn’t available on this device — it runs on your computer,
-          not the browser. Copy{" "}
-          <span className="font-mono text-foreground">npx vigiles audit</span>{" "}
-          below and run it in your terminal.
-        </p>
-      )}
-
-      {/* Security reassurance — one line: the deeplink runs in the user's OWN CC. */}
       <p className="mt-3 flex items-center justify-center gap-1.5 text-sm text-muted-foreground">
         <ShieldCheck className="h-4 w-4 shrink-0 text-good" aria-hidden />
         <span>
-          Runs in <span className="font-medium text-foreground">your own</span>{" "}
-          Claude Code — nothing leaves your machine.
+          Runs in any terminal — auto-detects Claude Code or Codex.{" "}
+          <span className="text-foreground/70">Nothing is uploaded.</span>
         </span>
       </p>
 
-      {/* Fallback — the universal copy-command, always visible */}
-      <div className="mt-5 flex flex-col items-center gap-2">
-        <div className="flex items-center gap-3 text-sm text-muted-foreground">
-          <span className="hidden h-px w-8 bg-border sm:block" aria-hidden />
-          <span>or run it in any terminal</span>
-          <span className="hidden h-px w-8 bg-border sm:block" aria-hidden />
-        </div>
-        <CommandBlock command="npx vigiles audit" />
-      </div>
-
-      {/* Secondary path — a light pill to the public-repo picker (the RepoPicker). */}
-      <div className="mt-4 flex justify-center">
-        <a
-          href="#try"
-          className="inline-flex items-center gap-2 rounded-full border border-border px-4 py-2 text-sm font-medium text-muted-foreground no-underline transition-colors hover:border-accent/50 hover:text-foreground"
-        >
-          <Github className="h-4 w-4" aria-hidden />
-          Browse my public repos
-          <ArrowRight className="h-4 w-4" aria-hidden />
-        </a>
-      </div>
+      {/* Secondary — the desktop Claude Code one-click flow lives at #try. */}
+      <a
+        href="#try"
+        className="mt-5 inline-flex items-center gap-1.5 text-sm font-medium text-foreground/80 underline-offset-4 transition-colors hover:text-foreground hover:underline"
+      >
+        Have Claude Code? Audit a specific repo
+        <ArrowRight className="h-4 w-4" aria-hidden />
+      </a>
     </div>
   );
 }

--- a/site/src/components/sections/Hero.tsx
+++ b/site/src/components/sections/Hero.tsx
@@ -99,8 +99,9 @@ export function Hero() {
         </h1>
 
         <p className="mt-5 max-w-2xl text-balance text-lg leading-relaxed text-muted-foreground sm:text-xl">
-          Your skills, hooks, and subagents are code now. vigiles grades them —
-          and tells you what&apos;s actually broken.
+          Your skills, hooks, and subagents are code — and full of references
+          nothing checks. vigiles grades them and shows you what&apos;s silently
+          broken.
         </p>
 
         <AuditWidget className="mt-8" />

--- a/site/src/components/sections/RepoPicker.tsx
+++ b/site/src/components/sections/RepoPicker.tsx
@@ -127,14 +127,15 @@ export function RepoPicker() {
         <div className="mx-auto max-w-2xl text-center">
           <Badge variant="accent" className="mb-5">
             <Star className="h-3 w-3" aria-hidden />
-            Try it on your repo
+            Audit a specific repo
           </Badge>
           <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
-            Grade your harness.
+            Grade a specific repo.
           </h2>
           <p className="mt-4 text-lg leading-relaxed text-muted-foreground">
-            Pick a repo and hand it to your own Claude Code. It runs locally, on
-            your subscription — no account, no server, nothing uploaded.
+            Pick a repo and audit it — locally, on your own machine, nothing
+            uploaded. With Claude Code on your desktop it&apos;s one click;
+            anywhere else it&apos;s one command.
           </p>
         </div>
 
@@ -340,38 +341,48 @@ export function RepoPicker() {
                     {targetSlug}
                   </span>
                 </p>
-                <Button
-                  href={deeplink(targetSlug)}
-                  onClick={handoff}
-                  variant="primary"
-                  size="lg"
-                  className="mt-3 w-full"
-                >
-                  <Terminal className="h-4 w-4" aria-hidden />
-                  Test my skills in Claude Code
-                  <ArrowRight className="h-4 w-4" aria-hidden />
-                </Button>
-                <p className="mt-2.5 text-center text-xs text-muted-foreground">
-                  Opens your local Claude Code (the repo must be cloned
-                  locally); runs on your own subscription.{" "}
-                  <span className="text-foreground/70">
-                    Your code never leaves your machine — no server ever sees
-                    your repo.
-                  </span>
+
+                {/* Desktop: one click opens the user's local Claude Code. */}
+                <div className="hidden sm:block">
+                  <Button
+                    href={deeplink(targetSlug)}
+                    onClick={handoff}
+                    variant="primary"
+                    size="lg"
+                    className="mt-3 w-full"
+                  >
+                    <Terminal className="h-4 w-4" aria-hidden />
+                    Audit this repo in Claude Code
+                    <ArrowRight className="h-4 w-4" aria-hidden />
+                  </Button>
+                  <p className="mt-2.5 text-center text-xs text-muted-foreground">
+                    Opens your local Claude Code (the repo must be cloned
+                    locally) and runs the full audit on your own subscription —
+                    nothing uploaded.
+                  </p>
+                </div>
+
+                {/* Mobile: the deeplink can't reach Claude Code — use the command. */}
+                <p className="mt-3 rounded-xl border border-border bg-background px-4 py-3 text-sm text-muted-foreground sm:hidden">
+                  Claude Code runs on a computer, not a phone. On your machine,{" "}
+                  <span className="whitespace-nowrap font-mono text-foreground">
+                    cd {targetSlug.split("/")[1] ?? targetSlug}
+                  </span>{" "}
+                  and run the command below.
                 </p>
               </>
             ) : (
               <p className="text-sm text-muted-foreground">
                 Pick a repo above or type{" "}
-                <span className="font-mono">owner/name</span> to get your Claude
-                Code handoff.
+                <span className="font-mono">owner/name</span> to get your
+                command and (on desktop) a one-click Claude Code handoff.
               </p>
             )}
 
             <div className="mt-6 flex flex-col items-center gap-2 border-t border-border pt-6">
               <CommandBlock command="npx vigiles audit" />
               <p className="text-xs text-muted-foreground">
-                No Claude Code CLI? Run this in your terminal — zero install.
+                Any terminal, zero install — auto-detects Claude Code or Codex.
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Why

The landing was built around the Claude Code `claude-cli://` deeplink as the primary action — but that only fires on desktop-with-Claude-Code and **dead-ends silently on mobile / CC Web / desktop-without-CC**. That made the hero confusing ("type repo → tap → nothing"), crowded, and mis-framed the product (leading with Claude Code as TMI, and calling a whole-harness audit "test my skills").

## The reframe

Lead with the action that works for **everyone** — the command — and treat the deeplink as a desktop-only convenience.

- **Command-first hero:** `npx vigiles audit` is the single primary action, one-line trust ("runs in any terminal — auto-detects Claude Code or Codex, nothing uploaded"), and a quiet "Have Claude Code? Audit a specific repo →" link to the picker. No repo input, no deeplink, no CC-first paragraph on the fold — the product shot now reaches it.
- **Repo section reframed:** "Grade a specific repo" / **"Audit this repo in Claude Code"** (was the mis-framed "Test my skills in Claude Code" — audit grades the whole harness: references, skills, hooks, subagents, MCP, safety).
- **Deeplink is desktop-only now:** on mobile the section shows an honest "Claude Code runs on a computer — `cd <repo>` and run the command" note instead of a button that can't work.
- **Harness-neutral** throughout (Claude Code *or* Codex), not Claude-Code-first.

## Verification
Build + Prettier clean; screenshotted desktop + mobile. Mobile hero is uncrowded with the report card on the fold; the mobile repo handoff correctly hides the deeplink button (verified `false`) and shows the command + honest note (verified `true`).

## Follow-up (not in this PR)
A hosted, **deterministic-only** audit of public repos (fetch the repo's files via the GitHub API → run the model-free scan server-side → render the existing report UI) would give mobile a real zero-install "wow" without any LLM/quota. Teed up as a separate build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016EkhbHBV7Vvt6xyduUyMfy)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Features**
- command-first hero; deeplink demoted to a desktop-only repo audit
<!-- vigiles:pr-summary:end -->
