### PR TITLE
docs: refresh HANDOFF (site subtraction, audit CC-scope, mirror-collapse, ordered next)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -18,29 +18,39 @@
 **`vigiles.sh` is LIVE** 🎉 — landing at `/`, TypeDoc docs at `/api`, valid TLS. Site auto-deploys
 via `pages.yml` on push to main.
 
-**This session (2026-07-21): landing-site UX overhaul — all merged to `main` (#80–#84), deployed.**
-The site was built around the Claude Code `claude-cli://` deeplink as the PRIMARY CTA, which
-dead-ends silently on mobile / CC Web / desktop-without-CC ("type repo → tap → nothing"). Reworked
-around the action that works for everyone — the command:
+**This session (2026-07-21): landing-site UX overhaul + audit scope decision — merged #80–#90, deployed.**
 
-- **Command-first hero** (`site/src/components/AuditWidget.tsx`, now much simpler): `npx vigiles
-audit` is the single primary action + one-line "runs in any terminal — auto-detects Claude Code
-  or Codex, nothing uploaded" + a quiet "Have Claude Code? Audit a specific repo →" link to `#try`.
-  No repo input / deeplink / CC-first paragraph on the fold; the report shot reaches the fold.
-- **Deeplink demoted to the RepoPicker (`#try`), DESKTOP-ONLY** (`hidden sm:block`). On mobile that
-  section shows an honest "Claude Code runs on a computer — `cd <repo>` and run the command" note
-  instead of a dead button. Button relabeled **"Audit this repo in Claude Code"** (was the
-  mis-framed "Test my skills…" — audit grades the WHOLE harness, not skills).
-- **Mobile hero** = native readable report card (`HeroReportCard` in `Hero.tsx`) since the full PNG
-  is unreadable at 390px. **Rings section = FIVE** (Truthfulness/Triggering/Structure/Safety/Tested,
-  100/92/92/80/88) matching the report PNG. Wedge badge "The wedge"→"The problem".
-- Removed an earlier auto-clipboard-write on the deeplink fallback — it triggered a scary "wants to
-  see your clipboard" permission prompt on mobile. `lib/toast.ts` + `ui/toaster.tsx` = a tiny toast.
-- **CI fix (#81):** the API-surface gate had been RED on main since #79 (Codex-experimental added
-  public API without regenerating snapshots). Ran `npm run api:report`, committed the additive diff.
+SITE (command-first + subtraction, #80–#88): the site led with the CC `claude-cli://` deeplink as the
+PRIMARY CTA → dead-ends on mobile ("type repo → tap → nothing"). Reworked around the universal action
+`npx vigiles audit`. Command-first hero; deeplink DEMOTED to the RepoPicker (`#try`), DESKTOP-ONLY
+(`hidden sm:block`); honest mobile note. Two Fable passes drove ruthless SUBTRACTION:
 
-Deeplink verified via headless Chromium (global playwright at `$(npm root -g)/playwright`, serve
-with `vite preview`, `claude-cli://` never resolves there so the fallback path is exercisable).
+- **PNG DELETED** → `site/src/components/HeroReport.tsx` (native, responsive, DATA-DRIVEN report slice:
+  verdict + category strip + top fix; ONE component serves desktop AND mobile). No more 9px screenshot.
+- Killed say-it-5× redundancy; cut "FREE & OPEN SOURCE" badge (GitHub link implies it) + the weak
+  "Have Claude Code?" fold link → a desktop-only **"Grade a repo"** NAV link. Rings dropped the repeated
+  scores (name+question only, "One score, five categories"). Wedge badge → "The problem". CTA = one
+  primary action ("View on GitHub" demoted to a text link). Removed an auto-clipboard-write that
+  triggered a scary mobile permission prompt (`lib/toast.ts` + `ui/toaster.tsx` = a tiny toast).
+- **Design skill codified**: `.claude/skills/landing-site` (model-invocable) — "design by subtraction",
+  cut-what's-implied, actionable-CTAs, hosted-demo direction (TEASE the locked LLM part + a real
+  progress bar). HOLD every `site/` change against it; screenshot desktop+mobile; run a Fable pass.
+- **CI fix (#81):** the API-surface gate had been RED on main since #79 — ran `npm run api:report`.
+
+AUDIT SCOPE (#89–#90): **`vigiles audit` is CLAUDE-CODE-FOCUSED for now** (founder descope — multi-harness
+DX too complex for this bite). Deferred design + sourced research in `research/audit-harness-dx.md`
+(AGENTS.md is an AAIF cross-tool standard read by 20+ tools, NOT Codex; CLAUDE.md near-exclusive;
+explicit-config-first per Ruler/rulesync). SHIPPED the safe slice: **mirror-collapse** (#90) — a
+`CLAUDE.md`⇄`AGENTS.md` mirror collapses to one harness in `detectAdapterResult` (top===1 + a mirror,
+no independent `.codex/config.toml` → drop codex; no false "matches both"). Genuine different content
+stays ambiguous. Codex deterministic audit still works via `--harness=codex`.
+
+ORDERED NEXT (founder: "all needed, order up to u"): **#1 detection-correctness ✅** (mirror-collapse
+done; lone-AGENTS.md-agnostic + audit-both still deferred). **#2 LOCK THE WEBSITE ← NEXT** — remaining
+polish (simplify RepoPicker on mobile, footer self-link, spacing rhythm) + a final Fable pass. **#3 big
+items** — `apps/` + `packages/report-view` monorepo refactor (npm workspaces; root `vigiles` CI stays
+green; unblocks the demo) → hosted deterministic-only browser demo (tease/blur the LLM part + progress
+bar). Verify UI via headless Chromium (global playwright `$(npm root -g)/playwright` + `vite preview`).
 
 ### Codex behavioral tier is EXPERIMENTAL, not "supported" (SHIPPED this session)
 
@@ -57,12 +67,8 @@ MEASURES the oracle's accuracy vs ground truth (needs `codex` on PATH + quota; n
 
 ### STILL OPEN
 
-- **Hosted public-repo audit (mobile "wow", teed up, NOT built)** — user wants it; the LLM part is
-  the blocker (rate limits/quota). RESOLUTION: do the **deterministic-only** rings (Truthfulness/
-  Structure/Safety-via-lethal-trifecta/description-overlap — NO model), skip the model-gated
-  trigger-rate. Plan: serverless fn fetches a public repo's files via the GitHub API (no clone) →
-  runs the existing `scan`→`AuditReport` JSON → renders the EXISTING `report/` UI. Serverless > pure
-  in-browser (CORS + GH rate limits + needs a browser-safe fs shim). Server-side GH token for limits.
+- **Multi-harness audit DX + hosted demo + monorepo refactor** — the ORDERED-NEXT #2/#3 above;
+  full design + research in `research/audit-harness-dx.md`; scope entry in `roadmap.md` (Later).
 - **Codex trigger-rate promotion** — the live oracle-accuracy run above (blocked on codex + quota).
 - Personal/launch/calendar follow-ups → PRIVATE `zernie/mine` only (branch `claude/adoption-playbook-s49`,
   pushed, needs squash-merge). Do not restate here.


### PR DESCRIPTION
Refresh the volatile `HANDOFF.md` after this session's work (Stop-hook nudge at 5 commits). Updates RESUME-HERE to reflect: the full site subtraction passes (native `HeroReport` replacing the deleted PNG, redundancy/badge/CTA cuts, the `landing-site` design skill), the audit CC-scope decision + `research/audit-harness-dx.md`, the shipped mirror-collapse (#90), and the ordered next steps (#2 lock the website ← next, #3 monorepo refactor → hosted demo). Fixes now-stale bits (the PNG is gone; Rings dropped the repeated scores). ≤120 lines, Prettier-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016EkhbHBV7Vvt6xyduUyMfy)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Docs**
- refresh HANDOFF — site subtraction, audit CC-scope, mirror-collapse, ordered next steps
<!-- vigiles:pr-summary:end -->
