### PR TITLE
feat(site): in-browser "Grade a repo" demo — render real audit reports on vigiles.sh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10016,6 +10016,7 @@
       "name": "@vigiles/site",
       "version": "0.0.0",
       "dependencies": {
+        "@vigiles/report-view": "*",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.469.0",

--- a/research/report-view-and-browser-demo.md
+++ b/research/report-view-and-browser-demo.md
@@ -143,11 +143,55 @@ vigiles audit`." Dead-end → redirect.
 
 ### Build notes
 
-- Deterministic detectors only, compiled to run in-browser (the scan logic is
-  node-fs-coupled today — porting the pure detectors to a browser-safe entry is
-  the meat of Stage 2).
-- Render from `@vigiles/report-view` (Stage 1 prerequisite — done).
-- Chip results baked/cached at build time.
-- Instrument three events (command copied, chip clicked, repo submitted); funnel =
-  copies ÷ visitors. (Analytics provider still a founder decision — Plausible /
-  Fathom / GoatCounter, NOT Vercel since the site is on GitHub Pages.)
+- Deterministic detectors only. Render from `@vigiles/report-view` (Stage 1 — done).
+- Chip results baked/cached at build time. Instrument three events (command copied,
+  chip clicked, repo submitted); funnel = copies ÷ visitors. (Analytics provider a
+  founder decision — GoatCounter rec / Plausible / Fathom, NOT Vercel on Pages.)
+
+## Stage 2 build plan — the in-browser audit engine (the port)
+
+The key finding from mapping the port: **every deterministic detector reduces to a
+Set-membership / content lookup over a `Record<string,string>` file map** — no
+detector needs anything a fetched-file map can't give (no stat/mtime/symlink/dir
+listing beyond `Object.keys`). And `auditScore`/`buildAuditReport` are 100% pure
+over the `ScanReport` — ZERO changes. So the whole port is ONE new seam plus two
+small library refactors.
+
+**The seam** — `scanFiles(files: Record<string,string>, layout?, dialect?): ScanReport`
+(mirrors `scanPlugin(dir,…)` in `src/scan.ts`). It (a) reconstructs the
+`LoadedPlugin` shape (`{settings.hooks, files, warnings, sources}` — `src/plugin-loader.ts:39`)
+from the in-memory map instead of a disk walk, then (b) runs the SAME pure detectors
+`scanPlugin` runs, then (c) calls `auditScore`/`buildAuditReport` unchanged. Every
+fs call in `scanPlugin` maps to a lookup: `existsSync(p)`→`p in files`,
+`readFileSync(p)`→`files[p]`, "is a directory"→`Object.keys(files).some(k=>k.startsWith(p+"/"))`.
+The three DI-shaped detectors MUST be passed file-map impls (they default to node):
+`skillResourceIssues({existsSync})`, `pluginDirLayoutIssues({existsSync,isDirectory})`,
+`hookBlockIssues({readFileSync})`. `findUntestedSurfaces` (`src/test-coverage.ts`) is
+wholly disk-based → reimplement its globs as in-memory `Object.keys().filter()`.
+`verifyLiveMcpTools` (spawns servers) is NOT called by scanPlugin — exclude.
+
+**Two library refactors so the detector modules import clean in a browser bundle:**
+
+1. `editDistance` extracted from `core/linters.ts` (which runs a `node:fs`/`glob`
+   side effect at IMPORT time) into a zero-dep leaf `core/edit-distance.ts`;
+   tool-contract + hook-events repointed. **DONE (this PR).**
+2. `ncd` (used by `description-overlap`) still imports `node:zlib` (`gzipSync`) +
+   transitively `core/hash.ts`'s `node:crypto`. TODO: extract a leaf `ncd` using
+   `pako.gzip` directly, OR let the Vite demo bundle polyfill zlib/crypto. (One
+   detector — description-overlap — can also be skipped in-browser as a fallback.)
+   Also `core/effects.ts`→`bash-effects.ts` needs `mvdan-sh` CJS interop (fine under
+   Vite); `agent-runtime.ts`/`leaderboard.ts` import `node:fs`/`node:path` for
+   UNUSED exports → Vite alias `node:path`→`path-browserify`, `node:fs`→a no-op stub.
+
+**The three PRs:**
+
+- **PR 1 (this one):** `editDistance` leaf extraction + capture this plan. Groundwork.
+- **PR 2 — VISIBLE:** `scanFiles` (node-side first, reusing detectors as-is) + a node
+  test asserting PARITY with `scanPlugin` over the same files; then `apps/demo`
+  (Vite React workspace consuming `@vigiles/report-view`) with the full Fable UX,
+  rendering REAL `AuditReport`s baked at build time via `scanFiles` over vendored
+  `test/dogfood/*` plugins. This is where the UX care + Fable pass + screenshots go.
+- **PR 3 — LIVE:** bundle `scanFiles` client-side (the ncd/path/fs handling above) +
+  in-browser GitHub fetch (Trees API + `raw.githubusercontent.com`, harness paths
+  only) → live audit of any typed repo. Wire the demo into `site` / vigiles.sh; this
+  also fixes the mobile `#try` dead-end (a live in-browser audit works on a phone).

--- a/site/package.json
+++ b/site/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@vigiles/report-view": "*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.469.0",

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -3,7 +3,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { Hero } from "@/components/sections/Hero";
 import { Wedge } from "@/components/sections/Wedge";
 import { Debunk } from "@/components/sections/Debunk";
-import { RepoPicker } from "@/components/sections/RepoPicker";
+import { DemoAudit } from "@/components/sections/DemoAudit";
 import { CTA } from "@/components/sections/CTA";
 import { Footer } from "@/components/Footer";
 
@@ -15,7 +15,7 @@ export function App() {
         <Hero />
         <Wedge />
         <Debunk />
-        <RepoPicker />
+        <DemoAudit />
         <CTA />
         <Footer />
       </main>

--- a/site/src/components/StickyCTA.tsx
+++ b/site/src/components/StickyCTA.tsx
@@ -24,7 +24,7 @@ export function StickyCTA() {
   return (
     <div
       className={cn(
-        "fixed inset-x-0 top-0 z-50 border-b border-border bg-background/85 backdrop-blur-md transition-all duration-300",
+        "fixed inset-x-0 top-0 z-50 border-b border-border bg-background transition-all duration-300",
         show
           ? "translate-y-0 opacity-100"
           : "pointer-events-none -translate-y-full opacity-0",

--- a/site/src/components/sections/DemoAudit.tsx
+++ b/site/src/components/sections/DemoAudit.tsx
@@ -65,8 +65,10 @@ export function DemoAudit() {
           </p>
         </div>
 
-        {/* Repo chips — switch the rendered report. */}
-        <div className="mt-8 flex flex-wrap items-center justify-center gap-2">
+        {/* Repo chips — switch the rendered report. On mobile they're one
+            horizontally-scrollable row (not 3 wrapped rows pushing the grade
+            down the fold); on desktop they wrap + center. */}
+        <div className="mt-8 flex gap-2 overflow-x-auto pb-1 sm:flex-wrap sm:justify-center sm:overflow-x-visible">
           {FEATURED.map((f, i) => (
             <button
               key={f.slug}
@@ -74,7 +76,7 @@ export function DemoAudit() {
               onClick={() => setActive(i)}
               aria-pressed={i === active}
               className={cn(
-                "rounded-full border px-3.5 py-1.5 font-mono text-sm transition-colors",
+                "shrink-0 rounded-full border px-3.5 py-1.5 font-mono text-sm transition-colors",
                 i === active
                   ? "border-accent/60 bg-accent/10 text-foreground"
                   : "border-border text-muted-foreground hover:border-accent/40 hover:text-foreground",
@@ -85,12 +87,13 @@ export function DemoAudit() {
           ))}
         </div>
 
-        {/* The real report, rendered through @vigiles/report-view. */}
+        {/* The real report, rendered through @vigiles/report-view — full height,
+            NO inner scroll box (that hid the fix card, the whole payoff). */}
         <div className="reveal mt-8 overflow-hidden rounded-2xl border border-border bg-background shadow-2xl">
           <div className="border-b border-border bg-card/40 px-5 py-2.5 font-mono text-xs text-muted-foreground">
             $ vigiles audit {current.slug}
           </div>
-          <div className="max-h-[36rem] overflow-y-auto p-5 sm:p-7">
+          <div className="p-5 sm:p-7">
             <Report data={current.report} />
           </div>
         </div>

--- a/site/src/components/sections/DemoAudit.tsx
+++ b/site/src/components/sections/DemoAudit.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Lock } from "lucide-react";
 import { Report, type AuditReport } from "@vigiles/report-view";
 import { CommandBlock } from "@/components/CommandBlock";
 import { cn } from "@/lib/utils";
@@ -98,8 +99,28 @@ export function DemoAudit() {
           </div>
         </div>
 
+        {/* The honest model-gated tease — ONE row. Everything above is what the
+            browser can compute (deterministic). This names the ONE thing the local
+            run shows that this page can't — with NO fake numbers, bars, or blurred
+            skill names (that would be the dark pattern), just the plain reason. */}
+        <div className="mt-6 flex items-start gap-3 rounded-xl border border-border bg-card/40 px-5 py-4">
+          <Lock
+            className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground"
+            aria-hidden
+          />
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            <span className="font-semibold text-foreground">
+              Whether your skills actually fire
+            </span>{" "}
+            — and your guidance changes what the agent does — needs a real
+            model, and a browser can&apos;t ask one.{" "}
+            <span className="text-foreground">Your CLI can</span>, on your
+            Claude subscription. No API key, no signup, free.
+          </p>
+        </div>
+
         {/* The command — run it on your own repo. */}
-        <div className="mt-10 flex flex-col items-center gap-3 text-center">
+        <div className="mt-8 flex flex-col items-center gap-3 text-center">
           <p className="text-base text-muted-foreground">
             Now grade yours — one command, nothing uploaded:
           </p>

--- a/site/src/components/sections/DemoAudit.tsx
+++ b/site/src/components/sections/DemoAudit.tsx
@@ -1,0 +1,108 @@
+import { useState } from "react";
+import { Report, type AuditReport } from "@vigiles/report-view";
+import { CommandBlock } from "@/components/CommandBlock";
+import { cn } from "@/lib/utils";
+
+// Real audit reports, computed by the actual `vigiles audit` on real published
+// plugins and baked at build time. They render through the SAME @vigiles/report-view
+// component the CLI uses — so this IS the real artifact, not a screenshot or mock.
+// (PR 3 wires live in-browser compute for any repo you type; today these are the
+// featured set.)
+import ohMy from "@/demo/reports/oh-my-claudecode.json";
+import superpowers from "@/demo/reports/superpowers.json";
+import wshobson from "@/demo/reports/wshobson-accessibility.json";
+import madappgang from "@/demo/reports/madappgang-frontend.json";
+
+type Featured = {
+  slug: string;
+  label: string;
+  report: AuditReport;
+};
+
+// madappgang first — it's the one with a real finding + fix (a B "one fix from an
+// A"), the sharpest demonstration. The rest are clean A's (real plugins usually are).
+const FEATURED: Featured[] = [
+  {
+    slug: "madappgang/frontend",
+    label: "madappgang/frontend",
+    report: madappgang as unknown as AuditReport,
+  },
+  {
+    slug: "oh-my-claudecode",
+    label: "oh-my-claudecode",
+    report: ohMy as unknown as AuditReport,
+  },
+  {
+    slug: "obra/superpowers",
+    label: "obra/superpowers",
+    report: superpowers as unknown as AuditReport,
+  },
+  {
+    slug: "wshobson/agents",
+    label: "wshobson/agents",
+    report: wshobson as unknown as AuditReport,
+  },
+];
+
+export function DemoAudit() {
+  const [active, setActive] = useState(0);
+  const current = FEATURED[active];
+
+  return (
+    <section
+      id="try"
+      className="scroll-mt-20 border-t border-border bg-card/30"
+    >
+      <div className="mx-auto w-full max-w-4xl px-6 py-20 sm:py-28">
+        <div className="mx-auto max-w-2xl text-center">
+          <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
+            A real grade, for a real repo.
+          </h2>
+          <p className="mt-4 text-lg leading-relaxed text-muted-foreground">
+            The same report{" "}
+            <span className="font-mono text-foreground">vigiles audit</span>{" "}
+            prints — deterministic, model-free. Pick a published plugin:
+          </p>
+        </div>
+
+        {/* Repo chips — switch the rendered report. */}
+        <div className="mt-8 flex flex-wrap items-center justify-center gap-2">
+          {FEATURED.map((f, i) => (
+            <button
+              key={f.slug}
+              type="button"
+              onClick={() => setActive(i)}
+              aria-pressed={i === active}
+              className={cn(
+                "rounded-full border px-3.5 py-1.5 font-mono text-sm transition-colors",
+                i === active
+                  ? "border-accent/60 bg-accent/10 text-foreground"
+                  : "border-border text-muted-foreground hover:border-accent/40 hover:text-foreground",
+              )}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+
+        {/* The real report, rendered through @vigiles/report-view. */}
+        <div className="reveal mt-8 overflow-hidden rounded-2xl border border-border bg-background shadow-2xl">
+          <div className="border-b border-border bg-card/40 px-5 py-2.5 font-mono text-xs text-muted-foreground">
+            $ vigiles audit {current.slug}
+          </div>
+          <div className="max-h-[36rem] overflow-y-auto p-5 sm:p-7">
+            <Report data={current.report} />
+          </div>
+        </div>
+
+        {/* The command — run it on your own repo. */}
+        <div className="mt-10 flex flex-col items-center gap-3 text-center">
+          <p className="text-base text-muted-foreground">
+            Now grade yours — one command, nothing uploaded:
+          </p>
+          <CommandBlock command="npx vigiles audit" />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/site/src/demo/reports/madappgang-frontend.json
+++ b/site/src/demo/reports/madappgang-frontend.json
@@ -1,0 +1,89 @@
+{
+  "meta": {
+    "schemaVersion": 2,
+    "tool": "vigiles",
+    "kind": "audit",
+    "vigilesVersion": "0.0.0-semantically-released",
+    "harness": "claude-code",
+    "dir": "test/dogfood/madappgang-frontend@6097ad4"
+  },
+  "score": {
+    "overall": 82,
+    "grade": "B",
+    "categories": [
+      {
+        "key": "Truthfulness",
+        "score": 100,
+        "weight": 1,
+        "findings": []
+      },
+      {
+        "key": "Triggering",
+        "score": 100,
+        "weight": 1,
+        "findings": []
+      },
+      {
+        "key": "Structure",
+        "score": 92,
+        "weight": 1,
+        "findings": ["1 agent tool that don't exist (typo / never-available)"]
+      },
+      {
+        "key": "Safety",
+        "score": 90,
+        "weight": 1,
+        "findings": [
+          "1 unit holding all three lethal-trifecta legs (prompt-injection exfil path)"
+        ]
+      },
+      {
+        "key": "Tested",
+        "score": 97,
+        "weight": 1,
+        "advisory": true,
+        "findings": ["1 untested surface"]
+      }
+    ],
+    "empty": false
+  },
+  "verdict": {
+    "sentence": "One one-line fix away from an A.",
+    "grade": "B",
+    "pointsToNextGrade": 8,
+    "fixesToNextGrade": 1,
+    "perRecommendation": [
+      {
+        "index": 0,
+        "pointsIfFixed": 8
+      }
+    ]
+  },
+  "recommendations": [
+    {
+      "surface": "tester",
+      "action": "fix",
+      "rationale": "Tool \"AskUserQuestion\" is never available to a subagent — remove it from the tools list.",
+      "fix": "In \"tester\", remove or correct the tool \"AskUserQuestion\" — it isn't an available tool, so it's silently dropped from the contract.",
+      "detector": "subagent-tool-contract",
+      "confidence": "likely"
+    }
+  ],
+  "inventory": {
+    "skills": 0,
+    "agents": 1,
+    "hooks": 0,
+    "commands": 0,
+    "mcp": false,
+    "untested": 1
+  },
+  "adoptable": {
+    "surfaces": [
+      {
+        "path": "agents/tester.md",
+        "command": "npx vigiles init --target=agents/tester.md"
+      }
+    ],
+    "createAllCommand": "npx vigiles init"
+  }
+}

--- a/site/src/demo/reports/madappgang-frontend.json
+++ b/site/src/demo/reports/madappgang-frontend.json
@@ -27,7 +27,7 @@
         "key": "Structure",
         "score": 92,
         "weight": 1,
-        "findings": ["1 agent tool that don't exist (typo / never-available)"]
+        "findings": ["1 unavailable agent tool (typo / never-available)"]
       },
       {
         "key": "Safety",
@@ -48,7 +48,7 @@
     "empty": false
   },
   "verdict": {
-    "sentence": "One one-line fix away from an A.",
+    "sentence": "One fix away from an A.",
     "grade": "B",
     "pointsToNextGrade": 8,
     "fixesToNextGrade": 1,

--- a/site/src/demo/reports/oh-my-claudecode.json
+++ b/site/src/demo/reports/oh-my-claudecode.json
@@ -1,0 +1,90 @@
+{
+  "meta": {
+    "schemaVersion": 2,
+    "tool": "vigiles",
+    "kind": "audit",
+    "vigilesVersion": "0.0.0-semantically-released",
+    "harness": "claude-code",
+    "dir": "test/dogfood/oh-my-claudecode@deee3a4"
+  },
+  "score": {
+    "overall": 100,
+    "grade": "A",
+    "categories": [
+      {
+        "key": "Truthfulness",
+        "score": 100,
+        "weight": 1,
+        "findings": []
+      },
+      {
+        "key": "Triggering",
+        "score": 100,
+        "weight": 1,
+        "findings": []
+      },
+      {
+        "key": "Structure",
+        "score": 100,
+        "weight": 1,
+        "findings": ["2 agent(s) inherit all tools (no contract) (advisory)"]
+      },
+      {
+        "key": "Safety",
+        "score": 100,
+        "weight": 1,
+        "findings": [
+          "code-reviewer inherits all tools — maximal trifecta blast radius (advisory)",
+          "critic inherits all tools — maximal trifecta blast radius (advisory)",
+          "ask inherits all tools — maximal trifecta blast radius (advisory)",
+          "verify inherits all tools — maximal trifecta blast radius (advisory)"
+        ]
+      },
+      {
+        "key": "Tested",
+        "score": 88,
+        "weight": 1,
+        "advisory": true,
+        "findings": ["4 untested surfaces"]
+      }
+    ],
+    "empty": false
+  },
+  "verdict": {
+    "sentence": "A — nothing blocking; the harness is structurally clean.",
+    "grade": "A",
+    "pointsToNextGrade": null,
+    "fixesToNextGrade": null,
+    "perRecommendation": []
+  },
+  "recommendations": [],
+  "inventory": {
+    "skills": 2,
+    "agents": 2,
+    "hooks": 3,
+    "commands": 0,
+    "mcp": true,
+    "untested": 4
+  },
+  "adoptable": {
+    "surfaces": [
+      {
+        "path": "skills/ask/SKILL.md",
+        "command": "npx vigiles init --target=skills/ask/SKILL.md"
+      },
+      {
+        "path": "skills/verify/SKILL.md",
+        "command": "npx vigiles init --target=skills/verify/SKILL.md"
+      },
+      {
+        "path": "agents/code-reviewer.md",
+        "command": "npx vigiles init --target=agents/code-reviewer.md"
+      },
+      {
+        "path": "agents/critic.md",
+        "command": "npx vigiles init --target=agents/critic.md"
+      }
+    ],
+    "createAllCommand": "npx vigiles init"
+  }
+}

--- a/site/src/demo/reports/superpowers.json
+++ b/site/src/demo/reports/superpowers.json
@@ -1,0 +1,80 @@
+{
+  "meta": {
+    "schemaVersion": 2,
+    "tool": "vigiles",
+    "kind": "audit",
+    "vigilesVersion": "0.0.0-semantically-released",
+    "harness": "claude-code",
+    "dir": "test/dogfood/superpowers@6fd4507"
+  },
+  "score": {
+    "overall": 92,
+    "grade": "A",
+    "categories": [
+      {
+        "key": "Truthfulness",
+        "score": 92,
+        "weight": 1,
+        "findings": ["1 broken intra-plugin reference"]
+      },
+      {
+        "key": "Triggering",
+        "score": 100,
+        "weight": 1,
+        "findings": []
+      },
+      {
+        "key": "Structure",
+        "score": 100,
+        "weight": 1,
+        "findings": []
+      },
+      {
+        "key": "Safety",
+        "score": 100,
+        "weight": 1,
+        "findings": [
+          "systematic-debugging inherits all tools — maximal trifecta blast radius (advisory)",
+          "test-driven-development inherits all tools — maximal trifecta blast radius (advisory)"
+        ]
+      },
+      {
+        "key": "Tested",
+        "score": 94,
+        "weight": 1,
+        "advisory": true,
+        "findings": ["2 untested surfaces"]
+      }
+    ],
+    "empty": false
+  },
+  "verdict": {
+    "sentence": "A — nothing blocking; the harness is structurally clean.",
+    "grade": "A",
+    "pointsToNextGrade": null,
+    "fixesToNextGrade": null,
+    "perRecommendation": []
+  },
+  "recommendations": [],
+  "inventory": {
+    "skills": 2,
+    "agents": 0,
+    "hooks": 1,
+    "commands": 0,
+    "mcp": false,
+    "untested": 2
+  },
+  "adoptable": {
+    "surfaces": [
+      {
+        "path": "skills/systematic-debugging/SKILL.md",
+        "command": "npx vigiles init --target=skills/systematic-debugging/SKILL.md"
+      },
+      {
+        "path": "skills/test-driven-development/SKILL.md",
+        "command": "npx vigiles init --target=skills/test-driven-development/SKILL.md"
+      }
+    ],
+    "createAllCommand": "npx vigiles init"
+  }
+}

--- a/site/src/demo/reports/wshobson-accessibility.json
+++ b/site/src/demo/reports/wshobson-accessibility.json
@@ -1,0 +1,85 @@
+{
+  "meta": {
+    "schemaVersion": 2,
+    "tool": "vigiles",
+    "kind": "audit",
+    "vigilesVersion": "0.0.0-semantically-released",
+    "harness": "claude-code",
+    "dir": "test/dogfood/wshobson-accessibility@cf6059d"
+  },
+  "score": {
+    "overall": 100,
+    "grade": "A",
+    "categories": [
+      {
+        "key": "Truthfulness",
+        "score": 100,
+        "weight": 1,
+        "findings": []
+      },
+      {
+        "key": "Triggering",
+        "score": 100,
+        "weight": 1,
+        "findings": []
+      },
+      {
+        "key": "Structure",
+        "score": 100,
+        "weight": 1,
+        "findings": ["1 agent(s) inherit all tools (no contract) (advisory)"]
+      },
+      {
+        "key": "Safety",
+        "score": 100,
+        "weight": 1,
+        "findings": [
+          "ui-visual-validator inherits all tools — maximal trifecta blast radius (advisory)",
+          "screen-reader-testing inherits all tools — maximal trifecta blast radius (advisory)",
+          "wcag-audit-patterns inherits all tools — maximal trifecta blast radius (advisory)"
+        ]
+      },
+      {
+        "key": "Tested",
+        "score": 91,
+        "weight": 1,
+        "advisory": true,
+        "findings": ["3 untested surfaces"]
+      }
+    ],
+    "empty": false
+  },
+  "verdict": {
+    "sentence": "A — nothing blocking; the harness is structurally clean.",
+    "grade": "A",
+    "pointsToNextGrade": null,
+    "fixesToNextGrade": null,
+    "perRecommendation": []
+  },
+  "recommendations": [],
+  "inventory": {
+    "skills": 2,
+    "agents": 1,
+    "hooks": 0,
+    "commands": 1,
+    "mcp": false,
+    "untested": 3
+  },
+  "adoptable": {
+    "surfaces": [
+      {
+        "path": "skills/screen-reader-testing/SKILL.md",
+        "command": "npx vigiles init --target=skills/screen-reader-testing/SKILL.md"
+      },
+      {
+        "path": "skills/wcag-audit-patterns/SKILL.md",
+        "command": "npx vigiles init --target=skills/wcag-audit-patterns/SKILL.md"
+      },
+      {
+        "path": "agents/ui-visual-validator.md",
+        "command": "npx vigiles init --target=agents/ui-visual-validator.md"
+      }
+    ],
+    "createAllCommand": "npx vigiles init"
+  }
+}

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -1,5 +1,12 @@
 @import "tailwindcss";
 
+/* The demo renders the real audit report from the shared @vigiles/report-view
+   package, so Tailwind must scan its source for the utility classes those
+   components use (Tailwind v4 ignores node_modules). The report inherits THIS
+   site's theme tokens (warm dark), so it reads as one aesthetic — we do NOT
+   import the package's own light/dark theme.css. */
+@source "../../packages/report-view/src";
+
 /*
   Theme echoes zernie.com (the author's dark, warm, typographic developer
   aesthetic): a warm near-black ground + warm off-white ink, a single purple

--- a/src/audit-report.ts
+++ b/src/audit-report.ts
@@ -97,7 +97,7 @@ export interface AuditReport {
   /**
    * The one-line verdict + per-recommendation `pointsIfFixed`, both derived by
    * RE-SCORING (never a hardcoded number). Drives the report's verdict-led header
-   * ("Two one-line fixes away from a B.") and the `+N pts` badges on fix cards.
+   * ("Two fixes away from a B.") and the `+N pts` badges on fix cards.
    * Pure/deterministic — always present.
    */
   readonly verdict: Verdict;

--- a/src/audit-score.ts
+++ b/src/audit-score.ts
@@ -167,7 +167,7 @@ function structure(r: ScanReport): CategoryScore {
     {
       n: deadTools,
       weight: W_DANGLING_REF,
-      label: "agent tool(s) that don't exist (typo / never-available)",
+      label: "unavailable agent tool(s) (typo / never-available)",
     },
     {
       n: deadMcpTools,

--- a/src/audit-verdict.test.ts
+++ b/src/audit-verdict.test.ts
@@ -91,7 +91,7 @@ describe("computeVerdict", () => {
     expect(v.grade).toBe("B");
     expect(v.pointsToNextGrade).toBe(10);
     expect(v.fixesToNextGrade).toBe(1);
-    expect(v.sentence).toBe("One one-line fix away from an A.");
+    expect(v.sentence).toBe("One fix away from an A.");
     expect(v.perRecommendation).toHaveLength(2);
   });
 
@@ -148,7 +148,7 @@ describe("computeVerdict", () => {
     expect(v.grade).toBe("C");
     expect(v.pointsToNextGrade).toBe(9);
     expect(v.fixesToNextGrade).toBe(2);
-    expect(v.sentence).toBe("Two one-line fixes away from a B.");
+    expect(v.sentence).toBe("Two fixes away from a B.");
     // The three tool findings are recs; the invalid model is not.
     expect(v.perRecommendation).toHaveLength(3);
   });

--- a/src/audit-verdict.ts
+++ b/src/audit-verdict.ts
@@ -11,7 +11,7 @@
  *   1. `pointsIfFixed` per recommendation — the exact number of overall points the
  *      grade gains if THAT one fix is applied (so a fix card can show `+N pts` and
  *      sort by it). Computed as `overall(report − thisFinding) − overall(report)`.
- *   2. A verdict `sentence` for the report header — e.g. "Two one-line fixes away
+ *   2. A verdict `sentence` for the report header — e.g. "Two fixes away
  *      from an A." — where the COUNT is the minimal number of fixes whose COMBINED
  *      removal actually crosses the next grade threshold (a real cumulative
  *      re-score), and `pointsToNextGrade` is the real threshold gap.
@@ -337,7 +337,7 @@ function buildSentence(
   const nextGrade = gradeFor(score.overall + pointsToNextGrade);
   // Reachable by the deterministic fix list: fix-count-forward (the actionable framing).
   if (fixesToNextGrade !== null) {
-    return `${capitalize(numberWord(fixesToNextGrade))} one-line ${fixNoun(
+    return `${capitalize(numberWord(fixesToNextGrade))} ${fixNoun(
       fixesToNextGrade,
     )} away from ${article(nextGrade)} ${nextGrade}.`;
   }

--- a/src/core/edit-distance.ts
+++ b/src/core/edit-distance.ts
@@ -1,0 +1,29 @@
+/**
+ * Levenshtein distance for short-string typo detection. Rule names, tool names,
+ * and hook events are short, so edit distance is more appropriate than NCD
+ * (which is tuned for longer texts).
+ *
+ * Extracted to its own zero-dependency leaf module so the typo detectors
+ * (tool-contract, hook-events) can import it WITHOUT pulling in `core/linters.ts`,
+ * which runs a `node:fs`/`process`/`glob` side effect at import time — the
+ * blocker to running those detectors in a browser (the in-browser audit demo).
+ */
+export function editDistance(a: string, b: string): number {
+  if (a === b) return 0;
+  const m = a.length;
+  const n = b.length;
+  if (m === 0) return n;
+  if (n === 0) return m;
+  const dp: number[] = Array.from({ length: n + 1 }, (_, i) => i);
+  for (let i = 1; i <= m; i++) {
+    let prev = dp[0];
+    dp[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const tmp = dp[j];
+      dp[j] =
+        a[i - 1] === b[j - 1] ? prev : 1 + Math.min(prev, dp[j], dp[j - 1]);
+      prev = tmp;
+    }
+  }
+  return dp[n];
+}

--- a/src/core/hook-events.ts
+++ b/src/core/hook-events.ts
@@ -13,7 +13,7 @@
  * `hook-events` lint rule call the same code. Dialect injected (core ⊄ adapter).
  */
 import type { HarnessDialect } from "./dialect.js";
-import { editDistance } from "./linters.js";
+import { editDistance } from "./edit-distance.js";
 
 export interface HookEventIssue {
   readonly event: string;

--- a/src/core/linters.ts
+++ b/src/core/linters.ts
@@ -12,6 +12,7 @@
 
 import { readFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
+import { editDistance } from "./edit-distance.js";
 import { execSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { globSync } from "glob";
@@ -457,30 +458,10 @@ function makeResult(
   return { exists, enabled, linter: ctx.linterName, rule: ctx.ruleName, error };
 }
 
-/**
- * Levenshtein distance for short-string typo detection. Rule names are
- * short so edit distance is more appropriate than NCD (which is tuned
- * for longer texts).
- */
-export function editDistance(a: string, b: string): number {
-  if (a === b) return 0;
-  const m = a.length;
-  const n = b.length;
-  if (m === 0) return n;
-  if (n === 0) return m;
-  const dp: number[] = Array.from({ length: n + 1 }, (_, i) => i);
-  for (let i = 1; i <= m; i++) {
-    let prev = dp[0];
-    dp[0] = i;
-    for (let j = 1; j <= n; j++) {
-      const tmp = dp[j];
-      dp[j] =
-        a[i - 1] === b[j - 1] ? prev : 1 + Math.min(prev, dp[j], dp[j - 1]);
-      prev = tmp;
-    }
-  }
-  return dp[n];
-}
+// editDistance moved to ./edit-distance.ts (a zero-dep leaf) so the browser-safe
+// typo detectors don't transitively import this node-coupled module. Imported at
+// the top for closestRuleNames below; re-exported here for backward compatibility.
+export { editDistance };
 
 /** Top-N closest rule names by edit distance, filtered by a max distance. */
 function closestRuleNames(

--- a/src/core/tool-contract.ts
+++ b/src/core/tool-contract.ts
@@ -18,7 +18,7 @@
  * here — doing so against the agent catalog would be a false-positive factory.
  */
 import type { HarnessDialect } from "./dialect.js";
-import { editDistance } from "./linters.js";
+import { editDistance } from "./edit-distance.js";
 
 export type ToolIssueKind = "never-available" | "unknown";
 

--- a/src/leaderboard.ts
+++ b/src/leaderboard.ts
@@ -135,7 +135,7 @@ export function reportDeductions(r: ScanReport): Deduction[] {
     {
       n: deadTools,
       weight: W_DANGLING_REF,
-      label: "agent tool(s) that don't exist (typo / never-available)",
+      label: "unavailable agent tool(s) (typo / never-available)",
     },
     {
       n: deadMcpTools,


### PR DESCRIPTION
**Stage 2 of the in-browser demo** — the visible one. vigiles.sh now renders **real, live audit reports** on the page.

### What it does
The `#try` section is now a live demo: repo chips switch between **real `AuditReport`s** (computed by the actual `vigiles audit` on published plugins, baked at build time) rendered through the **same `@vigiles/report-view` component the CLI uses** — so it's the real artifact, byte-identical to the CLI, not a screenshot or mock. Defaults to `madappgang/frontend` (a B, "one fix away from an A", with a real finding + fix — the sharpest demo). Works on desktop **and mobile** — which also fixes the old mobile dead-end (`#try` used to collapse to a duplicate command on phones).

### Commits
1. `refactor(core)`: extract `editDistance` to a zero-dep leaf module (browser-port groundwork — removes `core/linters.ts`'s import-time `node:fs` side effect from the typo detectors).
2. `feat(site)`: the live demo — real reports via `@vigiles/report-view`, repo chips, the command CTA.
3. `fix(site,audit)`: acted on a Fable blind review — removed the inner scroll box that hid the fix card on mobile / chopped it on desktop; opaque sticky nav; one-row scroll chips on mobile; **and fixed two real CLI-output grammar bugs** ("1 agent tool that don't exist" → "unavailable agent tool(s)"; verdict "One one-line fix" stutter → "One fix away from an A"). Rejected the fake streaming animation (theater over a real artifact — Fable concurred).
4. `feat(site)`: the honest model-gated tease — one locked row naming the one thing the browser can't do (does your harness actually *fire* / move behavior — needs a real model; your CLI can, free), with **no fake numbers, bars, or blurred skill names**.

### Notes
- `site/` consumes `@vigiles/report-view` (workspace) + `@source`s it; the report inherits the site's warm-dark theme so it reads as one aesthetic.
- Baked reports under `site/src/demo/reports/` (regenerate via `vigiles audit --json`).
- Verified desktop + mobile (390px); audit tests green; fmt clean.
- **Next (PR 3):** bundle the deterministic detectors client-side (the `scanFiles` seam per `research/report-view-and-browser-demo.md`) so a visitor can audit *any* repo they type, live in-browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)