### PR TITLE
feat(hook): add CommandView.writesTo() and capture redirections in the parser

### DIFF
--- a/api-surface/vigiles-hook.api.md
+++ b/api-surface/vigiles-hook.api.md
@@ -37,6 +37,7 @@ export interface CommandView {
         readonly force?: boolean;
     }): boolean;
     touches(prefixes: readonly string[]): boolean;
+    writesTo(prefixes: readonly string[]): boolean;
 }
 
 // @public (undocumented)
@@ -276,6 +277,14 @@ export interface InlineProvider<Name extends string = string> {
 export function leafCommandsNormalized(command: string): NormalizedLeaf[];
 
 // @public
+export interface LeafRedirect {
+    readonly fd: number | null;
+    readonly op: string;
+    readonly target: string | null;
+    readonly writes: boolean;
+}
+
+// @public
 export type NeedSpec = ProviderName | InlineProvider | RegisteredRef;
 
 // @public
@@ -287,6 +296,7 @@ export interface NormalizedLeaf {
     hasAssign(...names: readonly string[]): boolean;
     hasFlag(...names: readonly string[]): boolean;
     readonly head: string;
+    readonly redirects: readonly LeafRedirect[];
 }
 
 // @public

--- a/docs/compiled-hooks.md
+++ b/docs/compiled-hooks.md
@@ -65,9 +65,13 @@ export default defineHook({
 - **`tool(name)` / `tools(...names)`** — which tool(s) the hook matches.
 - **`e.command`** (Bash) — an AST-backed `CommandView`:
   - `runs(program, { force? })` — a leaf runs `program` (e.g. `"git reset --hard"`), optionally forced.
-  - `touches(prefixes)` — a leaf references a path under one of `prefixes` (e.g. `["~/.ssh", ".env"]`) — secret reads.
+  - `touches(prefixes)` — a leaf **mentions** a path under one of `prefixes` (e.g. `["~/.ssh", ".env"]`) — secret reads.
+  - `writesTo(prefixes)` — a leaf **creates or modifies** a file under one of `prefixes`: redirection targets (`cmd > f`, `>>`, `>|`, `&>`) plus the writing argv position of `sed -i`, `cp` / `mv` / `install` (destination), `tee`, `dd of=`, `truncate`, `shred`.
   - `pipesToShell()` — pipes into a bare shell (`curl … | sh`) — remote-code execution. A shell _with_ a script file (`sh deploy.sh`) is **not** flagged.
   - `isSideEffecting()` — the deterministic Bash-effect classifier's verdict.
+
+  > **`touches` ≠ `writesTo` — conflating them is the trap.** `touches` answers _mentioned_: `grep -c x notes/S.md` matches, and so does `rm -rf notes`. `isSideEffecting()` does not rescue it, because it classifies the **whole command line** — `grep -c x notes/S.md 2>/dev/null` is side-effecting (there's a redirection), so a `touches() && isSideEffecting()` gate blocks a plain read. Use `writesTo` to gate writes and `touches` for "don't even look at this path". Deletion is reported by neither — pair with `runs("rm")` if a gate needs it.
+
 - **`e.path`** (Edit/Write) — a `PathView` with `under(prefixes)` for path confinement.
 - **`e.prompt`** (UserPromptSubmit) — the user's prompt text (a plain string).
 - **`e.stopHookActive`** (Stop) — the loop guard; `allow()` when it's `true`.

--- a/src/core/bash-effects-normalized.test.ts
+++ b/src/core/bash-effects-normalized.test.ts
@@ -188,3 +188,112 @@ test("non-HOME parameter makes an arg dynamic (dropped, not misparsed)", () => {
   assert.ok(l.args.includes("install"));
   assert.ok(!l.args.some((a) => a.includes("$PKG")));
 });
+
+// --- redirections are CAPTURED, not dropped ---------------------------------
+//
+// The parser walked CallExprs only, but a redirection lives on the enclosing
+// Stmt — so `echo x > papers/x/paper.md` normalized to a leaf whose head/argv/
+// args/flags/assigns mentioned only `echo` and `x`, and the file it WROTE
+// appeared in no field at all. Measured 2026-08-03: that made the single most
+// common write shape invisible to any matcher built on the leaf.
+
+test("a redirection target is captured on the leaf (it used to vanish)", () => {
+  const l = one("echo x > papers/x/paper.md");
+  assert.equal(l.head, "echo");
+  assert.deepEqual(l.args, ["x"]); // the target is NOT an argv word
+  assert.equal(l.redirects.length, 1);
+  assert.equal(l.redirects[0]?.op, ">");
+  assert.equal(l.redirects[0]?.target, "papers/x/paper.md");
+  assert.equal(l.redirects[0]?.fd, null);
+  assert.equal(l.redirects[0]?.writes, true);
+});
+
+test("append / clobber / all-streams redirections are writes", () => {
+  for (const [cmd, op] of [
+    ["a >> f", ">>"],
+    ["a >| f", ">|"],
+    ["a &> f", "&>"],
+    ["a &>> f", "&>>"],
+  ] as const) {
+    const r = one(cmd).redirects[0];
+    assert.equal(r?.op, op, cmd);
+    assert.equal(r?.writes, true, cmd);
+    assert.equal(r?.target, "f", cmd);
+  }
+});
+
+test("input redirections and fd-dups are NOT writes", () => {
+  for (const [cmd, op] of [
+    ["a < f", "<"],
+    ["a <<< f", "<<<"],
+  ] as const) {
+    const r = one(cmd).redirects[0];
+    assert.equal(r?.op, op, cmd);
+    assert.equal(r?.writes, false, cmd);
+  }
+  // `2>&1` duplicates an fd — its "target" is the fd 1, not a file named "1".
+  const dup = one("a 2>&1").redirects[0];
+  assert.equal(dup?.op, ">&");
+  assert.equal(dup?.fd, 2);
+  assert.equal(dup?.writes, false);
+});
+
+test("an explicit source fd is recorded", () => {
+  const r = one("a 2> err.log").redirects[0];
+  assert.equal(r?.fd, 2);
+  assert.equal(r?.op, ">");
+  assert.equal(r?.target, "err.log");
+  assert.equal(r?.writes, true);
+});
+
+test("a dynamic redirect target is null (present but unresolved), never a guess", () => {
+  const r = one('echo x > "$OUT"').redirects[0];
+  assert.equal(r?.op, ">");
+  assert.equal(r?.target, null);
+  assert.equal(r?.writes, true);
+});
+
+test("$HOME and quotes in a redirect target are normalized like any word", () => {
+  assert.equal(one('echo x > "$HOME/.bashrc"').redirects[0]?.target, "~/.bashrc"); // prettier-ignore
+  assert.equal(one("echo x > 'a b.md'").redirects[0]?.target, "a b.md");
+});
+
+test("a redirection inside a QUOTED word is data, not a redirection", () => {
+  const [outer] = leafCommandsNormalized(
+    "echo 'echo y > a/paper.md' > /tmp/note.txt",
+  );
+  assert.ok(outer);
+  assert.equal(outer.redirects.length, 1);
+  assert.equal(outer.redirects[0]?.target, "/tmp/note.txt");
+});
+
+test("every leaf of a compound command keeps its OWN redirections", () => {
+  const leaves = leafCommandsNormalized("cat a.md && echo x > b.md | tee c.md");
+  const byHead = new Map(leaves.map((l) => [l.head, l]));
+  assert.equal(byHead.get("cat")?.redirects.length, 0);
+  assert.equal(byHead.get("echo")?.redirects[0]?.target, "b.md");
+  assert.equal(byHead.get("tee")?.redirects.length, 0);
+});
+
+test("the mvdan redirect-op table is PINNED to the installed parser", () => {
+  // The op codes are numeric tokens with no public name mapping, so an mvdan-sh
+  // upgrade that renumbered one would silently reclassify a write as a read.
+  // Re-derive every entry from the parser itself: this fails LOUDLY instead.
+  const expected: Record<string, boolean> = {
+    ">": true,
+    ">>": true,
+    ">|": true,
+    "&>": true,
+    "&>>": true,
+    "<": false,
+    "<>": false,
+    "<<<": false,
+    ">&": false,
+    "<&": false,
+  };
+  for (const [op, writes] of Object.entries(expected)) {
+    const r = one(`a ${op} f`).redirects[0];
+    assert.equal(r?.op, op, `operator string for ${op}`);
+    assert.equal(r?.writes, writes, `write classification for ${op}`);
+  }
+});

--- a/src/core/bash-effects.ts
+++ b/src/core/bash-effects.ts
@@ -61,6 +61,10 @@ interface MvdanNode {
 
 interface MvdanRedirect extends MvdanNode {
   Op: number;
+  /** The explicit source fd (`2> f` → a Lit "2"); absent when omitted. */
+  N?: MvdanNode;
+  /** The redirection target word (`> f` → the word `f`). */
+  Word?: MvdanWord;
 }
 
 interface MvdanWord extends MvdanNode {
@@ -85,6 +89,28 @@ interface MvdanAssign {
 // ---------------------------------------------------------------------------
 
 const WRITE_REDIR_OPS = new Set([54, 55, 60, 64, 65]);
+
+/**
+ * Op code → the operator as WRITTEN, so a normalized leaf can REPORT the
+ * redirection it carries instead of a bare number. Pinned by
+ * `bash-effects-normalized.test.ts`, which re-derives every entry by parsing the
+ * operator itself — an mvdan-sh upgrade that renumbers a token fails there
+ * LOUDLY instead of silently misclassifying a write as a read.
+ */
+const REDIR_OP_NAMES: ReadonlyMap<number, string> = new Map([
+  [54, ">"],
+  [55, ">>"],
+  [56, "<"],
+  [57, "<>"],
+  [58, "<&"],
+  [59, ">&"],
+  [60, ">|"],
+  [61, "<<"],
+  [62, "<<-"],
+  [63, "<<<"],
+  [64, "&>"],
+  [65, "&>>"],
+]);
 
 // ---------------------------------------------------------------------------
 // Shell-escape heads: commands that dispatch arbitrary code as an argument.
@@ -520,6 +546,34 @@ export function leafCommands(command: string): string[][] {
 // Lit-only extractor leaves open (see research/ before/after measurement).
 // ===========================================================================
 
+/**
+ * One redirection attached to a simple command (`cmd > f`, `cmd 2>> log`).
+ *
+ * The parser used to DROP these: `echo x > out.md` normalized to a leaf whose
+ * every field (`head`/`argv`/`args`/`flags`/`assigns`) mentioned only `echo` and
+ * `x`, so the file the command actually WROTE appeared nowhere. That made the
+ * single most common write shape invisible to any matcher built on the leaf.
+ */
+export interface LeafRedirect {
+  /** The operator as written: `>`, `>>`, `>|`, `&>`, `&>>`, `<`, `<<`, `>&`, … */
+  readonly op: string;
+  /**
+   * The redirection target, quote-unwrapped and `$HOME`-canonicalized like every
+   * other word. `null` when the target is dynamic (`> "$out"`, `> $(f)`) — present
+   * but unresolvable, never silently dropped. For an fd-dup (`2>&1`) this is the
+   * fd, not a path; for a heredoc it's the delimiter.
+   */
+  readonly target: string | null;
+  /** The explicit source fd (`2> f` → 2), or `null` when omitted. */
+  readonly fd: number | null;
+  /**
+   * True iff this redirection CREATES OR MODIFIES the file named by `target` —
+   * `>`, `>>`, `>|`, `&>`, `&>>`. False for input (`<`, `<<`, `<<<`) and for fd
+   * duplication (`2>&1`), whose "target" is an fd, not a path.
+   */
+  readonly writes: boolean;
+}
+
 /** A single simple command, normalized to its operation form. */
 export interface NormalizedLeaf {
   /** Head normalized to its basename, backslash-stripped: `/bin/rm`→`rm`, `\rm`→`rm`. */
@@ -550,6 +604,11 @@ export interface NormalizedLeaf {
   readonly assigns: ReadonlyMap<string, string | null>;
   /** True iff a command-level assignment for ANY of `names` is present (resolved or not). */
   hasAssign(...names: readonly string[]): boolean;
+  /**
+   * The redirections attached to this leaf, in source order — see
+   * {@link LeafRedirect}. Empty for a command with no redirection.
+   */
+  readonly redirects: readonly LeafRedirect[];
 }
 
 /**
@@ -789,6 +848,11 @@ function stripWrappers(argv: readonly string[]): {
  * compares against the OPERATION rather than the surface tokens, so it is robust
  * to quoting, interpreter path, backslash escaping, flag aliasing, and $HOME/~.
  *
+ * Each leaf also carries its REDIRECTIONS ({@link LeafRedirect}), which live on
+ * the enclosing `Stmt` rather than the `CallExpr` — walking CallExprs alone
+ * dropped them, hiding the file a command writes. Every CallExpr in the mvdan AST
+ * IS a `Stmt.Cmd`, so iterating statements finds exactly the same leaves.
+ *
  * Purely additive: reuses the same mvdan-sh parse, changes nothing above. Parse
  * failure → []. A leaf with a dynamic head is skipped (can't be normalized).
  */
@@ -801,11 +865,25 @@ export function leafCommandsNormalized(command: string): NormalizedLeaf[] {
   }
   const out: NormalizedLeaf[] = [];
   sh.syntax.Walk(file, (node) => {
-    const leaf = normalizeCallExpr(node);
+    if (sh.syntax.NodeType(node) !== "Stmt" || !node.Cmd) return true;
+    const leaf = normalizeCallExpr(node.Cmd, node.Redirs ?? []);
     if (leaf) out.push(leaf);
     return true;
   });
   return out;
+}
+
+/** Normalize a Stmt's redirections into {@link LeafRedirect}s (source order). */
+function normalizeRedirects(redirs: readonly MvdanRedirect[]): LeafRedirect[] {
+  return redirs.map((r) => {
+    const fd = Number(r.N?.Value);
+    return {
+      op: REDIR_OP_NAMES.get(r.Op) ?? String(r.Op),
+      target: r.Word ? normalizeParts(r.Word.Parts) : null,
+      fd: Number.isInteger(fd) ? fd : null,
+      writes: WRITE_REDIR_OPS.has(r.Op),
+    };
+  });
 }
 
 /** Collect a CallExpr's leading `NAME=value` env-assignments into a name→value map. */
@@ -821,8 +899,14 @@ function collectAssigns(node: MvdanNode): Map<string, string | null> {
   return assigns;
 }
 
-/** Normalize a single CallExpr node to a {@link NormalizedLeaf}, or null if it isn't one / has a dynamic head. */
-function normalizeCallExpr(node: MvdanNode): NormalizedLeaf | null {
+/**
+ * Normalize a single CallExpr node (plus the redirections of the `Stmt` that
+ * wraps it) to a {@link NormalizedLeaf}, or null if it isn't one / has a dynamic head.
+ */
+function normalizeCallExpr(
+  node: MvdanNode,
+  redirs: readonly MvdanRedirect[],
+): NormalizedLeaf | null {
   if (sh.syntax.NodeType(node) !== "CallExpr" || !node.Args?.length)
     return null;
   const headRaw = normalizeParts(node.Args[0]?.Parts);
@@ -852,5 +936,6 @@ function normalizeCallExpr(node: MvdanNode): NormalizedLeaf | null {
     hasFlag: (...names) => names.some((n) => flags.has(n)),
     assigns,
     hasAssign: (...names) => names.some((n) => assigns.has(n)),
+    redirects: normalizeRedirects(redirs),
   };
 }

--- a/src/core/hook-program.test.ts
+++ b/src/core/hook-program.test.ts
@@ -176,6 +176,104 @@ test("commandView.touches/pipesToShell: high-signal secret-read + curl|sh matche
 });
 
 // ---------------------------------------------------------------------------
+// writesTo() — "what does this command WRITE", which touches() cannot answer.
+//
+// Measured 2026-08-03 dogfooding a compiled gate meant to protect a directory
+// from Bash writes: the redirection and its target were DROPPED by the parser, so
+// `echo x > papers/x/paper.md` had the written file in NO field of any leaf, and
+// the gate was silently weaker than the grep it replaced. The only available
+// discriminator, isSideEffecting(), classifies the WHOLE line — so
+// `grep -c x notes/S.md 2>/dev/null` classified side-effecting, touches()
+// matched, and a plain READ got blocked. That happened twice within an hour.
+// ---------------------------------------------------------------------------
+test("commandView.writesTo: a redirection target is a write, wherever it hides", () => {
+  assert.equal(
+    commandView("echo x > papers/x/paper.md").writesTo(["papers"]),
+    true,
+  );
+  assert.equal(
+    commandView("echo x >> papers/x/paper.md").writesTo(["papers"]),
+    true,
+  );
+  assert.equal(commandView("echo x >| papers/p.md").writesTo(["papers"]), true);
+  assert.equal(commandView("cmd &> papers/p.md").writesTo(["papers"]), true);
+  // Nested in a compound command / pipeline, exactly like runs().
+  assert.equal(
+    commandView("cd x && echo hi > papers/n.md").writesTo(["papers"]),
+    true,
+  );
+  assert.equal(
+    commandView("curl -s http://x | tee papers/n.md").writesTo(["papers"]),
+    true,
+  );
+  // A dynamic target is unresolvable — reported as no match, never guessed.
+  assert.equal(commandView('echo x > "$OUT"').writesTo(["papers"]), false);
+});
+
+test("commandView.writesTo: a READ is never a write (the false-block regression)", () => {
+  const read = commandView("grep -c x notes/S.md 2>/dev/null");
+  // touches() matches (the path IS mentioned) and the whole line classifies
+  // side-effecting because of the redirection — the exact pair that blocked real
+  // reads. writesTo() separates them.
+  assert.equal(read.touches(["notes"]), true);
+  assert.equal(read.isSideEffecting(), true);
+  assert.equal(read.writesTo(["notes"]), false);
+
+  assert.equal(commandView("cat notes/S.md").writesTo(["notes"]), false);
+  assert.equal(commandView("cat < notes/S.md").writesTo(["notes"]), false);
+  assert.equal(commandView("ls notes 2>&1").writesTo(["notes"]), false);
+  // An fd-dup's "target" is an fd, not a path.
+  assert.equal(commandView("cmd 2>&1 > /tmp/o").writesTo(["notes"]), false);
+});
+
+test("commandView.writesTo: quoting is handled by the PARSER, not a regex", () => {
+  // The real target is /tmp/note.txt; the `> a/paper.md` inside the quoted word
+  // is data, not a redirection. A regex over the raw string gets this wrong.
+  const v = commandView("echo 'echo y > a/paper.md' > /tmp/note.txt");
+  assert.equal(v.writesTo(["a"]), false);
+  assert.equal(v.writesTo(["/tmp"]), true);
+});
+
+test("commandView.writesTo: file-writing programs, at the position that writes", () => {
+  // sed edits in place ONLY with -i; the script operand is not a file.
+  const sed = commandView("sed -i s/a/b/ papers/x.md");
+  assert.equal(sed.writesTo(["papers"]), true);
+  assert.equal(commandView("sed s/a/b/ papers/x.md").writesTo(["papers"]), false); // prettier-ignore
+  assert.equal(
+    commandView("sed -i -e s/a/b/ papers/x.md").writesTo(["papers"]),
+    true,
+  );
+  // cp/mv/install write the DESTINATION; the sources are read.
+  assert.equal(commandView("cp /tmp/y papers/x.md").writesTo(["papers"]), true);
+  assert.equal(
+    commandView("cp papers/x.md /tmp/y").writesTo(["papers"]),
+    false,
+  );
+  assert.equal(commandView("mv /tmp/y papers/x.md").writesTo(["papers"]), true);
+  assert.equal(
+    commandView("install -m 644 src/a papers/a").writesTo(["papers"]),
+    true,
+  );
+  // tee / truncate / shred write every operand; dd writes only `of=`.
+  assert.equal(commandView("sudo tee papers/n.md").writesTo(["papers"]), true);
+  assert.equal(
+    commandView("truncate -s 0 papers/x.md").writesTo(["papers"]),
+    true,
+  );
+  assert.equal(commandView("shred papers/a").writesTo(["papers"]), true);
+  assert.equal(
+    commandView("dd if=/dev/zero of=papers/x.md").writesTo(["papers"]),
+    true,
+  );
+  assert.equal(
+    commandView("dd if=papers/x.md of=/tmp/o").writesTo(["papers"]),
+    false,
+  );
+  // An unlisted head contributes no write target — no guessing.
+  assert.equal(commandView("wc -l papers/x.md").writesTo(["papers"]), false);
+});
+
+// ---------------------------------------------------------------------------
 // MULTI-HARNESS EMIT — one typed program, the settings block is per-harness.
 // The dogfood is NON-CC-shaped (TOML + regex matcher) so it can't pass by
 // accident on a Claude-Code-hardcoded path (the adapter-aware-lint discipline).

--- a/src/core/hook-program.ts
+++ b/src/core/hook-program.ts
@@ -31,8 +31,10 @@
  */
 import {
   leafCommands,
+  leafCommandsNormalized,
   classifyBashCommand,
   type BashEffect,
+  type NormalizedLeaf,
 } from "./bash-effects.js";
 import { sha256short, assertNever, type SHA256Hash } from "./hash.js";
 import { stringify as stringifyToml } from "@iarna/toml";
@@ -117,11 +119,41 @@ export interface CommandView {
   /** True iff the command is provably side-effecting (bash-effects classifier). */
   isSideEffecting(): boolean;
   /**
-   * True iff a leaf command references a path under one of the prefixes (e.g.
+   * True iff a leaf command MENTIONS a path under one of the prefixes (e.g.
    * `~/.ssh`, `.env`) — the secret-read / sensitive-path matcher. Sees the path
    * however the command is wrapped (`cd x && cat ~/.ssh/id_rsa`).
+   *
+   * MENTIONS, not writes. `grep -c x notes/S.md` touches `notes` — so does
+   * `rm -rf notes`. Pairing this with {@link isSideEffecting}, which classifies
+   * the WHOLE command line, does NOT recover the difference: a plain read whose
+   * line happens to be side-effecting for an unrelated reason (`grep -c x
+   * notes/S.md 2>/dev/null`) matches both and gets blocked. To gate WRITES to a
+   * directory, use {@link writesTo}; conflating the two is the trap.
    */
   touches(prefixes: readonly string[]): boolean;
+  /**
+   * True iff a leaf command CREATES OR MODIFIES a file under one of the prefixes
+   * — the "don't let Bash write here" matcher, and the precise counterpart to
+   * {@link touches}. Two sources, both AST-backed:
+   *
+   * - **Redirection targets** — `cmd > f`, `cmd >> f`, `cmd >| f`, `cmd &> f`.
+   *   This is the single most common write shape, and it lives on the statement,
+   *   not in any argv.
+   * - **File-writing programs**, at the argv positions that actually name the
+   *   file written: `sed -i`, `cp`/`mv`/`install` (destination), `tee`, `dd of=`,
+   *   `truncate`, `shred`.
+   *
+   * A path merely READ never matches — `cat a/paper.md`, `grep x a/paper.md`,
+   * `cp a/paper.md /tmp/x` (the source is read, `/tmp/x` is the write) are all
+   * false for `writesTo(["a"])`. Quoting is handled by the parser, so a write
+   * QUOTED inside another command does not match: in
+   * `echo 'echo y > a/paper.md' > /tmp/note.txt` the only real target is
+   * `/tmp/note.txt`.
+   *
+   * Deletion is a different question and is deliberately NOT reported here —
+   * pair with `runs("rm")` if a gate cares about removal too.
+   */
+  writesTo(prefixes: readonly string[]): boolean;
   /**
    * True iff the command pipes into a BARE shell interpreter (`curl … | sh`,
    * `… | bash -s`) — the remote-code-execution shape. High-signal: a shell leaf
@@ -160,8 +192,90 @@ function isBareShellLeaf(argv: readonly string[]): boolean {
   );
 }
 
+// ---------------------------------------------------------------------------
+// writesTo — which argv positions of a known file-writing program name the file
+// it WRITES. Deliberately small and high-precision: an unlisted head contributes
+// no write target (the redirection half above already covers `cmd > f`), so this
+// never guesses. Anything that only READS its operands (cat/grep/…) is absent by
+// construction.
+// ---------------------------------------------------------------------------
+
+/** Options that consume a SEPARATE following token, per writer head. */
+const WRITER_VALUE_OPTS: Readonly<Record<string, ReadonlySet<string>>> = {
+  sed: new Set(["-e", "--expression", "-f", "--file", "-l", "--line-length"]),
+  truncate: new Set(["-s", "--size", "-r", "--reference"]),
+  tee: new Set(["-p", "--output-error"]),
+  install: new Set(["-m", "--mode", "-o", "--owner", "-g", "--group", "-t"]),
+  cp: new Set(["-t", "--target-directory", "-S", "--suffix"]),
+  mv: new Set(["-t", "--target-directory", "-S", "--suffix"]),
+  shred: new Set(["-n", "--iterations", "-s", "--size"]),
+  dd: new Set(),
+};
+
+/** The non-option operands of a leaf, with each option's separate value skipped. */
+function operandsOf(leaf: NormalizedLeaf): string[] {
+  const valueOpts = WRITER_VALUE_OPTS[leaf.head] ?? new Set<string>();
+  const out: string[] = [];
+  for (let i = 0; i < leaf.args.length; i++) {
+    const a = leaf.args[i];
+    if (a === undefined) continue;
+    if (a === "--") {
+      out.push(...leaf.args.slice(i + 1).filter((x) => x !== undefined));
+      break;
+    }
+    if (a.length > 1 && a.startsWith("-")) {
+      if (valueOpts.has(a)) i++; // this option's value is not an operand
+      continue;
+    }
+    out.push(a);
+  }
+  return out;
+}
+
+/**
+ * The paths a leaf WRITES, by head. Empty for anything not known to write —
+ * including every read-only command, so a read can never be mistaken for a write.
+ */
+function writeTargetsOf(leaf: NormalizedLeaf): string[] {
+  const operands = operandsOf(leaf);
+  switch (leaf.head) {
+    case "sed":
+      // Only `sed -i` edits in place; otherwise it writes to stdout. The first
+      // operand is the SCRIPT unless it was supplied via -e/-f.
+      if (!leaf.hasFlag("i", "in-place")) return [];
+      return leaf.hasFlag("e", "expression", "f", "file")
+        ? operands
+        : operands.slice(1);
+    case "cp":
+    case "mv":
+    case "install":
+      // The LAST operand is the destination; every earlier one is read.
+      return operands.length >= 2 ? operands.slice(-1) : [];
+    case "tee":
+    case "truncate":
+    case "shred":
+      return operands;
+    case "dd":
+      // `dd if=src of=dest` — only the output file is written.
+      return leaf.args.flatMap((a) =>
+        a.startsWith("of=") ? [a.slice(3)] : [],
+      );
+    default:
+      return [];
+  }
+}
+
 export function commandView(raw: string): CommandView {
   const leaves = leafCommands(raw);
+  // The operation-normalized leaves carry the redirections (and quote-unwrapped,
+  // wrapper-resolved argv) that `writesTo` needs; `leafCommands` cannot see them.
+  const normalized = leafCommandsNormalized(raw);
+  const writeTargets = normalized.flatMap((leaf) => [
+    ...leaf.redirects.flatMap((r) =>
+      r.writes && r.target !== null ? [r.target] : [],
+    ),
+    ...writeTargetsOf(leaf),
+  ]);
   return {
     raw,
     runs(program, opts) {
@@ -176,6 +290,8 @@ export function commandView(raw: string): CommandView {
       leaves.some((argv) =>
         argv.slice(1).some((tok) => prefixes.some((p) => tokenUnder(tok, p))),
       ),
+    writesTo: (prefixes) =>
+      writeTargets.some((t) => prefixes.some((p) => tokenUnder(t, p))),
     pipesToShell: () => leaves.some(isBareShellLeaf),
   };
 }

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -140,4 +140,4 @@ export type {
 // Operation-normalized leaf extraction — the robust matching primitive a
 // hardened guard is built on (see examples/harness/safe-bash-guard-v2.mjs).
 export { leafCommandsNormalized } from "./core/bash-effects.js";
-export type { NormalizedLeaf } from "./core/bash-effects.js";
+export type { NormalizedLeaf, LeafRedirect } from "./core/bash-effects.js";


### PR DESCRIPTION
## `CommandView` could not express "what does this command WRITE"

```js
leafCommandsNormalized("echo x > papers/x/paper.md")
// [{ head: "echo", argv: ["echo", "x"], args: ["x"], flags: {}, assigns: {} }]
```

The redirection and its target were **dropped by the parser** — they live on the enclosing `Stmt`, and `leafCommandsNormalized` walked `CallExpr` nodes only. The file the command actually wrote appeared in **no field of any leaf**.

Consequence: `touches(prefixes)` cannot see a redirect target, so `cmd > file` / `cmd >> file` — the single most common write shape — was invisible to a compiled gate. **A gate written to protect a directory from Bash writes was silently weaker than the `grep` it replaced.**

Worse, the only available discriminator was `isSideEffecting()`, which classifies the **whole command line**:

```
grep -c x notes/S.md 2>/dev/null
  touches(["notes"])   -> true   (the path IS mentioned)
  isSideEffecting()    -> true   (there's a redirection on the line)
  => a plain READ gets blocked
```

Measured while dogfooding on 2026-08-03: it blocked real work **twice within an hour**.

## The fix

**1. `NormalizedLeaf.redirects: readonly LeafRedirect[]`**

```ts
interface LeafRedirect {
  op: string;            // ">", ">>", ">|", "&>", "&>>", "<", "<<<", ">&", …
  target: string | null; // quote-unwrapped + $HOME-canonicalized; null when dynamic
  fd: number | null;     // `2> err.log` -> 2
  writes: boolean;       // creates/modifies the file named by `target`
}
```

`leafCommandsNormalized` now iterates `Stmt` nodes. Every `CallExpr` in the mvdan AST **is** a `Stmt.Cmd`, so exactly the same leaves are found — the existing 123 bash-effects tests pass unchanged.

A dynamic target (`> "$OUT"`) is `null` — present but unresolved, never guessed.

**2. `CommandView.writesTo(prefixes)`**

Two AST-backed sources:
- **Redirect targets** with a write op (`>`, `>>`, `>|`, `&>`, `&>>`). Input (`<`, `<<`, `<<<`) and fd-dup (`2>&1`, whose "target" is an fd) are not writes.
- **File-writing programs**, at the argv position that actually names the file: `sed -i` (skipping the script operand), `cp`/`mv`/`install` (**destination** only — sources are reads), `tee`, `dd of=`, `truncate`, `shred`. An unlisted head contributes no target, so it never guesses.

`touches` is **unchanged** — it still answers "mentioned". Both doc comments now say so explicitly, with the `grep … 2>/dev/null` case spelled out, because conflating them is exactly the trap. `docs/compiled-hooks.md` gets the same callout.

### The quoting property, pinned

```js
commandView("echo 'echo y > a/paper.md' > /tmp/note.txt")
  .writesTo(["a"])      // false — that's data inside a quoted word
  .writesTo(["/tmp"])   // true  — the real target
```

Handled by the parser, not a regex.

## Tests

- `src/core/bash-effects-normalized.test.ts` — redirect capture, append/clobber/all-streams are writes, input + fd-dups are not, explicit fd, dynamic target → `null`, `$HOME`/quotes normalized, quoted-redirection-is-data, each leaf of a compound command keeps its own redirections.
- **Op-table pin:** the mvdan op codes are bare numeric tokens with no public name mapping, so a test re-derives the whole `op → string` + write-classification table **from the installed parser**. An mvdan-sh upgrade that renumbers a token now fails loudly instead of silently reclassifying a write as a read.
- `src/core/hook-program.test.ts` — four `writesTo` suites, including the exact false-block regression (asserting `touches` **and** `isSideEffecting` are both true while `writesTo` is false) and the quoted-write property.

## API surface

`api-surface/vigiles-hook.api.md` regenerated (`npm run api:report`): `CommandView.writesTo`, `NormalizedLeaf.redirects`, and the new `LeafRedirect` type, which is exported from `vigiles/hook`.

## Checks

`npx tsc --noEmit`, `npm run lint` (0 errors), `npx prettier --check .`, `node scripts/api-extractor.mjs`, full unit suite (2348 passing).

⚠️ Pre-existing on `main`, unrelated: `src/core/spec.test.ts` › the two `pylint` cases fail locally because `pylint` isn't on this machine's PATH. CI installs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012omt6sirxNMyZN2x5RhK2u

---
_Generated by [Claude Code](https://claude.ai/code/session_012omt6sirxNMyZN2x5RhK2u)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Features**
- add CommandView.writesTo() and capture redirections
<!-- vigiles:pr-summary:end -->
