### PR TITLE
fix(site): verb-map alignment + gate the site e2e (incl. mobile overflow) in CI

### DIFF
--- a/.claude/skills/landing-site/SKILL.md
+++ b/.claude/skills/landing-site/SKILL.md
@@ -214,6 +214,18 @@ change, not bolted onto a design pass.
      shorten the example. Check EVERY `<pre>` and monospace example at 390px.
    - **Text touching / bleeding past edges**, and any element that reads as a render bug
      (ghosting through a sticky bar, a blurred block that looks failed-to-load).
+   - **Responsive-grid cell collision (check BOTH breakpoints, not just 390px).** A CSS
+     grid whose column count changes across `sm:` (e.g. `grid-cols-[1fr_auto]` →
+     `sm:grid-cols-[10.5rem_1fr_auto]`) will SILENTLY BUMP an auto-placed child to the
+     next ROW if another child is pinned to the same `col-start`/`row-start` cell — so a
+     label meant to sit inline after its command lands on a second line, indented to the
+     middle, reading as "why is this centered?". This shipped in the VerbMap: the model
+     note kept `col-start-2 row-start-1` from the 2-col mobile layout but never got a
+     `sm:col-start-3`, so at desktop it collided with the answer and pushed it to row 2.
+     Fix: give EVERY explicitly-placed grid child its `sm:col-start` for the wider grid,
+     and verify alignment on the DESKTOP shot too (this class hides at 390px — the mobile
+     grid is fine; it's the `sm:` layout that breaks). When you change a grid's template
+     across a breakpoint, re-check that every child's placement is set for BOTH.
      Then, two more things to scan for on the mobile scroll (both have also bitten us):
    - **No cross-section duplication.** The same command block / CTA / trust line must
      not appear in two adjacent sections. If a section's mobile fallback just repeats

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,9 @@ jobs:
   # real gate: parity (pako === node:zlib on real Chromium), the DemoAudit
   # interaction states, and the idb-keyval grade-cache (real IndexedDB). No API key,
   # deterministic. This closes the gap where demo/engine-parity regressions were
-  # only caught locally. `test:e2e` (Playwright) stays manual/browser-gated.
+  # only caught locally. The Playwright e2e (`test:e2e`) runs here too — it serves
+  # the REAL built bundle and drives it, incl. the 390px mobile-overflow gate that
+  # catches layout bleed a component-level test can't (no viewport in @vitest/browser).
   site:
     runs-on: ubuntu-latest
     steps:
@@ -254,6 +256,13 @@ jobs:
 
       - name: Run site browser tests (parity + interaction + grade-cache)
         run: npm run test:browser
+        working-directory: site
+
+      # Playwright e2e over the real built bundle (serves dist/, network mocked
+      # per-test) — the in-frame report/empty states AND the 390px mobile-overflow
+      # gate. Chromium is already installed above; the webServer builds engine+site.
+      - name: Run site e2e (Playwright — incl. mobile-overflow gate)
+        run: npm run test:e2e
         working-directory: site
 
   # Dogfood the per-level CI action for the e2e tier (allowlisted REAL egress).

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Every one of these is **valid markdown** — parses fine, does the wrong thing. 
 | `test`  | Does the harness behave?       | No — a scripted stand-in | Every commit             |
 | `eval`  | Does a skill actually help?    | Yes — your subscription  | On demand                |
 
-**One engine, two doors.** `audit` is the local report; **`lint` is the CI gate** that fails the build on the same deterministic checks — broken refs, bad tool contracts, dead hooks, skill collisions (Proofs 1–2). `test` and `eval` go further: past _does it exist_ to _does it work_. (`init` / `compile` / `eject` manage the optional typed-spec layer for the structural rules no linter can express — a graduation step you rarely run by hand.)
+**One engine, two doors.** `audit` is the local report; **`lint` is the CI gate** that fails the build on the same deterministic checks — broken refs, bad tool contracts, dead hooks, skill collisions (Proofs 1–2). `test` and `eval` go further: past _does it exist_ to _does it work_. (`init` / `compile` / `eject` manage the optional typed-spec layer for the structural rules no linter can express — a graduation step you rarely run by hand.) [How the verbs relate →](docs/commands-and-how-they-relate.md)
 
 ### 🔎 Lint — your instructions stop lying
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ The docs are grouped by what you're trying to do:
 ## Reference — "the exact flag, symbol, or rule"
 
 - [`cli.md`](cli.md) — the full CLI: every verb and flag, the Claude Code plugin, `lint` vs `audit`.
+- [`commands-and-how-they-relate.md`](commands-and-how-they-relate.md) — the mental model: how `audit` / `lint` / `test` / `eval` / `init` fit together, and why measuring "do my skills fire?" uses `init`, not `audit`.
 - [`testing-api.md`](testing-api.md) — the full harness-testing API: every predicate, assertion, `check`, matcher, and option (`measureTriggerRate` / `runEval` / significance).
 - [`spec-format.md`](spec-format.md) — the typed `.spec.ts` format (target, sections, rules, verified references) — the source of truth.
 - [`linter-support.md`](linter-support.md) — the 7 linter catalogs + `generate-types` / `generate-schema`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -653,6 +653,10 @@ bodies so no procedure runs. (The safety battery — which executes arbitrary ho
 and so needs cross-platform confinement that isn't shipped — is not here; it's a
 `vigiles/testing` capability you invoke explicitly.)
 
+For how all five verbs (`audit` / `lint` / `test` / `eval` / `init`) fit together —
+and why measuring "do my skills fire?" from an agent uses `init`, not `audit` — see
+[Commands & how they relate](commands-and-how-they-relate.md).
+
 ## GitHub Action
 
 Run vigiles in CI via a composite action over the published `npx vigiles` CLI.

--- a/docs/commands-and-how-they-relate.md
+++ b/docs/commands-and-how-they-relate.md
@@ -1,0 +1,66 @@
+# Commands & how they relate
+
+The README has the pitch; this is the map of vigiles's commands — what each one is
+for, and how they fit together. If you've ever wondered _"why does measuring my
+skills use `init`, not `audit`?"_, this is the doc.
+
+## The one-line model
+
+> **`audit` = check now · `lint` = gate in CI · `test` / `eval` = prove it
+> repeatably · `init` = the bridge that sets the rest up.**
+
+| Command     | What it is                                                                                   | Needs a model?                                                                                             | When you run it               |
+| ----------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| **`audit`** | Read & grade your harness, zero-config. "Where am I?" A local report, like Lighthouse.       | No for the report; the two executing checks (live MCP, skill-firing) run **only with your interactive OK** | Anytime — it's the front door |
+| **`lint`**  | The **CI gate** — the same deterministic checks, but they **fail the build**.                | No                                                                                                         | Every push (CI)               |
+| **`test`**  | Run your real hooks/skills against a **scripted stand-in** model — does the harness behave?  | No                                                                                                         | Every commit                  |
+| **`eval`**  | Drive a **real model** — does a skill actually fire / help? `measureTriggerRate` lives here. | Yes — on **your** subscription                                                                             | On demand / release gate      |
+| **`init`**  | **Graduate**: scaffold specs, install the plugin (skills + hooks), wire CI.                  | No                                                                                                         | Once, to set up               |
+
+`audit` and `lint` share one engine — `audit` is the local report, `lint` is the
+CI gate on the same findings. `test` and `eval` are the two testing tiers (cheap
+deterministic → real-model).
+
+## Why measuring "do my skills fire?" uses `init`, not `audit`
+
+This is the one that trips people up. Both `audit` and `eval` can answer _"do my
+skills actually fire?"_ — but at different commitment levels, and with a hard rule
+about **who's allowed to spend model quota**:
+
+- **You, at a terminal:** `npx vigiles audit` will **offer** to measure it right
+  there (it spends model quota, so it asks once and remembers your answer). No
+  `init` needed — just say yes.
+- **An agent** (pasting a prompt into Claude Code), **CI, or `--json`:** `audit`
+  deliberately **stays a read-only report** — it never spends quota without a human
+  to consent, so it won't run the measurement. To measure it from an agent, you use
+  the explicit test tier — `measureTriggerRate`, which the **`test-harness` skill**
+  wraps. That skill is installed by **`init`**.
+
+So a prompt that says _"run `npx vigiles init`, then use the test-harness skill to
+measure trigger-rate"_ isn't confused — it's the **agent-runnable** path, because an
+agent can't trigger `audit`'s interactive measurement. `init` there is just the
+**setup step** (install the skill), not the measurement.
+
+The same recall/precision numbers, two ways in:
+
+- **`audit` (interactive):** one-shot curiosity check — _"what's my score, including
+  whether skills fire?"_
+- **`eval` / `test-harness` (repeatable):** author it once, re-run it, gate CI — the
+  version an agent or a pipeline can drive. `init` installs it.
+
+## `audit` vs `lint` — one engine, two doors
+
+- **`audit`** is the **local report** (safe to run anywhere; a deterministic read).
+  It is **not** a CI step.
+- **`lint`** is the **CI gate** — it fails the build on the same deterministic checks
+  (broken references, tool contracts, dead hooks, skill collisions).
+
+Use `audit` to see where you are; wire `lint` into CI to keep it from regressing.
+
+## See also
+
+- [CLI reference](cli.md) — every verb and flag.
+- [The validation rules](verifying-instruction-files.md#the-validation-rules--the-full-matrix) — what `lint` / `audit` check.
+- [Harness testing](harness-testing.md) — the `test` / `eval` tiers in depth.
+- [Measuring skills](measuring-skills.md) — `measureTriggerRate`, recall + precision.
+- [Agent setup](agent-setup.md) — what `init` does, per agent.

--- a/packages/report-view/src/Report.tsx
+++ b/packages/report-view/src/Report.tsx
@@ -39,10 +39,12 @@ export const AUDIT_PROMPT =
  *  trigger-rate measurement (measureTriggerRate, via the test-harness skill) on the
  *  user's own Claude subscription. */
 export const TRIGGER_RATE_PROMPT =
-  "Set up vigiles and measure whether my skills actually fire: run " +
-  "`npx vigiles init`, then use the test-harness skill to run measureTriggerRate. " +
-  "Report each skill's recall (does it fire when it should?) and precision (does " +
-  "it stay quiet on unrelated prompts?). It runs on my Claude subscription — no API key.";
+  "Measure whether my skills actually fire (recall + precision). This is the " +
+  "test/eval tier, not the read-only audit — so if vigiles isn't set up in this " +
+  "repo yet, run `npx vigiles init` first (that installs the test-harness skill), " +
+  "then use that skill to run measureTriggerRate. Report each skill's recall (does " +
+  "it fire when it should?) and precision (does it stay quiet on unrelated " +
+  "prompts?). It runs on my Claude subscription — no API key.";
 
 /** The audit checks that have a dedicated explainer page at vigiles.sh/checks/<slug>/.
  *  Mirrors the slugs in site/src/checks/checks.ts — a finding whose detector is here

--- a/research/roadmap.md
+++ b/research/roadmap.md
@@ -851,6 +851,31 @@ assertRates`) is the recommended path for testing one skill, but
   - **Hosted in-browser audit demo** — deterministic-only rings run in the browser
     (nothing uploaded), with a real progress bar and the model-gated part TEASED
     (blurred/locked → "run locally to unlock"). Needs the shared report components. **MED**
+  - **Backend audit service (WITH rate-limited LLM access) — the path to the FULL
+    audit in the demo (2026-07-22, from founder feedback).** The in-browser demo is
+    STRUCTURALLY a subset on BOTH axes: (1) DETERMINISTIC depth it can't reach —
+    linter-rule cross-referencing (`enforce()` needs the 7 catalogs + the repo's
+    config), symbol resolution (ast-grep), live MCP resolution, references INSIDE
+    markdown prose; (2) the MODEL-GATED behavioral tier — trigger-rate ("do your
+    skills actually fire?" recall/precision), the currently locked/teased column.
+    Client-side fixes DON'T work: prose-ref parsing is SEMANTIC/undecidable (a
+    code-span may be an example, not a ref — exactly why vigiles needs MARKS/a spec,
+    see `reference-verification-limits.md`); catalogs/config/ast-grep aren't feasible
+    in a browser; and the model-gated tier obviously needs a model. So the long-term
+    fix is a BACKEND with RATE-LIMITED LLM ACCESS that runs the real `vigiles audit`
+    server-side — the full deterministic depth AND the behavioral tier — and returns
+    the complete report, so the demo shows REAL trigger-rate numbers (UNLOCKING the
+    tease) instead of "run locally to see." Design constraints: PUBLIC-repo only
+    (private stays CLI-local, preserving "nothing leaves your machine" for the CLI
+    path); the demo's LLM is VIGILES-FUNDED (a marketing cost — distinct from the
+    CLI's "your own subscription, no metered API" story, which stays the pitch for
+    real use), so RATE-LIMIT per session/IP + cache aggressively to cap spend; the
+    trigger-rate run must stub skill BODIES (firing is a frontmatter property) to keep
+    each measurement cheap. HONEST CAVEAT even with the backend: UNMARKED prose
+    references stay undecidable — the backend adds linter/symbol/MCP/spec-compile +
+    the behavioral tier, NOT "verify any sentence." Interim (done 2026-07-22): scope
+    the site text so the browser grade doesn't imply the full linter cross-reference.
+    **LARGE** (infra + cost + abuse controls).
   - **Shared-component monorepo refactor** — `apps/` + `packages/report-view` (npm
     workspaces) so the report UI is genuinely shared by `report/`, the site hero, and the
     demo (no screenshots, no hacks). Root `vigiles` package + CI stay green. **MED**

--- a/site/e2e/demo.spec.ts
+++ b/site/e2e/demo.spec.ts
@@ -61,16 +61,14 @@ test("types a repo → the real graded report renders in-frame", async ({
   await mockRepo(page, sampleFiles);
   await gradeRepo(page);
 
-  // The frame header names their repo; the real <Report> renders its grade badge.
-  await expect(
-    page.getByText("$ vigiles audit acme/widgets", { exact: true }),
-  ).toBeVisible();
+  // The frame header names their repo + tags it "your repo" (a typed report, not
+  // an example chip); the real <Report> renders its grade badge.
+  await expect(page.getByText("your repo", { exact: true })).toBeVisible();
+  await expect(page.getByText("acme/widgets").first()).toBeVisible();
   // The real <Report> rendered its grade badge (the sample map grades D).
   await expect(page.getByText("D", { exact: true }).first()).toBeVisible();
   // The model-gated lock row is present for a real report.
-  await expect(
-    page.getByText(/Whether your skills actually fire/i),
-  ).toBeVisible();
+  await expect(page.getByText(/Do your skills actually fire/i)).toBeVisible();
 });
 
 test("a repo with no harness shows the in-frame empty state, not an error", async ({
@@ -81,7 +79,8 @@ test("a repo with no harness shows the in-frame empty state, not an error", asyn
   await gradeRepo(page);
 
   await expect(page.getByText(/No Claude Code harness in/i)).toBeVisible();
-  await expect(
-    page.getByText("$ vigiles audit acme/widgets", { exact: true }),
-  ).toBeVisible();
+  // The in-frame empty state hands off to the CLI via an inline copy pill — the
+  // command is `npx vigiles audit` (repo-agnostic), not a `$ vigiles audit <slug>`
+  // echo. There's also the always-present private-repo hand-off pill, so match ≥1.
+  await expect(page.getByText("npx vigiles audit").first()).toBeVisible();
 });

--- a/site/e2e/mobile.spec.ts
+++ b/site/e2e/mobile.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * Mobile-overflow gate — the deterministic backstop for the layout bugs that
+ * shipped to a real phone (a crushed locked row, a clipped `<pre>`, edge-bleed).
+ * @vitest/browser has no per-test viewport, so a REAL 390px viewport (a proxy for
+ * the S23 Ultra / any narrow phone) lives HERE, in Playwright. The invariant is
+ * blunt and un-game-able: after exercising the interactive surfaces (expand every
+ * verb, tap a graded chip), the PAGE must never scroll horizontally, and no visible
+ * `<pre>` may overflow its own box. If a component bleeds past the viewport, this
+ * fails — which is exactly the class of bug that reached the founder's phone.
+ */
+
+// A narrow phone. 390px is the common logical width (iPhone 12–15, and close to
+// the S23 Ultra's ~384px) — the width where the `sm:` breakpoint is still OFF, so
+// the mobile-stacked layouts are the ones under test.
+test.use({ viewport: { width: 390, height: 844 } });
+
+/** The document must never scroll horizontally — the whole-page overflow check. */
+async function expectNoPageOverflow(page: Page): Promise<void> {
+  const overflow = await page.evaluate(() => {
+    const el = document.documentElement;
+    return { scrollWidth: el.scrollWidth, clientWidth: el.clientWidth };
+  });
+  // Allow 1px for sub-pixel rounding; anything more is a real horizontal bleed.
+  expect(
+    overflow.scrollWidth,
+    `page overflows horizontally by ${String(overflow.scrollWidth - overflow.clientWidth)}px at 390px`,
+  ).toBeLessThanOrEqual(overflow.clientWidth + 1);
+}
+
+/** No visible <pre> (code block) may overflow its own container — they must wrap. */
+async function expectPreBlocksWrap(page: Page): Promise<void> {
+  const overflows = await page.evaluate(() =>
+    [...document.querySelectorAll("pre")]
+      .filter((el) => el.offsetParent !== null) // visible only
+      .map((el) => el.scrollWidth - el.clientWidth)
+      .filter((delta) => delta > 1),
+  );
+  expect(
+    overflows,
+    `${String(overflows.length)} <pre> block(s) overflow their box at 390px`,
+  ).toEqual([]);
+}
+
+test("the landing page never bleeds past a 390px viewport", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expectNoPageOverflow(page);
+  await expectPreBlocksWrap(page);
+
+  // Expand every verb in the "One tool. Four questions." map — each reveals a
+  // prose detail + a `<pre>` example, the exact thing that clipped on mobile.
+  for (const summary of await page.locator("#how summary").all()) {
+    await summary.click();
+  }
+  await expectNoPageOverflow(page);
+  await expectPreBlocksWrap(page);
+
+  // Tap a graded example chip — swaps the in-frame report for a real graded one
+  // (the summary <Report>, the locked-row tease, the category strip).
+  await page
+    .getByRole("button", { name: /grade [A-F]/ })
+    .first()
+    .click();
+  await expectNoPageOverflow(page);
+  await expectPreBlocksWrap(page);
+});

--- a/site/src/components/sections/DemoAudit.tsx
+++ b/site/src/components/sections/DemoAudit.tsx
@@ -611,6 +611,17 @@ export function DemoAudit({
         )}
       </div>
 
+      {/* Honest scope: the browser runs the deterministic STRUCTURAL detectors —
+          it can't reach your linter config, so it doesn't do the full rule
+          cross-reference (does each `enforce()` rule exist AND is it enabled?).
+          That's the CLI. Keeps the demo from over-claiming what it verifies. */}
+      <p className="mt-4 text-center text-[11px] leading-relaxed text-muted-foreground/60">
+        Structural checks, in your browser.{" "}
+        <span className="font-mono">vigiles audit</span> locally goes deeper —
+        it cross-references every linter rule your instructions name against
+        your actual config.
+      </p>
+
       {/* Shareability is the growth loop — a graded result is a public link that
           auto-runs. Surface a one-tap share on any report/featured view. */}
       {canShare && <ShareRow slug={headerSlug(frameView)} />}

--- a/site/src/components/sections/VerbMap.tsx
+++ b/site/src/components/sections/VerbMap.tsx
@@ -89,7 +89,7 @@ export function VerbMap() {
                 <span className="col-start-1 pl-[1.375rem] text-sm text-foreground sm:col-start-2 sm:pl-0">
                   {v.answers}
                 </span>
-                <span className="col-start-2 row-start-1 text-xs text-muted-foreground sm:text-right">
+                <span className="col-start-2 row-start-1 text-xs text-muted-foreground sm:col-start-3 sm:text-right">
                   {v.model}
                 </span>
               </summary>
@@ -120,9 +120,16 @@ export function VerbMap() {
         {/* Your rules → enforced — the prose-to-enforcement payoff of the hero
             pain. One compact card, not a new section. */}
         <Card className="reveal mx-auto mt-10 max-w-3xl p-6">
-          <h3 className="text-base font-semibold tracking-tight">
-            Your rules → enforced
-          </h3>
+          <div className="flex items-center gap-2">
+            <h3 className="text-base font-semibold tracking-tight">
+              Your rules → enforced
+            </h3>
+            {/* Clearly an ILLUSTRATION, not a scan of your repo — the example
+                below is representative, not a fabricated result (credibility). */}
+            <span className="rounded bg-muted/60 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+              example
+            </span>
+          </div>
           <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
             <span className="font-mono text-foreground">audit</span> maps each
             prose rule you wrote to the lint rule that enforces it, and tells


### PR DESCRIPTION
Demo/site hardening + the demo-gap roadmap direction, in one branch.

## Site fix — verb-map alignment
The "One tool. Four questions." answer text was landing on a **middle-indented second row** instead of inline after the command. Cause: the model note (`no model · read-only · anytime`) kept `col-start-2 row-start-1` from the 2-col mobile grid but never got a `sm:col-start-3` for the 3-col desktop grid, so it collided with the answer cell and grid auto-placement bumped the answer down a row. Fixed by giving it its `sm:` column.

## Harden the demo — Playwright e2e now runs in CI
The site e2e (`test:e2e`) was **manual-only** — which is exactly why stale assertions and a real mobile layout bug slipped through. Now wired into the CI `site` job (Chromium is already installed there). Adds a **390px mobile-overflow gate**: after expanding every verb and tapping a graded chip, it fails on any horizontal page bleed or a `<pre>` that doesn't wrap — the class of bug that reached a real phone. Stale header assertions fixed.

## Docs — the commands mental model
New `commands-and-how-they-relate.md`: how `audit` / `lint` / `test` / `eval` / `init` fit together, and **why measuring "do my skills fire?" from an agent uses `init`, not `audit`** (the read-vs-run consent boundary). Linked from the README verb map, `cli.md`, and the docs index.

## Demo scope + roadmap
- The in-browser demo is structurally a subset on *both* axes — the deterministic depth it can't reach (linter cross-reference, ast-grep symbols, live MCP, **references inside markdown prose**) *and* the model-gated behavioral tier (trigger-rate). Client-side fixes don't work: prose-ref parsing is semantically undecidable, and the behavioral tier needs a model.
- Roadmap (Later): a **backend with rate-limited LLM access** running the real `vigiles audit` server-side — full deterministic depth **and** trigger-rate — public-repo only, vigiles-funded LLM (distinct from the CLI's "your subscription"), rate-limit + cache. Honest caveat: unmarked prose refs stay undecidable regardless.
- Interim: a muted caveat under the demo report so it doesn't over-claim.

## Skill (gate-failure → fix-the-gate-first)
The landing-site skill gains the responsive-grid cell-collision lesson so this alignment class is caught next time.

tsc clean · site suite 42/42 · e2e 3/3 (incl. mobile gate) · build clean · fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)