### PR TITLE
fix(compile): key hook wiring by the file, not the string you typed

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -224,6 +224,7 @@ import {
   discoverProviderFiles,
   mergeHooksJson,
   mergeHooksToml,
+  normalizeHookRef,
   serializeConfig,
 } from "./hook-install.js";
 import {
@@ -5973,8 +5974,9 @@ interface HookInstallResult {
  * outside the sanctioned API does NOT compile (capability = API surface). The
  * emitted block routes the live event to `hook-runtime run-program`; a
  * tamper-evident stamp sidecar lets the runtime refuse a hand-edited artifact.
- * The merge is idempotent (keyed by the hook PATH), so recompiling updates in
- * place and never clobbers the user's own hooks.
+ * The merge is idempotent (keyed by the hook FILE via `normalizeHookRef`, not by
+ * the string the user typed — `x.hook.ts` and `./x.hook.ts` are the same wiring),
+ * so recompiling updates in place and never clobbers the user's own hooks.
  */
 async function installHookFile(
   file: string,
@@ -5983,8 +5985,12 @@ async function installHookFile(
 ): Promise<HookInstallResult> {
   const source = readFileSync(resolve(process.cwd(), file), "utf-8");
   const program = await loadHookProgram(file);
+  // Emit the CANONICAL path so two spellings of the same file produce the same
+  // command — the merge key and the emitted command must agree, or recompiling
+  // appends a duplicate block instead of replacing the existing one.
+  const ref = normalizeHookRef(file);
   const compiled = compileHookProgram(source, program, {
-    gateCommand: `npx vigiles hook-runtime run-program ${file}`,
+    gateCommand: `npx vigiles hook-runtime run-program ${ref}`,
     dialect: adapter.dialect,
     hookProtocol: adapter.hookProtocol,
     settingsFormat: adapter.layout.settingsFormat,
@@ -6014,8 +6020,8 @@ async function installHookFile(
     : {};
   const merged =
     format === "toml"
-      ? mergeHooksToml(existing, compiled.hooks, file)
-      : mergeHooksJson(existing, compiled.hooks, file);
+      ? mergeHooksToml(existing, compiled.hooks, ref)
+      : mergeHooksJson(existing, compiled.hooks, ref);
   mkdirSync(dirname(settingsAbs), { recursive: true });
   writeFileSync(settingsAbs, serializeConfig(merged, format));
 

--- a/src/hook-install.test.ts
+++ b/src/hook-install.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   mergeHooksJson,
   mergeHooksToml,
+  normalizeHookRef,
   serializeConfig,
   discoverHookFiles,
 } from "./hook-install.js";
@@ -53,6 +54,69 @@ describe("mergeHooksJson", () => {
     expect(twice.hooks?.PreToolUse).toHaveLength(1);
   });
 
+  // Measured 2026-08-03: `vigiles compile x.hook.ts` then
+  // `vigiles compile ./x.hook.ts` appended a SECOND {matcher, hooks:[…]} block
+  // for the same hook, because the merge key was the raw string the user typed
+  // and `"… run-program x.hook.mjs".includes("./x.hook.mjs")` is false. A few
+  // edit-compile iterations left duplicate wirings that all fire.
+  it("is idempotent across path SPELLINGS of the same file", () => {
+    const spellings = [
+      ".vigiles/hooks/g.mjs",
+      "./.vigiles/hooks/g.mjs",
+      ".vigiles//hooks/g.mjs",
+      ".vigiles/hooks/../hooks/g.mjs",
+      join(process.cwd(), ".vigiles/hooks/g.mjs"),
+    ];
+    let settings = mergeHooksJson({}, compiled, spellings[0] ?? "");
+    for (const spelling of spellings.slice(1)) {
+      settings = mergeHooksJson(settings, compiled, spelling);
+    }
+    expect(settings.hooks?.PreToolUse).toHaveLength(1);
+  });
+
+  it("replaces an entry written with a DIFFERENT spelling (migrates old dupes)", () => {
+    const legacy = {
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Bash",
+            hooks: [
+              {
+                type: "command" as const,
+                command:
+                  "npx vigiles hook-runtime run-program ./.vigiles/hooks/g.mjs",
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const out = mergeHooksJson(legacy, compiled, ".vigiles/hooks/g.mjs");
+    expect(out.hooks?.PreToolUse).toHaveLength(1);
+  });
+
+  it("does NOT treat a path that merely CONTAINS ours as the same hook", () => {
+    // The old substring test said `my-g.mjs` was managed by `g.mjs`.
+    const neighbour = {
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Bash",
+            hooks: [
+              {
+                type: "command" as const,
+                command:
+                  "npx vigiles hook-runtime run-program .vigiles/hooks/my-g.mjs",
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const out = mergeHooksJson(neighbour, compiled, ".vigiles/hooks/g.mjs");
+    expect(out.hooks?.PreToolUse).toHaveLength(2);
+  });
+
   it("keeps a sibling vigiles hook for a DIFFERENT file", () => {
     const other = {
       PreToolUse: [
@@ -96,6 +160,37 @@ describe("mergeHooksToml", () => {
     const once = mergeHooksToml({}, compiled, ".vigiles/hooks/g.mjs");
     const twice = mergeHooksToml(once, compiled, ".vigiles/hooks/g.mjs");
     expect(twice.hooks?.PreToolUse).toHaveLength(1);
+  });
+
+  it("is idempotent across path spellings too", () => {
+    const once = mergeHooksToml({}, compiled, "./.vigiles/hooks/g.mjs");
+    const twice = mergeHooksToml(once, compiled, ".vigiles/hooks/g.mjs");
+    expect(twice.hooks?.PreToolUse).toHaveLength(1);
+  });
+});
+
+describe("normalizeHookRef", () => {
+  it("canonicalizes every spelling of one file to the same ref", () => {
+    const cwd = process.cwd();
+    const refs = [
+      ".vigiles/hooks/g.mjs",
+      "./.vigiles/hooks/g.mjs",
+      ".vigiles/hooks/../hooks/g.mjs",
+      join(cwd, ".vigiles/hooks/g.mjs"),
+    ].map((p) => normalizeHookRef(p, cwd));
+    expect(new Set(refs).size).toBe(1);
+    expect(refs[0]).toBe(".vigiles/hooks/g.mjs");
+  });
+
+  it("keeps a path outside the cwd absolute (still stable)", () => {
+    const cwd = join(tmpdir(), "vig-cwd");
+    const ref = normalizeHookRef(join(tmpdir(), "elsewhere/h.mjs"), cwd);
+    expect(ref.endsWith("elsewhere/h.mjs")).toBe(true);
+    expect(normalizeHookRef(ref, cwd)).toBe(ref); // idempotent
+  });
+
+  it("emits POSIX separators so the ref is platform-stable", () => {
+    expect(normalizeHookRef(".vigiles/hooks/g.mjs")).not.toMatch(/\\/);
   });
 });
 

--- a/src/hook-install.ts
+++ b/src/hook-install.ts
@@ -10,12 +10,14 @@
  * result into the active harness's native config (`.claude/settings.json` JSON
  * / `config.toml` TOML) — so the harness is actually wired, not handed a
  * paste-this block. The merge is idempotent: an entry is keyed by the runtime
- * command's hook PATH, so recompiling updates in place and never duplicates,
- * while a user's own hand-written hooks are preserved untouched. One source dir
- * also means basenames are unique, so the stamp can key on the basename safely.
+ * command's hook path, CANONICALIZED ({@link normalizeHookRef}) so it identifies
+ * the FILE rather than the string the user typed — recompiling updates in place
+ * and never duplicates, while a user's own hand-written hooks are preserved
+ * untouched. One source dir also means basenames are unique, so the stamp can key
+ * on the basename safely.
  */
 import { readdirSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative, resolve, sep } from "node:path";
 import { stringify as stringifyToml } from "@iarna/toml";
 
 /** The agnostic, committed home for hook SOURCE — one dir, cross-adapter. */
@@ -63,9 +65,46 @@ interface SettingsJson {
   [k: string]: unknown;
 }
 
-/** True when an entry's command routes through the runtime for `hookPath`. */
+/**
+ * The CANONICAL form of a hook-source reference — how the path is written into
+ * the emitted runtime command AND how an existing entry is recognized as "this
+ * hook", so the merge is keyed by the FILE, not by the string the user typed.
+ *
+ * Without this, `vigiles compile x.hook.ts` and `vigiles compile ./x.hook.ts`
+ * wired the SAME file twice: the second run's `hookPath` (`./x.hook.ts`) wasn't a
+ * substring of the first run's command (`… run-program x.hook.ts`), so nothing
+ * was replaced and a second `{matcher, hooks:[…]}` block was appended. A few
+ * iterations of an edit-compile loop left duplicate wirings that all fire.
+ *
+ * Canonical = POSIX separators, no `./` prefix, resolved against the cwd and made
+ * relative when it lives under it (an absolute path outside the repo is kept
+ * absolute — still stable, just not relative to anything).
+ */
+export function normalizeHookRef(
+  hookPath: string,
+  cwd = process.cwd(),
+): string {
+  const abs = resolve(cwd, hookPath);
+  const rel = relative(cwd, abs);
+  const chosen = rel === "" || rel.startsWith("..") ? abs : rel;
+  return chosen.split(sep).join("/");
+}
+
+/**
+ * True when an entry's command routes through the runtime for `hookPath`.
+ *
+ * Compares CANONICALIZED path tokens rather than testing for a raw substring:
+ * `./x.hook.ts` and `x.hook.ts` are the same file (so the entry is replaced,
+ * which also de-duplicates settings written by an older version), while
+ * `x.hook.ts` and `my-x.hook.ts` are not (a substring test said they were).
+ */
 function managesHook(entry: HookEntry, hookPath: string): boolean {
-  return entry.hooks.some((h) => h.command.includes(hookPath));
+  const ref = normalizeHookRef(hookPath);
+  return entry.hooks.some((h) =>
+    h.command
+      .split(/\s+/)
+      .some((token) => token !== "" && normalizeHookRef(token) === ref),
+  );
 }
 
 /**
@@ -115,8 +154,9 @@ export function mergeHooksToml(
 ): ConfigToml {
   const hooks: Record<string, TomlHookEntry[]> = { ...(existing.hooks ?? {}) };
   for (const [event, entries] of Object.entries(compiled)) {
+    // Same canonical-path keying as the JSON merge (one flat command per entry).
     const kept = (hooks[event] ?? []).filter(
-      (e) => !e.command.includes(hookPath),
+      (e) => !managesHook({ hooks: [{ type: "command", command: e.command }] }, hookPath), // prettier-ignore
     );
     hooks[event] = [...kept, ...toTomlEntries(entries)];
   }

--- a/src/hook.test.ts
+++ b/src/hook.test.ts
@@ -231,6 +231,54 @@ test("compile (hook): a clean hook compiles, MERGES into settings.json, stamps, 
   }
 });
 
+// Measured 2026-08-03: recompiling the same hook under a different path
+// SPELLING appended a SECOND {matcher, hooks:[…]} block instead of replacing the
+// existing one, because the wiring was keyed by the raw string the user typed. A
+// few edit-compile iterations left duplicate wirings that ALL fire.
+test("compile (hook): recompiling is idempotent, whatever the path spelling", () => {
+  const dir = makeTmpDir();
+  try {
+    linkVigiles(dir);
+    writeFileSync(resolve(dir, "guard.mjs"), GATE_PKG);
+    const compile = (arg: string) =>
+      spawnSync("node", [CLI, "compile", arg], { cwd: dir, encoding: "utf-8" });
+
+    for (const spelling of [
+      "guard.mjs",
+      "./guard.mjs",
+      resolve(dir, "guard.mjs"),
+      "./guard.mjs",
+    ]) {
+      const r = compile(spelling);
+      assert.equal(r.status, 0, r.stderr);
+    }
+
+    const settings = JSON.parse(
+      readFileSync(resolve(dir, ".claude/settings.json"), "utf-8"),
+    ) as { hooks: Record<string, { hooks: { command: string }[] }[]> };
+    const entries = settings.hooks.PreToolUse;
+    assert.equal(entries.length, 1, "one wiring per hook file, not four");
+    assert.equal(
+      entries[0].hooks[0].command,
+      "npx vigiles hook-runtime run-program guard.mjs",
+    );
+
+    // And the single surviving wiring still enforces.
+    const blocked = runHook(
+      `node ${CLI} hook-runtime run-program guard.mjs`,
+      {
+        hook_event_name: "PreToolUse",
+        tool_name: "Bash",
+        tool_input: { command: "git push -f" },
+      },
+      { cwd: dir },
+    );
+    assert.equal(blocked.blocked, true);
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});
+
 test("compile --harness=codex (hook): merges TOML for a gate, warns LOUDLY on inject (the honest gap)", () => {
   const dir = makeTmpDir();
   try {


### PR DESCRIPTION
## `vigiles compile` was not idempotent

Reproduced on `main` (2026-08-03):

```console
$ vigiles compile x.hook.mjs
$ vigiles compile ./x.hook.mjs        # same file, different spelling
$ cat .claude/settings.json
{
  "hooks": { "PreToolUse": [
    { "matcher": "Bash", "hooks": [{ "type": "command",
      "command": "npx vigiles hook-runtime run-program x.hook.mjs" }] },
    { "matcher": "Bash", "hooks": [{ "type": "command",
      "command": "npx vigiles hook-runtime run-program ./x.hook.mjs" }] }
  ] }
}
```

A **second** block for the same hook, not a replacement. After a few iterations of an edit-compile loop the settings file accumulates duplicate wirings that all fire.

### Root cause

The merge key was the raw path string the user passed; the emitted command carried that same string; and `managesHook` tested for a **substring**:

```ts
h.command.includes(hookPath)
// "… run-program x.hook.mjs".includes("./x.hook.mjs")  ->  false
```

so nothing matched and the entry was appended. The same substring test had the mirror-image bug in the other direction: `x.hook.mjs` "managed" a neighbouring `my-x.hook.mjs` and would have deleted its wiring.

Discovery discipline hid it in the common case — `vigiles compile` with no args always yields `.vigiles/hooks/<name>` — so it only bites when you pass a path explicitly, which is exactly what an edit-compile loop does.

## The fix

`normalizeHookRef(path, cwd?)` canonicalizes a hook reference: resolved against the cwd, made relative when it lives under it (kept absolute otherwise), POSIX separators, no `./`.

- `compile` emits the **canonical** ref in the runtime command **and** uses it as the merge key — the two must agree or the next run appends.
- `managesHook` compares **canonicalized whitespace-separated tokens** of the command instead of testing for a substring.

Consequences: every spelling of one file is one wiring; `my-x.hook.mjs` is correctly a different hook; and a settings file already carrying a differently-spelled entry (written by an older version) is **de-duplicated** on the next compile rather than gaining a third. The TOML (Codex) merge goes through the same predicate.

### Verified end-to-end

Four `compile` runs over `guard.mjs`, `./guard.mjs`, and the absolute path leave exactly one entry — `npx vigiles hook-runtime run-program guard.mjs` — and it still blocks `git push -f`.

## Tests

- `src/hook-install.test.ts` — idempotent across five spellings (`./`, doubled separator, `../` round-trip, absolute); replaces a differently-spelled legacy entry; does **not** treat `my-g.mjs` as managed by `g.mjs`; TOML sibling; plus `normalizeHookRef` unit tests (canonical collapse, out-of-cwd stays absolute and is idempotent, POSIX separators).
- `src/hook.test.ts` — the end-to-end CLI regression: four compiles, three spellings, one surviving wiring that still enforces.

## Checks

`npx tsc --noEmit`, `npm run lint` (0 errors), `npx prettier --check .`, `node scripts/api-extractor.mjs` (no drift), full unit suite (2343 passing).

⚠️ Pre-existing on `main`, unrelated: the two `pylint` cases in `src/core/spec.test.ts` fail locally because `pylint` isn't on this machine's PATH. CI installs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012omt6sirxNMyZN2x5RhK2u

---
_Generated by [Claude Code](https://claude.ai/code/session_012omt6sirxNMyZN2x5RhK2u)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Fixes**
- key hook wiring by the FILE, not the string you typed
<!-- vigiles:pr-summary:end -->
