### PR TITLE
fix(detect): collapse a CLAUDE.md⇄AGENTS.md mirror to one harness

### DIFF
--- a/research/audit-harness-dx.md
+++ b/research/audit-harness-dx.md
@@ -81,9 +81,11 @@ Today we only do the structural question, via file markers, and use it for every
   `ln -s AGENTS.md CLAUDE.md` or an `@AGENTS.md` import to bridge the two. So a
   well-configured repo shows BOTH files while being ONE logical config. A detector must
   collapse a mirror (symlink OR byte-identity OR a sync-tool marker) rather than read
-  "two harnesses." We already have `detectInstructionMirror` (symlink / identical
-  content) — but it is NOT wired into `detectAdapterResult`, and it should also key on
-  sync-tool markers (`.ruler/`, `.rulesync/`, a managed-block comment).
+  "two harnesses." **✅ SHIPPED (2026-07-21):** `detectInstructionMirror` (symlink /
+  byte-identical) is now WIRED into `detectAdapterResult` — a `CLAUDE.md`⇄`AGENTS.md`
+  mirror at the weak tie (top===1, no independent `.codex/config.toml`) collapses to
+  Claude Code, no false "matches both." STILL TODO: also key on sync-tool markers
+  (`.ruler/`, `.rulesync/`, a managed-block comment).
 - **Native format wins over the standard, everywhere.** Cursor (`.cursor/rules/` >
   `AGENTS.md`), Gemini (`GEMINI.md` > `AGENTS.md`), OpenCode (`AGENTS.md` > `CLAUDE.md`).
   The generic standard is always the LOWEST-precedence input — the opposite of "the

--- a/research/roadmap.md
+++ b/research/roadmap.md
@@ -845,9 +845,9 @@ assertRates`) is the recommended path for testing one skill, but
   `--harness=codex` (ships + tested) but isn't the focus. Deferred, thinking preserved in
   `research/audit-harness-dx.md`:
   - **Multi-harness audit DX** — audit ALL detected harnesses (shared-once + per-harness
-    slice), fix the detection (AGENTS.md is an AAIF cross-tool standard, NOT Codex;
-    wire in mirror-collapse for `CLAUDE.md`⇄`AGENTS.md`), read-vs-pick behavior, and a
-    metered-API cost warning. **MED**
+    slice), fix the detection (AGENTS.md is an AAIF cross-tool standard, NOT Codex),
+    read-vs-pick behavior, and a metered-API cost warning. (✅ mirror-collapse for
+    `CLAUDE.md`⇄`AGENTS.md` shipped 2026-07-21 — `detectAdapterResult`; rest deferred.) **MED**
   - **Hosted in-browser audit demo** — deterministic-only rings run in the browser
     (nothing uploaded), with a real progress bar and the model-gated part TEASED
     (blurred/locked → "run locally to unlock"). Needs the shared report components. **MED**

--- a/src/adapter-registry.test.ts
+++ b/src/adapter-registry.test.ts
@@ -160,15 +160,31 @@ test("resolveHarnessSelection: auto-detect a Codex-only repo (AGENTS.md)", () =>
   }
 });
 
-test("resolveHarnessSelection: ambiguous repo (CLAUDE.md + AGENTS.md) warns", () => {
+test("resolveHarnessSelection: ambiguous repo (CLAUDE.md + a DIFFERENT AGENTS.md) warns", () => {
   const dir = makeTmpDir();
   try {
-    writeFileSync(join(dir, "CLAUDE.md"), "# x\n");
-    writeFileSync(join(dir, "AGENTS.md"), "# x\n");
+    // Genuinely different instruction files (not a mirror) → real ambiguity.
+    writeFileSync(join(dir, "CLAUDE.md"), "# claude rules\n");
+    writeFileSync(join(dir, "AGENTS.md"), "# agents rules — different\n");
     const sel = resolveHarnessSelection({ root: dir });
     const notice = noticeOf(sel);
     assert.match(notice, /matches/);
     assert.match(notice, /harness/);
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});
+
+test("resolveHarnessSelection: a CLAUDE.md⇄AGENTS.md MIRROR collapses to Claude Code (no false 'both')", () => {
+  const dir = makeTmpDir();
+  try {
+    // Byte-identical mirror (the Anthropic-sanctioned bridge) — ONE logical config,
+    // not two harnesses; AGENTS.md is a cross-tool standard, not a Codex target.
+    writeFileSync(join(dir, "CLAUDE.md"), "# shared rules\n");
+    writeFileSync(join(dir, "AGENTS.md"), "# shared rules\n");
+    const sel = resolveHarnessSelection({ root: dir });
+    assert.equal(sel.kind, "ok"); // not a "matches both" notice
+    assert.equal(sel.adapter.name, "claude-code");
   } finally {
     cleanupTmpDir(dir);
   }

--- a/src/adapter-registry.ts
+++ b/src/adapter-registry.ts
@@ -11,6 +11,7 @@
  * wins regardless of order.
  */
 import type { HarnessAdapter } from "./core/adapter.js";
+import { detectInstructionMirror } from "./core/compose.js";
 import { claudeCodeAdapter } from "./adapters/claude-code/adapter.js";
 import { codexAdapter } from "./adapters/codex/adapter.js";
 
@@ -41,11 +42,11 @@ export interface DetectResult {
  *
  * SCOPE (2026-07-21): `vigiles audit` is CLAUDE-CODE-FOCUSED for now. This is
  * file-marker detection (a specificity score); it picks ONE harness (or the CC
- * default) and reports `ambiguousWith` when several match. The known-weak parts —
- * `AGENTS.md` is an AAIF cross-tool standard NOT a Codex signal, and a
- * `CLAUDE.md`⇄`AGENTS.md` mirror should collapse to one harness rather than read as
- * "both" — plus auditing ALL detected harnesses (shared-once + per-harness slice)
- * are DEFERRED. Full design + research: `research/audit-harness-dx.md`.
+ * default) and reports `ambiguousWith` when several genuinely match. Mirror-collapse
+ * (below) is done; the rest — treating a LONE `AGENTS.md` (an AAIF cross-tool
+ * standard, not a Codex signal) as harness-agnostic, and auditing ALL detected
+ * harnesses (shared-once + per-harness slice) — is DEFERRED. Full design + research:
+ * `research/audit-harness-dx.md`.
  */
 export function detectAdapterResult(root: string): DetectResult {
   const scored = ADAPTERS.map((a) => ({ a, score: a.detect(root) })).filter(
@@ -55,7 +56,27 @@ export function detectAdapterResult(root: string): DetectResult {
     return { adapter: defaultAdapter, fallback: true, ambiguousWith: [] };
   }
   const top = Math.max(...scored.map((s) => s.score));
-  const winners = scored.filter((s) => s.score === top).map((s) => s.a);
+  let winners = scored.filter((s) => s.score === top).map((s) => s.a);
+
+  // Mirror-collapse: the only false-"both" tie is at the weak instruction-file level
+  // (top === 1 — Claude Code via CLAUDE.md, Codex via AGENTS.md). When those two files
+  // are a MIRROR (symlink or byte-identical, per detectInstructionMirror), that's ONE
+  // logical config, not two harnesses — `AGENTS.md` is a cross-tool standard bridged to
+  // CLAUDE.md, not an independent Codex target (research/audit-harness-dx.md). Drop codex
+  // so it resolves to Claude Code without a spurious "matches claude-code, codex" notice.
+  // A genuine dual instruction file (different content, or a real .codex/config.toml at
+  // score 3) is NOT a mirror at top 1 → stays ambiguous, exactly as it should.
+  if (
+    winners.length > 1 &&
+    top === 1 &&
+    winners.some((w) => w.name === "codex") &&
+    detectInstructionMirror(root) !== null
+  ) {
+    // At top === 1 with a mirror, both files exist so Claude Code (CLAUDE.md) is
+    // always a co-winner — dropping codex leaves a non-empty set.
+    winners = winners.filter((w) => w.name !== "codex");
+  }
+
   return {
     adapter: winners[0],
     fallback: false,


### PR DESCRIPTION
The safe, self-contained slice of the deferred multi-harness detection work.

## What & why
A `CLAUDE.md`⇄`AGENTS.md` mirror (symlink or byte-identical — the Anthropic-sanctioned bridge) is **one** logical config, not two harnesses; `AGENTS.md` is a cross-tool standard, not an independent Codex target. Today a mirror trips a false "repo matches claude-code, codex" notice.

Wire `detectInstructionMirror` into `detectAdapterResult`: at the weak instruction-file tie (`top === 1`, i.e. Claude Code via `CLAUDE.md` + Codex via `AGENTS.md`, with no independent `.codex/config.toml` at score 3) **and** the two files mirror each other → drop codex → resolves cleanly to Claude Code, no spurious notice.

A **genuinely different** dual instruction file is *not* a mirror → stays ambiguous, exactly as it should (the scan-cli `mixed` fixture and the updated adapter-registry ambiguity test both use differing content).

## Tests
- Updated the ambiguity test to use genuinely-different content (real dual-target → still warns).
- Added a mirror test (byte-identical → collapses to `claude-code`, no notice).
- **100% statement/branch/function/line coverage** on `adapter-registry.ts`; 64 affected tests pass.

## Scope
This is only the mirror-collapse piece — the rest of the multi-harness DX (treating a *lone* `AGENTS.md` as harness-agnostic, auditing all detected harnesses, read-vs-pick, metered-API cost warning) stays deferred per `research/audit-harness-dx.md`, updated here to mark mirror-collapse shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016EkhbHBV7Vvt6xyduUyMfy)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Fixes**
- collapse a CLAUDE.md⇄AGENTS.md mirror to one harness (no false "both")
<!-- vigiles:pr-summary:end -->
