### PR TITLE
fix(site): mobile layout — stack the locked row, wrap code examples

### DIFF
--- a/.claude/skills/landing-site/SKILL.md
+++ b/.claude/skills/landing-site/SKILL.md
@@ -150,11 +150,40 @@ change, not bolted onto a design pass.
 
 ## Process — before shipping any site change
 
+> **GATE-FAILURE → FIX THE GATE FIRST (non-negotiable).** If a bug reaches the user
+> that this skill's review _should_ have caught — a broken mobile layout, a clipped
+> element, an unexplained control — the **skill is the root cause**, not just the
+> component. Before (or in the same change as) fixing the bug, UPDATE THIS SKILL so
+> the gate would catch that whole class next time: add the missing check to the
+> checklist below, name the failure that slipped, and make the check concrete enough
+> that following it mechanically would have caught it. A shipped bug the gate missed
+> is a SKILL bug — fixing only the component and moving on guarantees the next one
+> slips too. (This is why the mobile-layout checklist in step 2 exists: it was written
+> from real misses — a flex row that crushed a heading into one word per line, and a
+> `<pre>` that clipped its example off the right edge on a phone.)
+
 1. **Hold it against this bar.** Ask "what can I remove?" before "what can I add?"
 2. **Screenshot desktop AND mobile (390px) — the FULL page top-to-bottom on EACH,
    every time, and actually look.** Mobile is its own layout, not desktop-minus-width;
-   a change is not verified until you've looked at both. Two things to scan for on the
-   mobile scroll specifically (both have bitten us):
+   a change is not verified until you've looked at both. **Every component you added or
+   changed must be SCROLLED FULLY INTO VIEW and screenshotted at 390px — not just the
+   top of it, not "it's below the fold so I'll trust it."** A component whose mobile
+   render you did not actually see in a screenshot is UNVERIFIED, full stop.
+   **MOBILE-LAYOUT BUG CHECKLIST** — scan every changed component's 390px shot for these
+   (each is a real ship that slipped THIS gate; if you can't rule one out from the
+   screenshot, you haven't looked hard enough):
+   - **Crushed flex column** — a `flex ... justify-between` row (text on one side, a
+     button/badge on the other) that should STACK on a phone but doesn't, squeezing the
+     text into a 1–2-word-per-line column. Fix: `flex-col sm:flex-row` (stack on mobile,
+     row at `sm+`); never leave a `flex-1 min-w-0` text block fighting a `shrink-0`
+     button on a narrow screen.
+   - **Clipped / overflowing code or long text** — a `<pre>`/`<code>`/long inline string
+     cut off at the card's right edge (an `overflow-x-auto` block reads as _clipped_, not
+     scrollable, on a phone). Fix: `whitespace-pre-wrap break-words` so it wraps, or
+     shorten the example. Check EVERY `<pre>` and monospace example at 390px.
+   - **Text touching / bleeding past edges**, and any element that reads as a render bug
+     (ghosting through a sticky bar, a blurred block that looks failed-to-load).
+     Then, two more things to scan for on the mobile scroll (both have also bitten us):
    - **No cross-section duplication.** The same command block / CTA / trust line must
      not appear in two adjacent sections. If a section's mobile fallback just repeats
      what the hero or CTA already shows, that IS the duplication — hide the section on

--- a/packages/report-view/src/Report.tsx
+++ b/packages/report-view/src/Report.tsx
@@ -434,8 +434,10 @@ function LockedRow({ onUnlock }: { onUnlock?: () => void }) {
   };
   return (
     <div className="rounded-xl border border-dashed border-border/70 bg-card/20 p-4">
-      <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-3">
-        <div className="min-w-0 flex-1">
+      {/* Stack on mobile (the button below the text) — side-by-side only at sm+,
+          so a narrow screen never crushes the heading into a 1-word-per-line column. */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+        <div className="min-w-0 sm:flex-1">
           <div className="flex items-center gap-1.5 text-sm font-medium">
             <Lock
               size={13}
@@ -463,12 +465,12 @@ function LockedRow({ onUnlock }: { onUnlock?: () => void }) {
             </span>
           </div>
         </div>
-        <div className="flex shrink-0 flex-col items-end gap-1">
+        <div className="flex flex-col items-start gap-1 sm:shrink-0 sm:items-end">
           <button
             type="button"
             onClick={unlock}
             title={TRIGGER_RATE_PROMPT}
-            className="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-3 py-1.5 text-xs font-semibold transition-colors hover:border-foreground"
+            className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-md border border-border bg-card px-3 py-1.5 text-xs font-semibold transition-colors hover:border-foreground"
           >
             {copied ? (
               <>

--- a/site/src/components/sections/VerbMap.tsx
+++ b/site/src/components/sections/VerbMap.tsx
@@ -99,7 +99,7 @@ export function VerbMap() {
                 <p className="text-sm leading-relaxed text-muted-foreground">
                   {v.detail}
                 </p>
-                <pre className="mt-3 overflow-x-auto rounded-md border border-border bg-card/50 px-3 py-2 font-mono text-xs leading-relaxed text-foreground">
+                <pre className="mt-3 whitespace-pre-wrap break-words rounded-md border border-border bg-card/50 px-3 py-2 font-mono text-xs leading-relaxed text-foreground">
                   {v.example}
                 </pre>
               </div>
@@ -133,7 +133,7 @@ export function VerbMap() {
             </span>{" "}
             Deterministic, no model.
           </p>
-          <pre className="mt-4 overflow-x-auto rounded-md border border-signal/25 bg-signal/[0.06] px-3 py-2.5 font-mono text-xs leading-relaxed text-signal">
+          <pre className="mt-4 whitespace-pre-wrap break-words rounded-md border border-signal/25 bg-signal/[0.06] px-3 py-2.5 font-mono text-xs leading-relaxed text-signal">
             {`"always use ===" → eqeqeq is "off" in your ESLint config
    your CLAUDE.md says enforce it; your config quietly turns it off`}
           </pre>


### PR DESCRIPTION
Two mobile layout bugs (reported on an S23 Ultra) that the review gate should have caught:

- **Locked "Do your skills actually fire?" row** crushed its heading into one word per line — a `flex ... justify-between` row that didn't stack on a phone. Now `flex-col` on mobile, `flex-row` at `sm+` (button drops below the text).
- **VerbMap code examples** (the verb examples + "Your rules → enforced") clipped off the right edge — `overflow-x-auto` reads as *clipped*, not scrollable, on mobile. Now `whitespace-pre-wrap break-words` so they wrap.

**Also fixes the skill that let them ship.** The `landing-site` skill now carries a **GATE-FAILURE → FIX-THE-GATE-FIRST** rule (a shipped bug the review missed is a skill bug — fix the gate before/with the component) plus a concrete mobile-layout checklist (crushed flex column, clipped code block, edge-bleed) written from these exact misses, and a requirement to scroll every changed component fully into view at 390px.

Verified: rv + site tsc, site suite 42/42 (fresh Vite cache), Prettier clean, mobile 390px screenshots of the locked row + code blocks reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016EkhbHBV7Vvt6xyduUyMfy)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Fixes**
- mobile layout — stack the locked row, wrap the code examples
<!-- vigiles:pr-summary:end -->
