### PR TITLE
fix(site): mobile #try command-only, blog new-tab, reveal guard; codify TOP GOAL + capture polish/strategy

### DIFF
--- a/.claude/skills/landing-site/SKILL.md
+++ b/.claude/skills/landing-site/SKILL.md
@@ -16,12 +16,24 @@ caption, a second button, or a reassurance line is suspect until proven necessar
 
 ## Purpose (what the site is for)
 
+- **TOP GOAL — maximize the % of visitors who actually RUN `npx vigiles audit`.**
+  This is the ONE conversion metric every design decision serves. The CTA must be
+  GREAT (frictionless, obvious, always reachable). If a change doesn't help someone
+  run the command, it's not earning its place.
 - **Audience:** developers who already live in agentic-coding tools (Claude Code,
   Codex, Cursor). They are skeptical and skim on a phone.
-- **The one job:** get them to run `npx vigiles audit` (or adopt vigiles). The
-  _wow_ is the **graded report** — show the result, don't explain the mechanism.
+- **The wow** is the **graded report** — show the result, don't explain the mechanism.
 - **Front-door promise:** "Lighthouse for your agent harness" — a one-command,
   zero-config, nothing-uploaded grade of your skills/hooks/subagents/references.
+- **Lower the friction to try:** offer PREFILLED popular OSS repos (e.g. an official
+  Anthropic plugin) as one-click "grade this" chips, so a visitor can see a real
+  report without typing or having a repo of their own. (Idea — not yet built.)
+- **Instrument conversion:** we need analytics on the funnel (command copies, "Grade
+  it"/deeplink clicks, prefilled-repo tries). The site is on GitHub Pages, NOT Vercel
+  — so **Vercel Analytics does NOT apply**. Use a lightweight, privacy-friendly,
+  script-tag analytics that works on static hosting: **Plausible / Fathom / GoatCounter**
+  (or GTM if a tag manager is wanted). Pick one, add the snippet, define the events.
+  (Not yet built — see the roadmap.)
 
 ## UX requirements
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -45,25 +45,39 @@ explicit-config-first per Ruler/rulesync). SHIPPED the safe slice: **mirror-coll
 no independent `.codex/config.toml` → drop codex; no false "matches both"). Genuine different content
 stays ambiguous. Codex deterministic audit still works via `--harness=codex`.
 
-ORDERED NEXT (founder: "all needed, order up to u"): **#1 detection-correctness ✅** (mirror-collapse
-done; lone-AGENTS.md-agnostic + audit-both still deferred). **#2 LOCK THE WEBSITE ← NEXT** — remaining
-polish (simplify RepoPicker on mobile, footer self-link, spacing rhythm) + a final Fable pass. **#3 big
-items** — `apps/` + `packages/report-view` monorepo refactor (npm workspaces; root `vigiles` CI stays
-green; unblocks the demo) → hosted deterministic-only browser demo (tease/blur the LLM part + progress
-bar). Verify UI via headless Chromium (global playwright `$(npm root -g)/playwright` + `vite preview`).
+ORDERED (founder: "all needed, order up to u"): **#1 detection ✅** (mirror-collapse; lone-AGENTS.md-agnostic
+and audit-both deferred). **#2 website locked ✅** (#92/#93, Fable 8.5/8) — BUT a fresh MOBILE-POLISH +
+STRATEGY batch landed after; IN PROGRESS as #94 (below). **#3** = `apps/` + `packages/report-view` monorepo
+refactor (npm workspaces; root `vigiles` CI stays green; unblocks the demo) → hosted deterministic-only
+browser demo (tease/blur the LLM part + progress bar). Verify UI via headless Chromium (global playwright
+`$(npm root -g)/playwright` + `vite preview`).
 
-### Codex behavioral tier is EXPERIMENTAL, not "supported" (SHIPPED this session)
+### 🎯 TOP GOAL + WEBSITE POLISH (post-compact — DO NEXT, before #3)
 
-Deterministic `vigiles audit` on Codex is **full parity** (proven live + `scan-cli.test.ts`) — KEEP it.
-But the real-model **trigger-rate** on Codex is NOT trustworthy: Codex has no skill-fire event, so
-`codexSkillFired` infers firing from whether the model READ `SKILL.md` — cache → false-negative,
-exploration-read → false-positive, so the NUMBER can be wrong either way. A wrong measurement violates
-the precision/don't-cry-wolf brand, so we don't claim Codex trigger-rate. DONE:
-`EvalDriver.experimental` caveat on `codexEvalDriver` (CC stays supported) → copied onto
-`TriggerRateReport`/`BehavioralReport`; `measureTriggerRate` warns on stderr + the formatters print
-`⚠ EXPERIMENTAL` (audit --harness=codex too); documented in `docs/harness-testing-codex.md` +
-`research/harness-capabilities.md`; tests added. REMAINING gate to promote it: a LIVE Codex run that
-MEASURES the oracle's accuracy vs ground truth (needs `codex` on PATH + quota; not installed here).
+**TOP GOAL (now codified in `.claude/skills/landing-site`): maximize the % of visitors who RUN
+`npx vigiles audit`.** Every site decision serves that ONE conversion; the CTA must be GREAT.
+
+- **Analytics — NOT built:** instrument the funnel (command copies, Grade-it/deeplink clicks, prefilled
+  tries). Site is on GitHub Pages, NOT Vercel → **Vercel Analytics N/A**. Use Plausible/Fathom/GoatCounter
+  (or GTM) — a static-hosting script tag; pick one, add the snippet, define events.
+- **Prefilled popular OSS — NOT built:** one-click "grade this" chips (e.g. an official Anthropic plugin)
+  so a visitor sees a real report without typing / owning a repo.
+- **Mobile — #94 IN FLIGHT (partly done, uncommitted at compact):** ✅ mobile `#try` = command-only (was a
+  weird sparse card, "…or" dangled); ✅ blog link new-tab (`Debunk`); ✅ `.reveal` @supports guard
+  (the "empty screenshots" is a scroll-reveal capture artifact, NOT a user bug — Fable concurred). STILL
+  TODO: hero trust-line **shield icon mis-placed** (floats between the 2 wrapped lines → align to top);
+  **CTA buried low / no mobile quick-link** (StickyCTA shows the command on scroll — make the CTA GREAT
+  and reachable); make **other external links (GitHub) open new-tab** too.
+- **Content — TODO:** fold "One score, five categories" (`Rings`) INTO "The problem" (`Wedge`) to be more
+  practical; add **linter icons** to the Wedge "7 linter catalogs" line.
+- Process: hold every change against the skill; screenshot desktop+mobile; Fable pass; deploy = Pages on push.
+
+### Codex trigger-rate is EXPERIMENTAL (shipped earlier)
+
+Deterministic Codex audit = full parity (KEEP). Real-model **trigger-rate** on Codex is NOT trustworthy
+(no skill-fire event → `codexSkillFired` infers from `SKILL.md` reads → wrong either way); marked
+`⚠ EXPERIMENTAL` across the API + formatters + `docs/harness-testing-codex.md`. Promote only after a LIVE
+oracle-accuracy run (needs `codex` + quota).
 
 ### STILL OPEN
 

--- a/site/src/components/sections/Debunk.tsx
+++ b/site/src/components/sections/Debunk.tsx
@@ -45,6 +45,8 @@ export function Debunk() {
             </p>
             <a
               href={ARTICLE}
+              target="_blank"
+              rel="noopener noreferrer"
               className="mt-6 inline-flex items-center gap-2 text-base font-semibold text-accent no-underline transition-colors hover:text-accent/80"
             >
               Read the measurement

--- a/site/src/components/sections/RepoPicker.tsx
+++ b/site/src/components/sections/RepoPicker.tsx
@@ -131,174 +131,176 @@ export function RepoPicker() {
             One click with Claude Code on your desktop — one command anywhere
             else.
           </p>
+
+          {/* Mobile: the repo picker + deeplink are a DESKTOP flow, so phones get
+              the universal command instead of a near-empty card. */}
+          <div className="mt-8 flex flex-col items-center gap-2 sm:hidden">
+            <CommandBlock command="npx vigiles audit" />
+            <p className="text-xs text-muted-foreground">
+              Run it inside any repo on your computer.
+            </p>
+          </div>
         </div>
 
-        <Card className="reveal mt-12 p-6 sm:p-8">
-          {/* GitHub-username search is a desktop convenience; hide it on mobile,
-              where the repo flow dead-ends into "run the command" anyway. Phones
-              keep the manual owner/name field + the command. */}
-          <div className="hidden sm:block">
-            {/* Step 1 — username */}
-            <label
-              htmlFor="gh-username"
-              className="block text-sm font-semibold tracking-tight"
-            >
-              Your GitHub username
-            </label>
-            <div className="mt-2 flex flex-col gap-2.5 sm:flex-row">
-              <div className="relative flex-1">
-                <Github
-                  className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-                  aria-hidden
-                />
-                <input
-                  id="gh-username"
-                  type="text"
-                  autoCapitalize="off"
-                  autoCorrect="off"
-                  spellCheck={false}
-                  placeholder="octocat"
-                  value={username}
-                  onChange={(e) => setUsername(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") {
-                      e.preventDefault();
-                      void loadRepos();
-                    }
-                  }}
-                  className="w-full rounded-xl border border-border bg-background py-3 pl-10 pr-3.5 text-sm text-foreground placeholder:text-muted-foreground/70 transition-colors focus:border-accent/60 focus:outline-none focus:ring-2 focus:ring-accent/30"
-                />
-              </div>
-              <button
-                type="button"
-                onClick={() => void loadRepos()}
-                disabled={!username.trim() || state.kind === "loading"}
-                className="inline-flex h-[46px] items-center justify-center gap-2 whitespace-nowrap rounded-xl bg-accent px-6 text-sm font-semibold text-accent-foreground transition-colors hover:bg-accent/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-card disabled:pointer-events-none disabled:opacity-50"
-              >
-                {state.kind === "loading" ? (
-                  <>
-                    <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
-                    Loading
-                  </>
-                ) : (
-                  <>
-                    Find repos
-                    <ArrowRight className="h-4 w-4" aria-hidden />
-                  </>
-                )}
-              </button>
+        {/* Desktop only — the username search, repo list, and one-click deeplink. */}
+        <Card className="reveal mt-12 hidden p-6 sm:block sm:p-8">
+          {/* Step 1 — username */}
+          <label
+            htmlFor="gh-username"
+            className="block text-sm font-semibold tracking-tight"
+          >
+            Your GitHub username
+          </label>
+          <div className="mt-2 flex flex-col gap-2.5 sm:flex-row">
+            <div className="relative flex-1">
+              <Github
+                className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                aria-hidden
+              />
+              <input
+                id="gh-username"
+                type="text"
+                autoCapitalize="off"
+                autoCorrect="off"
+                spellCheck={false}
+                placeholder="octocat"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    void loadRepos();
+                  }
+                }}
+                className="w-full rounded-xl border border-border bg-background py-3 pl-10 pr-3.5 text-sm text-foreground placeholder:text-muted-foreground/70 transition-colors focus:border-accent/60 focus:outline-none focus:ring-2 focus:ring-accent/30"
+              />
             </div>
-
-            {/* Public-only messaging + repo list */}
-            {state.kind !== "idle" && (
-              <div className="mt-6">
-                <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
-                  <span className="text-sm font-semibold tracking-tight">
-                    Your public repos
-                  </span>
-                  <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
-                    <Lock className="h-3 w-3" aria-hidden />
-                    Public repos only. For a private repo, type owner/name
-                    below.
-                  </span>
-                </div>
-
-                <div className="mt-3">
-                  {state.kind === "loading" && (
-                    <ul className="space-y-2" aria-hidden>
-                      {[0, 1, 2, 3].map((i) => (
-                        <li
-                          key={i}
-                          className="h-11 animate-pulse rounded-lg border border-border bg-muted/30"
-                        />
-                      ))}
-                    </ul>
-                  )}
-
-                  {state.kind === "error" && (
-                    <p className="rounded-lg border border-signal/30 bg-signal/[0.06] px-4 py-3 text-sm text-signal">
-                      {state.message}
-                    </p>
-                  )}
-
-                  {state.kind === "loaded" && repos.length === 0 && (
-                    <p className="rounded-lg border border-border bg-background px-4 py-3 text-sm text-muted-foreground">
-                      No public repos on this account. Enter one manually below.
-                    </p>
-                  )}
-
-                  {state.kind === "loaded" && repos.length > 0 && (
-                    <>
-                      {repos.length > 7 && (
-                        <div className="relative mb-2.5">
-                          <Search
-                            className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-                            aria-hidden
-                          />
-                          <input
-                            type="text"
-                            aria-label="Filter repositories"
-                            placeholder={`Filter ${repos.length} repos…`}
-                            value={filter}
-                            onChange={(e) => setFilter(e.target.value)}
-                            className="w-full rounded-xl border border-border bg-background py-2.5 pl-10 pr-3.5 text-sm text-foreground placeholder:text-muted-foreground/70 transition-colors focus:border-accent/60 focus:outline-none focus:ring-2 focus:ring-accent/30"
-                          />
-                        </div>
-                      )}
-                      <ul className="max-h-72 space-y-1.5 overflow-y-auto pr-1">
-                        {shown.map((r) => {
-                          const active =
-                            selected === r.full_name && !manualSlug;
-                          return (
-                            <li key={r.full_name}>
-                              <button
-                                type="button"
-                                onClick={() => {
-                                  setSelected(r.full_name);
-                                  setManual("");
-                                }}
-                                aria-pressed={active}
-                                className={cn(
-                                  "flex w-full items-center justify-between gap-3 rounded-lg border px-3.5 py-2.5 text-left transition-colors",
-                                  active
-                                    ? "border-accent/60 bg-accent/10"
-                                    : "border-border bg-background hover:border-accent/40 hover:bg-muted/40",
-                                )}
-                              >
-                                <span className="min-w-0 flex-1 truncate font-mono text-sm text-foreground">
-                                  {r.name}
-                                  {r.fork && (
-                                    <span className="ml-2 text-xs text-muted-foreground">
-                                      fork
-                                    </span>
-                                  )}
-                                </span>
-                                <span className="flex shrink-0 items-center gap-3 text-xs text-muted-foreground">
-                                  {r.stargazers_count > 0 && (
-                                    <span className="inline-flex items-center gap-1">
-                                      <Star className="h-3 w-3" aria-hidden />
-                                      {r.stargazers_count}
-                                    </span>
-                                  )}
-                                  <span>{timeAgo(r.updated_at)}</span>
-                                </span>
-                              </button>
-                            </li>
-                          );
-                        })}
-                        {shown.length === 0 && (
-                          <li className="px-3.5 py-2.5 text-sm text-muted-foreground">
-                            No repos match &ldquo;{filter}&rdquo;.
-                          </li>
-                        )}
-                      </ul>
-                    </>
-                  )}
-                </div>
-              </div>
-            )}
+            <button
+              type="button"
+              onClick={() => void loadRepos()}
+              disabled={!username.trim() || state.kind === "loading"}
+              className="inline-flex h-[46px] items-center justify-center gap-2 whitespace-nowrap rounded-xl bg-accent px-6 text-sm font-semibold text-accent-foreground transition-colors hover:bg-accent/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-card disabled:pointer-events-none disabled:opacity-50"
+            >
+              {state.kind === "loading" ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                  Loading
+                </>
+              ) : (
+                <>
+                  Find repos
+                  <ArrowRight className="h-4 w-4" aria-hidden />
+                </>
+              )}
+            </button>
           </div>
 
+          {/* Public-only messaging + repo list */}
+          {state.kind !== "idle" && (
+            <div className="mt-6">
+              <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+                <span className="text-sm font-semibold tracking-tight">
+                  Your public repos
+                </span>
+                <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <Lock className="h-3 w-3" aria-hidden />
+                  Public repos only. For a private repo, type owner/name below.
+                </span>
+              </div>
+
+              <div className="mt-3">
+                {state.kind === "loading" && (
+                  <ul className="space-y-2" aria-hidden>
+                    {[0, 1, 2, 3].map((i) => (
+                      <li
+                        key={i}
+                        className="h-11 animate-pulse rounded-lg border border-border bg-muted/30"
+                      />
+                    ))}
+                  </ul>
+                )}
+
+                {state.kind === "error" && (
+                  <p className="rounded-lg border border-signal/30 bg-signal/[0.06] px-4 py-3 text-sm text-signal">
+                    {state.message}
+                  </p>
+                )}
+
+                {state.kind === "loaded" && repos.length === 0 && (
+                  <p className="rounded-lg border border-border bg-background px-4 py-3 text-sm text-muted-foreground">
+                    No public repos on this account. Enter one manually below.
+                  </p>
+                )}
+
+                {state.kind === "loaded" && repos.length > 0 && (
+                  <>
+                    {repos.length > 7 && (
+                      <div className="relative mb-2.5">
+                        <Search
+                          className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                          aria-hidden
+                        />
+                        <input
+                          type="text"
+                          aria-label="Filter repositories"
+                          placeholder={`Filter ${repos.length} repos…`}
+                          value={filter}
+                          onChange={(e) => setFilter(e.target.value)}
+                          className="w-full rounded-xl border border-border bg-background py-2.5 pl-10 pr-3.5 text-sm text-foreground placeholder:text-muted-foreground/70 transition-colors focus:border-accent/60 focus:outline-none focus:ring-2 focus:ring-accent/30"
+                        />
+                      </div>
+                    )}
+                    <ul className="max-h-72 space-y-1.5 overflow-y-auto pr-1">
+                      {shown.map((r) => {
+                        const active = selected === r.full_name && !manualSlug;
+                        return (
+                          <li key={r.full_name}>
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setSelected(r.full_name);
+                                setManual("");
+                              }}
+                              aria-pressed={active}
+                              className={cn(
+                                "flex w-full items-center justify-between gap-3 rounded-lg border px-3.5 py-2.5 text-left transition-colors",
+                                active
+                                  ? "border-accent/60 bg-accent/10"
+                                  : "border-border bg-background hover:border-accent/40 hover:bg-muted/40",
+                              )}
+                            >
+                              <span className="min-w-0 flex-1 truncate font-mono text-sm text-foreground">
+                                {r.name}
+                                {r.fork && (
+                                  <span className="ml-2 text-xs text-muted-foreground">
+                                    fork
+                                  </span>
+                                )}
+                              </span>
+                              <span className="flex shrink-0 items-center gap-3 text-xs text-muted-foreground">
+                                {r.stargazers_count > 0 && (
+                                  <span className="inline-flex items-center gap-1">
+                                    <Star className="h-3 w-3" aria-hidden />
+                                    {r.stargazers_count}
+                                  </span>
+                                )}
+                                <span>{timeAgo(r.updated_at)}</span>
+                              </span>
+                            </button>
+                          </li>
+                        );
+                      })}
+                      {shown.length === 0 && (
+                        <li className="px-3.5 py-2.5 text-sm text-muted-foreground">
+                          No repos match &ldquo;{filter}&rdquo;.
+                        </li>
+                      )}
+                    </ul>
+                  </>
+                )}
+              </div>
+            </div>
+          )}
           {/* Manual repo field (the private / any-repo path) */}
           <div className="mt-6">
             <label

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -105,10 +105,16 @@
     transform: translateY(0);
   }
 }
-.reveal {
-  animation: fade-in-up 0.6s ease-out both;
-  animation-timeline: view();
-  animation-range: entry 0% cover 22%;
+/* Progressive enhancement: content is visible by DEFAULT. The scroll-reveal only
+   applies where scroll-driven animations are supported, so a non-supporting browser
+   never leaves a section blank (a full-page screenshot in a supporting browser can
+   still capture off-screen sections mid-fade — that's a capture artifact, not a bug). */
+@supports (animation-timeline: view()) {
+  .reveal {
+    animation: fade-in-up 0.6s ease-out both;
+    animation-timeline: view();
+    animation-range: entry 0% cover 22%;
+  }
 }
 @media (prefers-reduced-motion: reduce) {
   .reveal {


### PR DESCRIPTION
Pre-compact batch — mobile fixes + writing down the founder's strategic direction so nothing is lost.

**Site fixes:**
- **RepoPicker mobile:** on a phone the picker + deeplink are a desktop flow, so mobile now gets the universal command (the card was a weird sparse thing with a dangling "…or"). Card is desktop-only.
- **Blog link → new tab** (`Debunk`, `target=_blank rel=noopener`).
- **`.reveal` @supports guard:** content visible by default, scroll-reveal only where `animation-timeline` is supported. (The "empty screenshots" were a scroll-reveal *capture* artifact, not a user bug — confirmed by the mechanism + Fable.)

**Captured (not built) — so it survives the compaction:**
- `.claude/skills/landing-site`: **TOP GOAL = maximize the % of visitors who RUN `npx vigiles audit`; the CTA must be great.** Plus conversion analytics (Plausible/Fathom/GoatCounter/GTM — the site is GitHub Pages, so **Vercel Analytics is N/A**) and prefilled popular-OSS "grade this" chips.
- `HANDOFF.md`: full post-compact TODO — shield-icon align, CTA reachability, GitHub links new-tab, fold Rings into Wedge, linter icons — plus the ordered plan (#3 monorepo refactor → demo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016EkhbHBV7Vvt6xyduUyMfy)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Other**
- fix(site) + docs: mobile #try command-only, blog new-tab, reveal guard; codify TOP GOAL + capture polish/strategy in HANDOFF
<!-- vigiles:pr-summary:end -->
