### PR TITLE
feat(testing): export loadHook + add assertHookNotices / assertHookSilent

### DIFF
--- a/api-surface/vigiles-e2e.api.md
+++ b/api-surface/vigiles-e2e.api.md
@@ -49,6 +49,12 @@ export function assertHookFired(trace: Trace, name: string | RegExp, opts?: {
 }): void;
 
 // @public
+export function assertHookNotices(hook: AnyHook, event: RawHookEvent, matcher?: string | RegExp): void;
+
+// @public
+export function assertHookSilent(hook: AnyHook, event: RawHookEvent): void;
+
+// @public
 export function assertImproves(report: EvalReport, opts: {
     baseline: string;
     arm: string;
@@ -409,6 +415,9 @@ export type JudgeFn = (opts: {
 export function latency(opts: {
     maxMs: number;
 }): Check<UsageTrace>;
+
+// @public
+export function loadHook(file: string): Promise<AnyHook>;
 
 // @public
 export function mcp(server: string, toolName: string): Check<Trace>;

--- a/api-surface/vigiles-integration.api.md
+++ b/api-surface/vigiles-integration.api.md
@@ -49,6 +49,12 @@ export function assertHookFired(trace: Trace, name: string | RegExp, opts?: {
 }): void;
 
 // @public
+export function assertHookNotices(hook: AnyHook, event: RawHookEvent, matcher?: string | RegExp): void;
+
+// @public
+export function assertHookSilent(hook: AnyHook, event: RawHookEvent): void;
+
+// @public
 export function assertImproves(report: EvalReport, opts: {
     baseline: string;
     arm: string;
@@ -409,6 +415,9 @@ export type JudgeFn = (opts: {
 export function latency(opts: {
     maxMs: number;
 }): Check<UsageTrace>;
+
+// @public
+export function loadHook(file: string): Promise<AnyHook>;
 
 // @public
 export function mcp(server: string, toolName: string): Check<Trace>;

--- a/api-surface/vigiles-testing.api.md
+++ b/api-surface/vigiles-testing.api.md
@@ -124,6 +124,12 @@ export function assertHookFired(trace: Trace, name: string | RegExp, opts?: {
 }): void;
 
 // @public
+export function assertHookNotices(hook: AnyHook, event: RawHookEvent, matcher?: string | RegExp): void;
+
+// @public
+export function assertHookSilent(hook: AnyHook, event: RawHookEvent): void;
+
+// @public
 export function assertImproves(report: EvalReport, opts: {
     baseline: string;
     arm: string;
@@ -572,6 +578,9 @@ export type JudgeFn = (opts: {
 export function latency(opts: {
     maxMs: number;
 }): Check<UsageTrace>;
+
+// @public
+export function loadHook(file: string): Promise<AnyHook>;
 
 // @public
 export function mcp(server: string, toolName: string): Check<Trace>;

--- a/api-surface/vigiles-unit.api.md
+++ b/api-surface/vigiles-unit.api.md
@@ -49,6 +49,12 @@ export function assertHookFired(trace: Trace, name: string | RegExp, opts?: {
 }): void;
 
 // @public
+export function assertHookNotices(hook: AnyHook, event: RawHookEvent, matcher?: string | RegExp): void;
+
+// @public
+export function assertHookSilent(hook: AnyHook, event: RawHookEvent): void;
+
+// @public
 export function assertImproves(report: EvalReport, opts: {
     baseline: string;
     arm: string;
@@ -355,6 +361,9 @@ export type JudgeFn = (opts: {
 export function latency(opts: {
     maxMs: number;
 }): Check<UsageTrace>;
+
+// @public
+export function loadHook(file: string): Promise<AnyHook>;
 
 // @public
 export function mcp(server: string, toolName: string): Check<Trace>;

--- a/docs/compiled-hooks.md
+++ b/docs/compiled-hooks.md
@@ -242,12 +242,13 @@ Hooks are **not** auto-discovered by sitting just anywhere — they must be unde
 
 **Because the decision is a pure function, you test it deterministically** — no model, and (cheapest) no subprocess. Three levels, by cost:
 
-**1. In-process (cheapest).** Pass the hook and a raw event to `assertHookDenies` / `assertHookAllows` — no `node` spawn, no CLI, milliseconds:
+**1. In-process (cheapest).** Load the hook FILE with `loadHook(path)` and pass it plus a raw event to the assertions — no `node` spawn, no CLI, milliseconds:
 
 ```ts
 import { it } from "vitest";
-import { assertHookDenies, assertHookAllows } from "vigiles/unit";
-import guard from "./safe-bash-guard.mjs"; // the hook's default export
+import { loadHook, assertHookDenies, assertHookAllows } from "vigiles/testing";
+
+const guard = await loadHook(".vigiles/hooks/guard.mjs");
 
 it("blocks a force-push, even hidden in a compound command", () => {
   assertHookDenies(guard, {
@@ -260,6 +261,28 @@ it("blocks a force-push, even hidden in a compound command", () => {
   });
 });
 ```
+
+`loadHook` is the same loader the runtime uses (so a hook that loads in a test loads identically in production) and it is what makes this tier reachable from a `.harness.mjs` file, which has a hook's PATH and not its object. A TypeScript hook (`guard.hook.ts`) loads the same way under tsx / Node ≥ 23.6. If you already have the object — a static `import guard from "./guard.mjs"` — pass it directly.
+
+**React hooks get their own pair.** A react can't block, so the gate assertions don't apply; use `assertHookNotices(hook, event, matcher?)` and `assertHookSilent(hook, event)`:
+
+```ts
+import { assertHookNotices, assertHookSilent } from "vigiles/testing";
+
+const warn = await loadHook(".vigiles/hooks/warn-on-failure.mjs");
+const after = (isError) => ({
+  tool_name: "Bash",
+  tool_input: { command: "npm test" },
+  tool_response: isError ? { error: "boom" } : { stdout: "ok" },
+});
+
+assertHookNotices(warn, after(true), /read the error/);
+assertHookSilent(warn, after(false));
+```
+
+> ⚠️ **Don't test a react hook by reading stdout.** `notice(…)` writes to **stderr**, so a probe built on `execFileSync` (which returns stdout only) sees nothing and reports a perfectly healthy react hook as **dead**. These assertions read the reaction itself, so the stream never enters into it.
+
+Runnable end to end: [`examples/harness/compiled-hook-inprocess.harness.mjs`](../examples/harness/compiled-hook-inprocess.harness.mjs) (with its two hook files) is exactly this pattern, and runs in CI.
 
 `runHookProgram(hook, event)` is the underlying primitive — it returns a normalized outcome (`{ kind: "decision" | "injection" | "reaction", … }`) dispatched by role, so an inject or react hook is just as testable as a gate.
 

--- a/docs/testing-api.md
+++ b/docs/testing-api.md
@@ -95,11 +95,18 @@ default export and a raw event:
 
 ```ts
 import {
+  loadHook,
   assertHookDenies,
   assertHookAllows,
+  assertHookNotices,
+  assertHookSilent,
   runHookProgram,
-} from "vigiles/unit";
-import guard from "./safe-bash-guard.mjs";
+} from "vigiles/testing";
+
+// loadHook takes the hook's PATH — what a .harness.mjs file actually has. It is
+// the same loader the runtime uses, and it handles a .hook.ts under tsx / Node
+// >= 23.6. Already holding the object (a static import)? Pass it directly.
+const guard = await loadHook(".vigiles/hooks/guard.mjs");
 
 assertHookDenies(guard, {
   tool_name: "Bash",
@@ -109,6 +116,13 @@ assertHookAllows(guard, {
   tool_name: "Bash",
   tool_input: { command: "git status" },
 });
+
+// A REACT hook can't block, so it gets its own pair. NB `notice()` writes to
+// STDERR — a probe that reads stdout reports a healthy react hook as dead.
+// These read the reaction itself.
+const warn = await loadHook(".vigiles/hooks/warn-on-failure.mjs");
+assertHookNotices(warn, failedBashEvent, /read the error/); // message matcher optional
+assertHookSilent(warn, successfulBashEvent);
 
 // the raw primitive: a normalized, role-dispatched outcome
 runHookProgram(guard, event); // → { kind: "decision" | "injection" | "reaction", … }

--- a/examples/harness/compiled-hook-inprocess.harness.mjs
+++ b/examples/harness/compiled-hook-inprocess.harness.mjs
@@ -1,0 +1,59 @@
+/**
+ * Canonical example — testing a COMPILED hook IN-PROCESS.
+ *
+ * The cheapest tier there is: a compiled hook's decision is a pure function, so
+ * a test can load the hook FILE and call it directly — no subprocess, no exit
+ * codes, no JSON plumbing, no `claude` binary, milliseconds.
+ *
+ *   loadHook(path)  ->  the hook object
+ *   assertHookDenies / assertHookAllows      (gates)
+ *   assertHookNotices / assertHookSilent     (reacts)
+ *
+ * Contrast with `hook-unit.harness.mjs`, which drives a hook as a PROCESS via
+ * `runHook`. That tier is still the right one for a hand-written shell hook, or
+ * to prove the WIRED artifact behaves end to end. For a compiled hook's LOGIC,
+ * this one is strictly cheaper.
+ *
+ *   npx vigiles test examples/harness/compiled-hook-inprocess.harness.mjs
+ *   node examples/harness/compiled-hook-inprocess.harness.mjs   # standalone
+ *
+ * External users import from the package: `from "vigiles/testing"`. A hook
+ * authored in TypeScript (`guard.hook.ts`) loads the same way, under tsx or
+ * Node >= 23.6.
+ */
+import {
+  loadHook,
+  assertHookDenies,
+  assertHookAllows,
+  assertHookNotices,
+  assertHookSilent,
+} from "../../dist/testing.js";
+
+// --- a GATE: load it by path, assert over its decisions ---------------------
+
+const guard = await loadHook("examples/harness/protect-main.hook.mjs");
+
+const bash = (command) => ({ tool_name: "Bash", tool_input: { command } });
+
+assertHookDenies(guard, bash("git push --force origin main"));
+// The matcher is AST-backed, so the compound-command bypass is caught too.
+assertHookDenies(guard, bash("cd repo && git commit -am wip && git push -f"));
+assertHookAllows(guard, bash("git push origin main"));
+assertHookAllows(guard, bash("git status"));
+console.log("  ✓ gate: denies a force-push (however wrapped), allows the rest");
+
+// --- a REACT: its notice goes to STDERR, so assert the REACTION, not output --
+
+const warn = await loadHook("examples/harness/warn-on-failure.hook.mjs");
+
+const afterBash = (isError) => ({
+  tool_name: "Bash",
+  tool_input: { command: "npm test" },
+  tool_response: isError ? { error: "boom" } : { stdout: "ok" },
+});
+
+assertHookNotices(warn, afterBash(true), /read the error/);
+assertHookSilent(warn, afterBash(false));
+console.log("  ✓ react: notices on a failure, stays silent on success");
+
+console.log("\n6 passed.");

--- a/examples/harness/protect-main.hook.mjs
+++ b/examples/harness/protect-main.hook.mjs
@@ -1,0 +1,19 @@
+/**
+ * A compiled hook, exactly as you'd author it — a pure `(event) => Decision`
+ * against the closed `vigiles/hook` vocabulary. It is the SUBJECT of
+ * `compiled-hook-inprocess.harness.mjs`, which loads this file by PATH and
+ * asserts over its decisions in-process (no subprocess, no model).
+ *
+ * External users import from the package (`from "vigiles/hook"`); in-repo
+ * examples point at the built dist so they run straight from a clone.
+ */
+import { defineHook, tool, deny, allow } from "../../dist/hook.js";
+
+export default defineHook({
+  on: "PreToolUse",
+  match: tool("Bash"),
+  decide: (e) =>
+    e.command.runs("git push", { force: true })
+      ? deny("no force-push to a protected branch")
+      : allow(),
+});

--- a/examples/harness/warn-on-failure.hook.mjs
+++ b/examples/harness/warn-on-failure.hook.mjs
@@ -1,0 +1,19 @@
+/**
+ * A compiled REACT hook — it fires after the tool ran, so it can't block; it
+ * emits a `notice(…)` instead. The subject of the react half of
+ * `compiled-hook-inprocess.harness.mjs`.
+ *
+ * Why testing this in-process matters: a notice goes to **stderr**. A probe that
+ * shells out and reads stdout sees nothing and concludes the hook is dead, when
+ * it is working perfectly. `assertHookNotices` reads the reaction itself.
+ */
+import { defineReact, tools, notice, nothing } from "../../dist/hook.js";
+
+export default defineReact({
+  on: "PostToolUse",
+  match: tools("Bash"),
+  react: (e) =>
+    e.response.isError()
+      ? notice("that command failed — read the error before retrying")
+      : nothing(),
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -291,6 +291,7 @@ import { adoptMarkdown, adoptSkill, adoptAgent } from "./core/adopt.js";
 import { computeScriptCoverage } from "./core/coverage.js";
 import { findOrphanDocs, formatOrphanReport } from "./core/orphans.js";
 import { findDocRefs, formatDocRefReport } from "./core/doc-refs.js";
+import { loadHook } from "./load-hook.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -5870,39 +5871,11 @@ function refsHookCommand(): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Load a compiled-hook program's default export. JS module formats
- * (`.mjs`/`.cjs`/`.js`) load via dynamic import directly; a TypeScript hook
- * loads only under a TS-capable runtime (tsx / Node >= 23.6) — otherwise an
- * actionable error points at authoring it as `.mjs`.
+ * Load a compiled-hook program's default export — the SHARED loader, also the
+ * public `vigiles/testing` `loadHook` a `.harness.mjs` test uses, so a hook that
+ * loads in a test loads identically here (one loader, no drift).
  */
-async function loadHookProgram(file: string): Promise<AnyHook> {
-  const abs = resolve(process.cwd(), file);
-  const { pathToFileURL } = require("node:url") as typeof import("node:url");
-  let mod: { default?: unknown };
-  try {
-    mod = (await import(pathToFileURL(abs).href)) as { default?: unknown };
-  } catch (e) {
-    if (/\.(?:m|c)?ts$/.test(file)) {
-      throw new HookCompileError(
-        `Cannot load TypeScript hook "${file}" in this Node runtime. Run under ` +
-          `tsx (npx tsx …) / Node >= 23.6, or author the hook as a .mjs file.`,
-      );
-    }
-    throw new HookCompileError(
-      `Cannot load hook "${file}": ${(e as Error).message}`,
-    );
-  }
-  // Unwrap the ESM/CJS double-default that `export default` can produce.
-  const program =
-    (mod.default as { default?: unknown } | undefined)?.default ?? mod.default;
-  if (!program || typeof program !== "object") {
-    throw new HookCompileError(
-      `${file} has no default-exported hook program ` +
-        `(use \`export default defineHook({…})\`).`,
-    );
-  }
-  return program as AnyHook;
-}
+const loadHookProgram = loadHook;
 
 /** Load a registered provider (`.vigiles/providers/<name>`) → its definition. */
 async function loadProvider(file: string): Promise<RegisteredProvider> {

--- a/src/harness-assert.test.ts
+++ b/src/harness-assert.test.ts
@@ -22,6 +22,8 @@ import {
   assertHookAllowed,
   assertHookDenies,
   assertHookAllows,
+  assertHookNotices,
+  assertHookSilent,
   assertNoEgress,
   assertEgressOnly,
   egressHosts,
@@ -57,6 +59,8 @@ import {
   inject,
   defineReact,
   run,
+  notice,
+  nothing,
   tools,
 } from "./core/hook-program.js";
 import type { Check } from "./check.js";
@@ -785,4 +789,81 @@ test("assertHookDenies / assertHookAllows test a compiled hook in-process (no su
       tool_input: { file_path: "x.ts" },
     });
   }, /got run \(a reaction\)/);
+});
+
+// A react hook can't block, so the gate assertions don't apply to it — and until
+// now nothing else did either. `notice()` writes to STDERR, which is a live trap:
+// a probe built on `execFileSync` (stdout only) reported three perfectly healthy
+// react hooks as DEAD on 2026-08-03. These read the reaction in-process, so
+// stdout-vs-stderr never enters into it.
+test("assertHookNotices / assertHookSilent test a react hook in-process", () => {
+  const warnOnFailure = defineReact({
+    on: "PostToolUse",
+    match: tools("Bash"),
+    react: (e) =>
+      e.response.isError() ? notice("that command failed — check the log") : nothing(), // prettier-ignore
+  });
+  const ev = (isError: boolean) => ({
+    tool_name: "Bash",
+    tool_input: { command: "npm test" },
+    tool_response: isError ? { error: "boom" } : { stdout: "ok" },
+  });
+
+  assert.doesNotThrow(() => {
+    assertHookNotices(warnOnFailure, ev(true));
+  });
+  assert.doesNotThrow(() => {
+    assertHookSilent(warnOnFailure, ev(false));
+  });
+
+  // The message can be pinned by substring OR regexp.
+  assert.doesNotThrow(() => {
+    assertHookNotices(warnOnFailure, ev(true), "check the log");
+  });
+  assert.doesNotThrow(() => {
+    assertHookNotices(warnOnFailure, ev(true), /failed/);
+  });
+  assert.throws(() => {
+    assertHookNotices(warnOnFailure, ev(true), "totally different");
+  }, /expected the notice to match totally different, got "that command failed/);
+  assert.throws(() => {
+    assertHookNotices(warnOnFailure, ev(true), /^nope$/);
+  }, /expected the notice to match/);
+
+  // Each assertion throws loudly on the other outcome (never a silent pass).
+  assert.throws(() => {
+    assertHookNotices(warnOnFailure, ev(false));
+  }, /expected the hook to notice, got none \(a reaction\)/);
+  assert.throws(() => {
+    assertHookSilent(warnOnFailure, ev(true));
+  }, /expected the hook to stay silent, got notice \(a reaction\)/);
+
+  // A `run(…)` reaction is not silence — the hook still reacted.
+  const formatOnWrite = defineReact({
+    on: "PostToolUse",
+    match: tools("Write"),
+    react: () => run("prettier --write x"),
+  });
+  assert.throws(() => {
+    assertHookSilent(formatOnWrite, {
+      tool_name: "Write",
+      tool_input: { file_path: "x.ts" },
+    });
+  }, /expected the hook to stay silent, got run \(a reaction\)/);
+
+  // Aimed at the wrong ROLE, both name what they got instead of passing.
+  const guard = defineHook({
+    on: "PreToolUse",
+    match: tool("Bash"),
+    decide: () => allow(),
+  });
+  assert.throws(() => {
+    assertHookNotices(guard, { tool_name: "Bash", tool_input: { command: "x" } }); // prettier-ignore
+  }, /expected the hook to notice, got allow \(a gate decision\)/);
+  assert.throws(() => {
+    assertHookSilent(guard, {
+      tool_name: "Bash",
+      tool_input: { command: "x" },
+    });
+  }, /expected a react hook, got allow \(a gate decision\)/);
 });

--- a/src/harness-assert.ts
+++ b/src/harness-assert.ts
@@ -166,6 +166,57 @@ export function assertHookAllows(hook: AnyHook, event: RawHookEvent): void {
   }
 }
 
+/**
+ * Assert a COMPILED **react** hook emits a `notice(…)` for an event, optionally
+ * matching its message — the react-tier twin of {@link assertHookDenies}.
+ *
+ * A react hook can't block, so the gate assertions don't apply to it, and there
+ * was no assertion that did. That left `notice()` a live trap: its message goes
+ * to **stderr**, so a probe built on `execFileSync` (which returns stdout only)
+ * sees nothing and reports a perfectly healthy react hook as DEAD — measured
+ * against three real hooks on 2026-08-03. Reading the reaction in-process means
+ * stdout-vs-stderr never enters into it.
+ */
+export function assertHookNotices(
+  hook: AnyHook,
+  event: RawHookEvent,
+  matcher?: string | RegExp,
+): void {
+  const o = runHookProgram(hook, event);
+  if (o.kind !== "reaction" || o.reaction.kind !== "notice") {
+    fail(`expected the hook to notice, got ${describeOutcome(o)}`);
+  }
+  if (matcher === undefined) return;
+  const { message } = o.reaction;
+  const matched =
+    typeof matcher === "string"
+      ? message.includes(matcher)
+      : matcher.test(message);
+  if (!matched) {
+    fail(
+      `expected the notice to match ${String(matcher)}, got ${JSON.stringify(message)}`,
+    );
+  }
+}
+
+/**
+ * Assert a COMPILED **react** hook stays silent for an event — it returns
+ * `nothing()` (a `"none"` reaction). The twin of {@link assertHookNotices}: together they pin both
+ * halves of a react hook's behaviour — it fires when it should, and (the half
+ * that actually regresses) it does NOT fire when it shouldn't.
+ *
+ * A `run(…)` reaction is not silent for this purpose: the hook still reacted.
+ */
+export function assertHookSilent(hook: AnyHook, event: RawHookEvent): void {
+  const o = runHookProgram(hook, event);
+  if (o.kind !== "reaction") {
+    fail(`expected a react hook, got ${describeOutcome(o)}`);
+  }
+  if (o.reaction.kind !== "none") {
+    fail(`expected the hook to stay silent, got ${describeOutcome(o)}`);
+  }
+}
+
 // --- egress (network) — recordEgress runs ----------------------------------
 //
 // A `runHook(..., { recordEgress: true })` confines the hook AND records every

--- a/src/load-hook.test.ts
+++ b/src/load-hook.test.ts
@@ -1,0 +1,125 @@
+/**
+ * `loadHook` — the public compiled-hook loader (vitest).
+ *
+ * The in-process assertions take the hook OBJECT, but a `.harness.mjs` test only
+ * has its PATH. Until this was exported the intended in-process test path was
+ * unreachable from the file format `vigiles test` runs, so authors spawned the
+ * runtime as a subprocess instead — the plumbing compiled hooks exist to remove.
+ *
+ * These drive the loader over REAL files on disk (it's an ESM dynamic import;
+ * there is nothing to fake) and pin the error messages, which are the whole
+ * reason a loader is public rather than a one-line `await import()`.
+ */
+import { test } from "vitest";
+import assert from "node:assert/strict";
+import { writeFileSync } from "node:fs";
+import { resolve, relative } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { loadHook } from "./load-hook.js";
+import { HookCompileError } from "./core/hook-program.js";
+import { assertHookDenies, assertHookAllows } from "./harness-assert.js";
+import { makeTmpDir, cleanupTmpDir } from "./core/test-utils.js";
+
+const HOOK_DIST = pathToFileURL(
+  resolve(__dirname, "..", "dist", "hook.js"),
+).href;
+
+const GATE = `import { defineHook, tool, deny, allow } from "${HOOK_DIST}";
+export default defineHook({
+  on: "PreToolUse",
+  match: tool("Bash"),
+  decide: (e) =>
+    e.command.runs("git push", { force: true }) ? deny("no force-push") : allow(),
+});`;
+
+test("loadHook: a loaded hook feeds the in-process assertions directly", async () => {
+  const dir = makeTmpDir();
+  try {
+    const file = resolve(dir, "guard.mjs");
+    writeFileSync(file, GATE);
+
+    // THE pattern a .harness.mjs test uses: path in, assertions over the object.
+    const guard = await loadHook(file);
+    assertHookDenies(guard, {
+      tool_name: "Bash",
+      tool_input: { command: "git push --force origin main" },
+    });
+    assertHookAllows(guard, {
+      tool_name: "Bash",
+      tool_input: { command: "git status" },
+    });
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});
+
+test("loadHook: resolves a RELATIVE path against the cwd, not against this module", async () => {
+  const dir = makeTmpDir();
+  try {
+    const abs = resolve(dir, "guard.mjs");
+    writeFileSync(abs, GATE);
+    // The path a .harness.mjs test would actually pass — relative to where the
+    // test process runs, not to the loader's own file.
+    const rel = relative(process.cwd(), abs);
+    assert.ok(!rel.startsWith("/"), "the fixture path must be relative");
+    const guard = await loadHook(rel);
+    assertHookAllows(guard, {
+      tool_name: "Bash",
+      tool_input: { command: "git status" },
+    });
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});
+
+test("loadHook: a module with no default export fails with an actionable error", async () => {
+  const dir = makeTmpDir();
+  try {
+    const file = resolve(dir, "not-a-hook.mjs");
+    writeFileSync(file, `export const notDefault = 1;`);
+    await assert.rejects(
+      () => loadHook(file),
+      (e: Error) =>
+        e instanceof HookCompileError &&
+        /use `export default defineHook/.test(e.message),
+    );
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});
+
+test("loadHook: an unimportable file reports WHY, not just that it failed", async () => {
+  const dir = makeTmpDir();
+  try {
+    const file = resolve(dir, "broken.mjs");
+    writeFileSync(file, `export default {{{ not javascript`);
+    await assert.rejects(
+      () => loadHook(file),
+      (e: Error) =>
+        e instanceof HookCompileError && /^Cannot load hook /.test(e.message),
+    );
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});
+
+test("loadHook: a TypeScript hook on a non-TS runtime says how to fix it", async () => {
+  const dir = makeTmpDir();
+  try {
+    const file = resolve(dir, "guard.hook.ts");
+    // Deliberately unparseable AS JS too, so the failure is the runtime's
+    // inability to load TS on any Node that lacks type stripping.
+    writeFileSync(file, `const x: number = 1;\nexport default {{{`);
+    await assert.rejects(
+      () => loadHook(file),
+      (e: Error) =>
+        e instanceof HookCompileError &&
+        /Run under tsx .*Node >= 23\.6, or author the hook as a \.mjs file/s.test(
+          e.message,
+        ),
+    );
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});

--- a/src/load-hook.ts
+++ b/src/load-hook.ts
@@ -1,0 +1,66 @@
+/**
+ * `loadHook` — load a compiled-hook program from a FILE.
+ *
+ * The in-process assertions (`assertHookDenies` / `assertHookAllows` /
+ * `assertHookNotices` / `assertHookSilent`) take the hook OBJECT, but a
+ * `.harness.mjs` test only has the hook's PATH — and the loader that turns one
+ * into the other lived privately inside `cli.ts`. So the intended in-process test
+ * path was unreachable from the file format `vigiles test` actually runs, and
+ * authors fell back to spawning the runtime as a subprocess: exactly the plumbing
+ * compiled hooks exist to remove. Measured 2026-08-03.
+ *
+ * This is now the ONE loader — the CLI runtime calls it too, so a hook that loads
+ * in a test loads identically in production (one loader, no drift).
+ */
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { HookCompileError, type AnyHook } from "./core/hook-program.js";
+
+/**
+ * Load a compiled-hook program's default export from `file`.
+ *
+ * JS module formats (`.mjs`/`.cjs`/`.js`) load via dynamic import directly; a
+ * TypeScript hook (`.ts`/`.mts`/`.cts`) loads only under a TS-capable runtime
+ * (tsx, or Node >= 23.6 with type stripping) — otherwise the error says so and
+ * points at authoring the hook as `.mjs`.
+ *
+ * ```js
+ * import { loadHook, assertHookDenies } from "vigiles/testing";
+ *
+ * const guard = await loadHook(".vigiles/hooks/guard.mjs");
+ * assertHookDenies(guard, {
+ *   tool_name: "Bash",
+ *   tool_input: { command: "git push --force" },
+ * });
+ * ```
+ *
+ * @throws {HookCompileError} when the file can't be imported, or has no
+ * default-exported hook program.
+ */
+export async function loadHook(file: string): Promise<AnyHook> {
+  const abs = resolve(process.cwd(), file);
+  let mod: { default?: unknown };
+  try {
+    mod = (await import(pathToFileURL(abs).href)) as { default?: unknown };
+  } catch (e) {
+    if (/\.(?:m|c)?ts$/.test(file)) {
+      throw new HookCompileError(
+        `Cannot load TypeScript hook "${file}" in this Node runtime. Run under ` +
+          `tsx (npx tsx …) / Node >= 23.6, or author the hook as a .mjs file.`,
+      );
+    }
+    throw new HookCompileError(
+      `Cannot load hook "${file}": ${(e as Error).message}`,
+    );
+  }
+  // Unwrap the ESM/CJS double-default that `export default` can produce.
+  const program =
+    (mod.default as { default?: unknown } | undefined)?.default ?? mod.default;
+  if (!program || typeof program !== "object") {
+    throw new HookCompileError(
+      `${file} has no default-exported hook program ` +
+        `(use \`export default defineHook({…})\`).`,
+    );
+  }
+  return program as AnyHook;
+}

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -71,6 +71,13 @@ export type {
 } from "./eval.js";
 
 export * from "./harness-assert.js";
+// The compiled-hook LOADER. The in-process assertions above take the hook
+// OBJECT, but a `.harness.mjs` test only has its PATH — without this the
+// intended in-process test path is unreachable from the file format
+// `vigiles test` actually runs, and authors fall back to spawning the runtime as
+// a subprocess (the very plumbing compiled hooks exist to remove). Same loader
+// the CLI runtime uses, so a hook that loads in a test loads identically in prod.
+export { loadHook } from "./load-hook.js";
 // The declarative check vocabulary is now first-class at the front door. Its
 // `hookFired` (a `Check<Trace>`) supersedes the legacy boolean predicate of the
 // same name — the explicit re-export below wins over the two `export *`s.

--- a/src/unit.ts
+++ b/src/unit.ts
@@ -12,6 +12,10 @@
  * `vigiles/e2e`.
  */
 export * from "./harness-assert.js";
+// The compiled-hook loader belongs to the no-capability tier: it imports a local
+// module and nothing else. Without it the in-process assertions above are
+// unreachable from a test that only knows the hook's PATH.
+export { loadHook } from "./load-hook.js";
 export {
   runHook,
   parseHookOutput,


### PR DESCRIPTION
## The compiled-hook testing story had a hole at each end

Found dogfooding on 2026-08-03.

### 1. There was no public way to load a hook FILE

`assertHookDenies(hook, event)` / `assertHookAllows` take the hook **object**. A `.harness.mjs` test has the hook's **path**. The loader that bridges them — `loadHookProgram` — lived privately inside `cli.ts` and was exported from no public entry point.

So the intended in-process test path was **unreachable from the file format `vigiles test` actually runs**, and authors fell back to spawning the runtime as a subprocess — precisely the plumbing compiled hooks exist to remove.

`loadHook(path)` is now exported from `vigiles/testing` and `vigiles/unit`, and **`cli.ts` calls the same function** (`const loadHookProgram = loadHook`) — one loader, no drift, so a hook that loads in a test loads identically in production. It keeps the actionable errors that make a loader worth having over a bare `await import()`:

- a `.ts` hook on a runtime without type stripping → "Run under tsx (npx tsx …) / Node >= 23.6, or author the hook as a .mjs file"
- a module with no default export → "use \`export default defineHook({…})\`"

### 2. There was no assertion for a `react` hook

A react hook can't block, so the gate assertions don't apply — and nothing else did either. That left `notice()` a **live trap**: its message goes to **stderr**, so a probe built on `execFileSync` (which returns stdout only) sees nothing and reports a perfectly healthy react hook as **DEAD**. That's exactly how three real react hooks got mis-diagnosed.

```js
assertHookNotices(hook, event, matcher?)   // matcher: string (substring) or RegExp
assertHookSilent(hook, event)              // the hook returned nothing()
```

Both read the reaction **in-process**, so the stream never enters into it, and both name what they got instead on failure — including when aimed at the wrong role (`expected a react hook, got allow (a gate decision)`), so a mis-aimed assertion fails loudly instead of passing.

## The example the finding asked for

`examples/harness/compiled-hook-inprocess.harness.mjs` loads a gate and a react hook **by path** and asserts over both:

```js
const guard = await loadHook("examples/harness/protect-main.hook.mjs");
assertHookDenies(guard, bash("cd repo && git commit -am wip && git push -f"));
assertHookAllows(guard, bash("git status"));

const warn = await loadHook("examples/harness/warn-on-failure.hook.mjs");
assertHookNotices(warn, afterBash(true), /read the error/);
assertHookSilent(warn, afterBash(false));
```

It runs under `vigiles test` (verified: `13 passed` on the repo's own suite), so **CI proves the documented pattern works**, not just that it parses.

## Docs

`docs/compiled-hooks.md` and `docs/testing-api.md` now show the `loadHook` path and the react pair, with a call-out box on the stderr trap.

## Tests

- `src/load-hook.test.ts` — a loaded hook feeds the assertions directly; a relative path resolves against the **cwd** (what a harness test passes), not the loader's own module; and the three error paths (no default export, unimportable file, TypeScript on a non-TS runtime) each pin their message.
- `src/harness-assert.test.ts` — the react pair: fires/silent on the right events, message matched by substring **and** regexp (plus both mismatch messages), each assertion throwing on the other outcome, `run(…)` correctly not counting as silence, and both aimed at a gate.

## API surface

`api-surface/vigiles-{testing,unit,integration,e2e}.api.md` regenerated (`npm run api:report`).

## Checks

`npx tsc --noEmit`, `npm run lint` (0 errors), `npx prettier --check .`, `node dist/cli.js test` (13 passed), full unit suite (2344 passing), and `npm run coverage` — the 100% gate on `src/harness-assert.ts` still passes with the new assertions.

⚠️ Pre-existing on `main`, unrelated: the two `pylint` cases in `src/core/spec.test.ts` fail locally because `pylint` isn't on this machine's PATH. CI installs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012omt6sirxNMyZN2x5RhK2u

---
_Generated by [Claude Code](https://claude.ai/code/session_012omt6sirxNMyZN2x5RhK2u)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Features**
- export loadHook + add the react assertions
<!-- vigiles:pr-summary:end -->
