### PR TITLE
fix(site): cut the redundant OSS badge + weak hero link; sharpen the design skill

### DIFF
--- a/.claude/skills/landing-site/SKILL.md
+++ b/.claude/skills/landing-site/SKILL.md
@@ -46,6 +46,14 @@ few words, one clear focal point per section. NOT a feature-stuffed template.
 
 - **Every element must earn its place.** Remove anything that only restates another
   (a caption repeating the screenshot; a trust line said twice; a redundant subhead).
+- **Cut any label another element already IMPLIES.** A "free & open source" badge is
+  redundant when a GitHub/star link is present; an "AUDIT A SPECIFIC REPO" badge above
+  a "Grade a specific repo" heading restates it. If the context already tells the
+  reader, the label is noise.
+- **Every link/CTA is ACTIONABLE and specific.** The reader must know exactly what
+  happens on click. No vague or passive secondary links ("Have Claude Code?…"). If a
+  secondary path isn't worth a clear, concrete action, cut it (or move it to the nav,
+  where a persistent link beats a limp fold link).
 - **One focal point per section.** The eye should land on one thing first.
 - **Whitespace + typography over boxes.** Don't stack 3+ full-width bordered boxes;
   that repetition is what reads as crowded. Prefer type hierarchy and space to
@@ -106,5 +114,6 @@ change, not bolted onto a design pass.
 2. **Screenshot desktop AND mobile** (390px) and actually look — most crowding shows
    up on the phone fold. (Global playwright + `vite preview`; or the `screenshot` skill.)
 3. **Run a Fable blind pass** for anything nontrivial — fresh skeptical eyes catch
-   crowding and incoherence the author is blind to.
+   crowding and incoherence the author is blind to. **Act on the flagged cuts** — a
+   Fable P0/P1 "delete this" is not optional; don't just note it and move on.
 4. Verify build + Prettier clean; deterministic deploy via `pages.yml` on push to main.

--- a/site/src/components/AuditWidget.tsx
+++ b/site/src/components/AuditWidget.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, ShieldCheck } from "lucide-react";
+import { ShieldCheck } from "lucide-react";
 import { CommandBlock } from "@/components/CommandBlock";
 import { cn } from "@/lib/utils";
 
@@ -28,15 +28,6 @@ export function AuditWidget({ className }: { className?: string }) {
           <span className="text-foreground/70">Nothing is uploaded.</span>
         </span>
       </p>
-
-      {/* Secondary — the desktop Claude Code one-click flow lives at #try. */}
-      <a
-        href="#try"
-        className="mt-5 inline-flex items-center gap-1.5 text-sm font-medium text-foreground/80 underline-offset-4 transition-colors hover:text-foreground hover:underline"
-      >
-        Have Claude Code? Audit a specific repo
-        <ArrowRight className="h-4 w-4" aria-hidden />
-      </a>
     </div>
   );
 }

--- a/site/src/components/sections/Hero.tsx
+++ b/site/src/components/sections/Hero.tsx
@@ -1,5 +1,4 @@
 import { Star } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
 import { AuditWidget } from "@/components/AuditWidget";
 import { HeroReport } from "@/components/HeroReport";
 
@@ -20,22 +19,25 @@ export function Hero() {
           />
           <span className="text-lg font-semibold tracking-tight">vigiles</span>
         </a>
-        <a
-          href={REPO}
-          className="inline-flex items-center gap-2 rounded-full border border-border px-3.5 py-1.5 text-sm font-medium text-muted-foreground no-underline transition-colors hover:border-accent/50 hover:text-foreground"
-        >
-          <Star className="h-3.5 w-3.5" aria-hidden />
-          Star on GitHub
-        </a>
+        <div className="flex items-center gap-5">
+          <a
+            href="#try"
+            className="hidden text-sm font-medium text-muted-foreground no-underline transition-colors hover:text-foreground sm:inline"
+          >
+            Grade a repo
+          </a>
+          <a
+            href={REPO}
+            className="inline-flex items-center gap-2 rounded-full border border-border px-3.5 py-1.5 text-sm font-medium text-muted-foreground no-underline transition-colors hover:border-accent/50 hover:text-foreground"
+          >
+            <Star className="h-3.5 w-3.5" aria-hidden />
+            Star on GitHub
+          </a>
+        </div>
       </nav>
 
       {/* Hero content — headline + ONE primary action, then the real product shot. */}
-      <div className="mx-auto flex w-full max-w-3xl flex-col items-center px-6 pb-10 pt-10 text-center sm:pt-14">
-        <Badge variant="accent" className="mb-6">
-          <Star className="h-3 w-3" aria-hidden />
-          Free &amp; open source
-        </Badge>
-
+      <div className="mx-auto flex w-full max-w-3xl flex-col items-center px-6 pb-10 pt-14 text-center sm:pt-20">
         <h1 className="text-balance text-4xl font-bold leading-[1.05] tracking-tight sm:text-6xl">
           Lighthouse for your
           <br className="hidden sm:block" /> agent harness.


### PR DESCRIPTION
Follow-ups from a DX review of the hero.

- **Cut the "FREE & OPEN SOURCE" badge** — the "Star on GitHub" pill + the CTA link already imply it (Fable flagged this P1; it was missed on the first subtraction pass).
- **Drop the vague "Have Claude Code? Audit a specific repo →" fold link.** It did discoverability badly. Discoverability moves to a persistent, desktop-only **"Grade a repo"** nav link (the repo flow is deeplink-based, so desktop-oriented). The fold now points only at the command.
- **Sharpen `.claude/skills/landing-site`** so these get caught: cut any label another element already implies; every CTA must be actionable/specific (no vague secondary links); and a Fable P0/P1 "delete this" is not optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016EkhbHBV7Vvt6xyduUyMfy)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Fixes**
- cut the redundant OSS badge + weak hero link; sharpen the design skill
<!-- vigiles:pr-summary:end -->
