### PR TITLE
fix(site): drop the footer's self-referential vigiles.sh link

### DIFF
--- a/site/src/components/Footer.tsx
+++ b/site/src/components/Footer.tsx
@@ -42,12 +42,6 @@ export function Footer() {
               <BookText className="h-4 w-4" aria-hidden />
               API reference
             </a>
-            <a
-              href="https://vigiles.sh"
-              className="text-muted-foreground no-underline transition-colors hover:text-foreground"
-            >
-              vigiles.sh
-            </a>
           </div>
         </div>
         <div className="mt-10 border-t border-border pt-6 text-xs text-muted-foreground">


### PR DESCRIPTION
Part of locking the website (#2). The footer linked to `vigiles.sh` — but the site *is* vigiles.sh, so the link goes nowhere useful. Removed it, leaving GitHub + API reference (the two links that actually go somewhere). A final Fable pass is running; any further polish it surfaces will follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016EkhbHBV7Vvt6xyduUyMfy)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Fixes**
- drop the footer's self-referential vigiles.sh link
<!-- vigiles:pr-summary:end -->
