### PR TITLE
feat(site): answer "can I grade a private repo?" up front

### DIFF
--- a/.claude/skills/landing-site/SKILL.md
+++ b/.claude/skills/landing-site/SKILL.md
@@ -25,6 +25,37 @@ caption, a second button, or a reassurance line is suspect until proven necessar
 - **The wow** is the **graded report** — show the result, don't explain the mechanism.
 - **Front-door promise:** "Lighthouse for your agent harness" — a one-command,
   zero-config, nothing-uploaded grade of your skills/hooks/subagents/references.
+- **THE DEMO FRAME SERVES FOUR JOBS AT ONCE — design for all four, don't let one
+  crowd out the rest.** (1) INTRO — teach what vigiles is at a glance (the graded
+  report IS the pitch). (2) DEMO — instant real grades with zero effort (the baked
+  `FEATURED` chips). (3) RUN-IN-BROWSER — grade YOUR public repo live by typing it
+  (GitHub anonymous API; public-only). (4) COMMAND-COPY for the rest — a private or
+  local repo can't run in-browser, so the job there is a clean, obvious COPY of
+  `npx vigiles audit` (a command hand-off, NOT a fake in-browser run). Two clarity
+  rules fall out and are load-bearing: **(a) the frame must always make clear WHICH
+  repo is shown and whether it's a PREDEFINED EXAMPLE (a chip) or YOUR OWN (typed) —
+  never ambiguous; (b) the private-repo path is a first-class affordance, not an
+  afterthought jammed into a sentence — a clean labelled command-copy, verified at
+  390px.** Don't restate the command in three stacked lines (the header showing
+  `$ vigiles audit <slug>` on top of a highlighted chip that already names it is TMI
+  — the header's job is to IDENTIFY the graded repo + its source, not re-print the
+  command).
+- **COPY: concrete over clever, and NEVER plant a doubt the reader didn't arrive
+  with.** Two real misses this stops: (1) a clever headline that reads as cryptic
+  ("'Valid' is not 'true.'") — lead with the concrete pain ("Valid config. Broken
+  agent."), let the cards below carry the nuance; (2) a DEFENSIVE FAQ that spotlights
+  a weakness the reader hadn't noticed ("Is it stable enough to adopt?" draws the eye
+  to a scary version number) — replace doubt-planters with confidence-builders a
+  skeptic actually asks ("Does anything leave my machine?", "Can I grade a private
+  repo?"). Test each line as a cold skeptic: does it make me MORE or LESS likely to
+  run the command? If less, cut or reframe.
+- **CREDIBILITY: the demo report shows ONLY REAL scans — never fabricate a result.**
+  The brand is "measured, not claimed", so one hardcoded/fake number in the report
+  retroactively poisons trust in every real finding. A LOCKED tease with HONEST
+  PLACEHOLDERS (em-dash "run to fill", no digits) for a genuinely-can't-run-here thing
+  (model-gated trigger-rate) is fine — it fakes NOTHING. Fabricated "results" for a
+  thing the tool actually computes is NOT — show the REAL computed result or keep it
+  an honest explanatory card OUTSIDE the report frame.
 - **Lower the friction to try:** offer PREFILLED popular OSS repos as one-click
   "grade this" chips, so a visitor sees a real report without typing or having a repo
   of their own. **SHIPPED** — the `FEATURED` chips in `DemoAudit` render baked real

--- a/site/src/components/sections/DemoAudit.browser.test.tsx
+++ b/site/src/components/sections/DemoAudit.browser.test.tsx
@@ -106,9 +106,12 @@ describe("DemoAudit — chips stay instant", () => {
     const user = userEvent.setup();
     render(<DemoAudit />);
     // The chip's accessible name now includes its grade badge ("… A").
-    await user.click(screen.getByRole("button", { name: /oh-my-claudecode/ }));
-    // Baked report frame header updates instantly; fetch never called.
-    await screen.findByText(/vigiles audit oh-my-claudecode/);
+    const chip = screen.getByRole("button", { name: /oh-my-claudecode/ });
+    await user.click(chip);
+    // Baked report renders instantly: the chip is selected, the frame header
+    // marks it an "example" (source tag), and fetch is never called.
+    await waitFor(() => expect(chip.getAttribute("aria-pressed")).toBe("true"));
+    await screen.findByText("example");
     expect(mockFetch).not.toHaveBeenCalled();
     expect(screen.queryByText(/fetching repo tree/)).toBeNull();
   });
@@ -153,8 +156,9 @@ describe("DemoAudit — the in-frame edge states", () => {
       render(<DemoAudit />);
       await typeRepo("acme/widgets");
       await screen.findByText(c.expect);
-      // Same frame — the header still names the repo.
-      expect(screen.getByText(/vigiles audit acme\/widgets/)).toBeTruthy();
+      // Same frame — the repo is still named (the header slug, and usually the
+      // edge-state body too).
+      expect(screen.getAllByText(/acme\/widgets/).length).toBeGreaterThan(0);
     });
   }
 });

--- a/site/src/components/sections/DemoAudit.tsx
+++ b/site/src/components/sections/DemoAudit.tsx
@@ -497,6 +497,14 @@ export function DemoAudit({
 
       <RepoCombobox onSubmit={run} />
 
+      {/* Proactive private-repo answer — the browser demo is public-only (GitHub
+          anonymous API), so tell a private-repo visitor the CLI path HERE, at the
+          moment of intent, instead of only after they type a repo and hit a 404. */}
+      <p className="mt-3 text-center text-xs leading-relaxed text-muted-foreground">
+        Private repo? Run <InlineCommand /> in it locally — it reads your
+        working copy off disk, nothing leaves your machine.
+      </p>
+
       {/* Featured chips as a lightweight LEADERBOARD — real popular plugins with
             their real grades. Reframes the one-tap examples as "here's how the
             ecosystem scores; where does yours land?" (social proof + the ranking

--- a/site/src/components/sections/DemoAudit.tsx
+++ b/site/src/components/sections/DemoAudit.tsx
@@ -5,7 +5,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { Check, Copy, RotateCw, Link2, Star } from "lucide-react";
+import { Check, Copy, RotateCw, Link2, Star, Lock } from "lucide-react";
 import { Report, type AuditReport } from "@vigiles/report-view";
 import { normalizeSlug } from "@/lib/deeplink";
 import { fetchStars, formatStars } from "@/demo/searchRepos";
@@ -498,11 +498,18 @@ export function DemoAudit({
       <RepoCombobox onSubmit={run} />
 
       {/* Proactive private-repo answer — the browser demo is public-only (GitHub
-          anonymous API), so tell a private-repo visitor the CLI path HERE, at the
-          moment of intent, instead of only after they type a repo and hit a 404. */}
-      <p className="mt-3 text-center text-xs leading-relaxed text-muted-foreground">
-        Private repo? Run <InlineCommand /> in it locally — it reads your
-        working copy off disk, nothing leaves your machine.
+          anonymous API). A private/local repo can't run in-browser, so the job here
+          is a clean COMMAND HAND-OFF: a labelled command-copy, not a button jammed
+          mid-sentence. Label + pill stack on mobile; the privacy note is a sub-line. */}
+      <div className="mt-4 flex flex-col items-center justify-center gap-2 sm:flex-row">
+        <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+          <Lock className="h-3 w-3" aria-hidden />
+          Private or local repo? Grade it in your terminal:
+        </span>
+        <InlineCommand />
+      </div>
+      <p className="mt-1.5 text-center text-[11px] text-muted-foreground/70">
+        Reads your working copy off disk — nothing leaves your machine.
       </p>
 
       {/* Featured chips as a lightweight LEADERBOARD — real popular plugins with
@@ -557,9 +564,23 @@ export function DemoAudit({
       {/* The report frame — one component, every state renders inside it (no
             toast, no layout jump). */}
       <div className="reveal mt-8 overflow-hidden rounded-2xl border border-border bg-background shadow-2xl">
-        <div className="flex items-center justify-between gap-3 border-b border-border bg-card/40 px-5 py-2.5 font-mono text-xs text-muted-foreground">
-          <span className="truncate">
-            $ vigiles audit {headerSlug(frameView)}
+        <div className="flex items-center justify-between gap-3 border-b border-border bg-card/40 px-5 py-2.5 text-xs text-muted-foreground">
+          {/* Identify the graded repo + its SOURCE (example chip vs your typed repo)
+              — not the redundant `$ vigiles audit <slug>` command, which just repeats
+              the highlighted chip / the input above. */}
+          <span className="flex min-w-0 items-center gap-2">
+            <span className="truncate font-mono text-foreground">
+              {headerSlug(frameView)}
+            </span>
+            {frameView.k === "featured" ? (
+              <span className="shrink-0 rounded bg-muted/60 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide">
+                example
+              </span>
+            ) : frameView.k === "report" ? (
+              <span className="shrink-0 rounded bg-accent/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-accent">
+                your repo
+              </span>
+            ) : null}
           </span>
           {cachedAtOf(frameView) !== undefined && (
             <CachedBadge

--- a/site/src/components/sections/FAQ.tsx
+++ b/site/src/components/sections/FAQ.tsx
@@ -30,13 +30,16 @@ const QA: { q: string; a: ReactNode }[] = [
     ),
   },
   {
-    q: "Does anything leave my machine?",
+    q: "Can I grade a private repo?",
     a: (
       <>
-        No. <span className="font-mono">audit</span> and{" "}
-        <span className="font-mono">lint</span> read your local repo — no
-        upload, no account, no server. The demo above only calls GitHub&apos;s
-        public API to read a public repo you name.
+        Yes — run <span className="font-mono">npx vigiles audit</span> in it
+        locally. It reads your working copy off disk, so private repos work with{" "}
+        <span className="text-foreground">
+          no upload, no account, no server
+        </span>{" "}
+        — nothing leaves your machine. Only the browser demo above is
+        public-only (it calls GitHub&apos;s API to read a repo you name).
       </>
     ),
   },


### PR DESCRIPTION
The browser demo is public-only (GitHub anonymous API). A private-repo visitor only learned the CLI path *reactively* — after typing a repo and hitting a 404. Now it's answered proactively:

- **At the input:** a line right under the combobox — "Private repo? Run `npx vigiles audit` in it locally — it reads your working copy off disk, nothing leaves your machine." (with the inline copy affordance).
- **FAQ:** a dedicated "Can I grade a private repo?" entry (replaces the implicit privacy Q, which it also answers).

Verified desktop + mobile 390px per the skill's mobile-layout checklist (the inline command wraps cleanly, no crush/clip). Site suite 42/42, Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Features**
- answer "can I grade a private repo?" up front

**Fixes**
- cleaner private-repo hand-off + source-tagged frame header
<!-- vigiles:pr-summary:end -->

