### PR TITLE
docs: loop() combinator idea — checkable stop condition for iterating orchestrators

### DIFF
--- a/research/CLAUDE.md
+++ b/research/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- vigiles:sha256:dcabffbebce80c34 compiled from research/CLAUDE.md.spec.ts -->
+<!-- vigiles:sha256:a0cc27bf904ec0ef compiled from research/CLAUDE.md.spec.ts -->
 
 # CLAUDE.md
 

--- a/research/CLAUDE.md
+++ b/research/CLAUDE.md
@@ -120,6 +120,7 @@ The `research/` corpus is the INTERNAL record (design rationale, competitive ana
 - `research/executable-specs.md` — [shipped] Original v2 design doc for the spec.ts→markdown compilation model now built as vigiles's core architecture
 - `research/lightweight-spec-authoring.md` — [active] Sweep of 16 real instruction files: current claude() spec is too heavy; value is composition/templates
 - `research/railway-subagents.md` — [active] Railway-orchestration design over flat subagents: Temporal analogy, marks vs typed workflow() vs driver options
+- `research/loop-combinator.md` — [idea] loop(body,{until,maxIters}) extending railway(): a checkable stop condition (deterministic until-gate → Stop-hook, mandatory maxIters cap) so an iterating orchestrator's "until done" is a compiled gate, not prose. Product side of the terminatability / Prose-Isn't-Policy-for-control-flow angle
 - `research/shareable-presets.md` — [idea] Design sketch for publishable npm-package typed presets that other repos extend, bundling rules + evals
 - `research/composable-instruction-files.md` — [active] Mid-2026 survey of composable/modular instruction files: only Claude Code + Gemini CLI have true @import; AGENTS.md standard has no imports (open proposal); demand real+dated (openai/codex#17401); the unmet gap is multi-repo registry-distributed versioned rule packages; maps onto vigiles's preset()/extends() + compose.ts
 - `research/spec-api-design.md` — [active] Best-practice synthesis for spec.ts API: doc()/section() split, preset()/extends() merge model, strict-typing upgrades

--- a/research/CLAUDE.md.spec.ts
+++ b/research/CLAUDE.md.spec.ts
@@ -165,6 +165,7 @@ export default claude({
     "research/executable-specs.md": `[shipped] Original v2 design doc for the spec.ts→markdown compilation model now built as vigiles's core architecture`,
     "research/lightweight-spec-authoring.md": `[active] Sweep of 16 real instruction files: current claude() spec is too heavy; value is composition/templates`,
     "research/railway-subagents.md": `[active] Railway-orchestration design over flat subagents: Temporal analogy, marks vs typed workflow() vs driver options`,
+    "research/loop-combinator.md": `[idea] loop(body,{until,maxIters}) extending railway(): a checkable stop condition (deterministic until-gate → Stop-hook, mandatory maxIters cap) so an iterating orchestrator's "until done" is a compiled gate, not prose. Product side of the terminatability / Prose-Isn't-Policy-for-control-flow angle`,
     "research/shareable-presets.md": `[idea] Design sketch for publishable npm-package typed presets that other repos extend, bundling rules + evals`,
     "research/composable-instruction-files.md": `[active] Mid-2026 survey of composable/modular instruction files: only Claude Code + Gemini CLI have true @import; AGENTS.md standard has no imports (open proposal); demand real+dated (openai/codex#17401); the unmet gap is multi-repo registry-distributed versioned rule packages; maps onto vigiles's preset()/extends() + compose.ts`,
     "research/spec-api-design.md": `[active] Best-practice synthesis for spec.ts API: doc()/section() split, preset()/extends() merge model, strict-typing upgrades`,

--- a/research/README.md
+++ b/research/README.md
@@ -77,6 +77,7 @@ one click away.
 
 - [`subagent-compilation.md`](subagent-compilation.md) — compiling typed subagent definitions (`agent()` → `agents/<name>.md`); the declared-vs-enforced tool gap (`tools:` is documentation, a `PreToolUse` hook is the rail); the empirical "no iterator in a subagent" survey (~100 agents).
 - [`railway-subagents.md`](railway-subagents.md) — **railway-style orchestration over flat subagents.** The direct, differentiated answer to Anthropic's **ultraplan / dynamic-workflows** (plan-as-code): be the _typed, verified, compiled_ counterpart to its ephemeral generated script. Includes the Temporal analogy and the marks / `workflow()`-spec / deterministic-driver options. **Closest external thing to our direction — read for inspiration.**
+- [`loop-combinator.md`](loop-combinator.md) — _[idea]_ **`loop()` extending the finite railway** with a *checkable* stop condition: a deterministic `until`-gate (compiles to a `Stop`-hook) + a mandatory `maxIters` cap, so an iterating orchestrator's "until done" is a **compiled gate, not prose** ("a loop is a self-edge node; stop conditions live at the loop level"). The product side of the terminatability / "Prose Isn't Policy for control flow" angle.
 
 ## Skills
 

--- a/research/loop-combinator.md
+++ b/research/loop-combinator.md
@@ -1,0 +1,92 @@
+---
+status: idea
+topic: spec
+---
+
+# `loop()` combinator — a checkable stop condition for iterating orchestrators
+
+Design idea. Extends [`railway-subagents.md`](railway-subagents.md), which
+deliberately ships **no loop combinator** — `railway({ steps, recover })` is a
+finite step list + bounded recovery, so *termination is structural* (it cannot
+spin forever by construction). That is the safe end of the control-flow spectrum.
+This doc asks the next question: real orchestrators **do** loop
+(discover → plan → execute → verify, *until done*), and today that "until done"
+is **prose**, not a checkable gate. So a `loop()` combinator has to earn its
+termination guarantee the way `railway()` gets it for free.
+
+## The framing (why this is a vigiles-shaped problem)
+
+A widely-shared distinction (Jason Zhou, "wtf is graph engineering") makes the
+gap crisp: **"a loop is a single-node graph with an edge back to itself"** — and
+therefore **stop conditions and verification live at the *loop* level, not the
+graph level.** "A graph of weak loops is just a more expensive way to produce
+slop."
+
+That is our thesis restated for control flow: **the stop condition is prose, not
+policy.** An orchestrator's "keep going until the tests pass / until it looks
+done" is an LLM judgment, unverified — the same shape as an unenforced CLAUDE.md
+rule. vigiles already turns prose rules into deterministic gates; a `loop()`
+combinator turns a **prose stop condition into a compiled one**.
+
+## Sketch
+
+```ts
+loop(
+  body,                          // a railway step / delegate() — the work per pass
+  {
+    until: cmd("npm test"),      // MUST be a deterministic gate (cmd() or a
+                                 // predicate over typed state) — NOT prose.
+    maxIters: 5,                 // MANDATORY cap — the runaway backstop.
+  },
+)
+```
+
+- **`until` must be deterministic — prose ⇒ compile error / abstain.** `until:
+  "when it looks done"` does not compile; it degrades to advisory. This mirrors
+  the two-stage adversarial gate in the rule-compiler (`@vigiles/compiler`): if a
+  condition can't be expressed as a checkable predicate, vigiles refuses to claim
+  it enforces one, rather than emitting a fake gate.
+- **`until` compiles to a `Stop`-hook** — the loop's termination check *is* the
+  gate, reusing the shipped `Stop`-gate emission (`skill-hook`,
+  [`runtime-enforcement.md`](runtime-enforcement.md)).
+- **`maxIters` compiles to a hook-counter cap** — the same backstop shape as the
+  spawn-depth cap for nested subagents in `railway-subagents.md`; guarantees
+  termination even if `until` is never satisfied.
+- **Blast-radius is per-iteration, not widened.** Each pass reuses the existing
+  `PreToolUse` tool-contract / purity rail (`src/adapters/claude-code/agent-runtime.ts`);
+  a loop repeats the rail N times, it does not grant new authority.
+- **`assertLoopTerminates`** in `src/harness-assert.ts` — the testing-framework
+  payoff: an eval (pass^k) that the `until` gate is actually *reachable*, not just
+  that the railway type-checks. Reuses the eval tier that would score a railway.
+
+## Boundary (same as railway Option 3)
+
+**Do not build a loop engine.** vigiles emits + verifies the loop (the `until`
+gate, the `maxIters` cap, the per-iteration rail) and delegates *execution* to the
+harness's native `Stop`-hook + state-file pattern. The moat is "the stop condition
+is a compiled gate, not prose" — not a runtime.
+
+## Relation to the measurement / paper angle
+
+The **measurement** side — a *terminatability probe* over real agent-loop
+templates (what fraction have a deterministic vs LLM-judged stop condition) — is
+the external research artifact and lives in the private KB
+(`migratsiya/papers/research/2026-07-23-deep-research-agent-control-loop-taxonomy.md`,
+`zernie/mine`), tied to the "Prose Isn't Policy" paper lane. **This doc is the
+product idea**; that one is the study. Keep them cross-linked, not merged.
+
+## Open questions
+
+- Can a `Stop`-hook read enough between iterations to evaluate `until`
+  deterministically over the run's state — or is it limited to a command gate?
+  (Same open question as the railway Option 3 driver in `railway-subagents.md`.)
+- Is `loop()` a combinator inside `railway()`, or a mode of the future
+  `command()` compilation target (where real flow lives)? Leaning: same home as
+  `railway()` resolves to.
+
+## See also
+
+- [`railway-subagents.md`](railway-subagents.md) — the finite railway this extends
+  (the "no loop combinator, termination is structural" decision).
+- [`spec-syntax-and-railway-scope.md`](spec-syntax-and-railway-scope.md) — railway/Result is subagent-only.
+- [`runtime-enforcement.md`](runtime-enforcement.md) — the `Stop`-gate emission this reuses.

--- a/research/railway-subagents.md
+++ b/research/railway-subagents.md
@@ -155,7 +155,10 @@ programming with a subagent as the step:
   err | malformed), validated against the contract shape. The shared primitive.
 - **`railway({ steps, onError, recover })` + `delegate()`** (`src/spec.ts`) — the
   sub-Turing composer: a finite step list + bounded recovery, **no loop
-  combinator**, so termination is structural. **`compileRailway`/`validateRailway`**
+  combinator**, so termination is structural. (A proposed `loop()` extension that
+  keeps termination *checkable* for orchestrators that genuinely iterate — a
+  deterministic `until`-gate + a mandatory `maxIters` cap — is spec'd in
+  [`loop-combinator.md`](loop-combinator.md).) **`compileRailway`/`validateRailway`**
   (`src/compile.ts`) emit the orchestrator command and resolve every delegate
   target against the known agent set (stale-ref), reject an empty railway, and
   require `recover.max ≥ 1`.

--- a/research/roadmap.md
+++ b/research/roadmap.md
@@ -988,6 +988,17 @@ assertRates`) is the recommended path for testing one skill, but
   the reference-verification domain — only do it if the symmetry is judged worth
   that. · **LOW**
 
+- **`loop()` combinator — a checkable stop condition for iterating orchestrators.**
+  `railway()` ships no loop (finite steps → termination is structural); real
+  orchestrators loop "until done", and that stop condition is prose today. Add
+  `loop(body, { until, maxIters })` where `until` MUST be a deterministic gate
+  (compiles to a `Stop`-hook) and `maxIters` is a mandatory cap — prose `until` is
+  a compile error / advisory. Emit-and-verify only (no engine), reusing the shipped
+  `Stop`-gate + per-iteration `PreToolUse` rail. The product side of the
+  terminatability / "Prose Isn't Policy for control flow" paper angle. →
+  [`loop-combinator.md`](loop-combinator.md), extends [`railway-subagents.md`](railway-subagents.md).
+  · **MED / needs the railway-driver open question resolved**
+
 ## Backlog — lower priority / niche
 
 - Pillar 1: #12 annotation-typo (partial), #10 instruction diff (PR-time), #4


### PR DESCRIPTION
## What

Adds `research/loop-combinator.md` (`status: idea`, `topic: spec`) — the **product-side** extension of `railway-subagents.md`.

`railway()` deliberately ships **no loop combinator** (finite steps → termination is structural). But real orchestrators loop `discover → plan → execute → verify` *until done*, and that stop condition is **prose** today, not a checkable gate. This idea adds:

```ts
loop(body, {
  until: cmd("npm test"),  // MUST be deterministic — prose ⇒ compile error / advisory
  maxIters: 5,             // MANDATORY runaway cap
})
```

- `until` compiles to a `Stop`-hook (the termination check *is* the gate); prose `until` degrades to advisory (mirrors the rule-compiler adversarial gate).
- `maxIters` → hook-counter cap (same shape as the spawn-depth cap).
- Blast-radius is per-iteration (reuses the shipped `PreToolUse` rail), not widened.
- `assertLoopTerminates` — eval (pass^k) that the `until` gate is reachable.
- **Emit-and-verify only, no engine** (same boundary as railway Option 3).

Framing: *"a loop is a single-node graph with an edge back to itself → stop conditions and verification live at the loop level."* The stop condition is **prose, not policy** — the same thesis applied to control flow.

## Scope

Docs/idea only — no code. Indexed in `research/CLAUDE.md` (+ `.spec.ts` source, keeps `research-index-complete` green), listed in `research/README.md`, ranked in `research/roadmap.md` (Later), cross-linked from `railway-subagents.md`.

The **measurement/paper** side (a *terminatability probe* over real agent-loop templates) stays in the private KB — this PR is only the product idea, cross-linked, not merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArRSDLJCEcFDyJZTs1FywC)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Fixes**
- recompile research/CLAUDE.md hash after adding loop-combinator entry

**Other**
- research: loop() combinator idea — checkable stop condition for iterating orchestrators
<!-- vigiles:pr-summary:end -->

