### PR TITLE
docs: add SECURITY.md, code of conduct, and a PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+<!--
+  Title must be a Conventional Commit — it drives semantic-release and is
+  validated by .github/workflows/pr-title.yml. e.g. "fix(audit): …", "docs: …".
+
+  The body below the auto-managed summary block is yours; pr-describe.yml only
+  rewrites its own markers and leaves your prose alone.
+-->
+
+## What and why
+
+<!-- What changes, and what problem it solves. A sentence or two is fine. -->
+
+## Safety impact
+
+<!--
+  Required. vigiles executes untrusted harness code and, at the eval tier, lets a
+  real model choose tool calls — so a change can quietly widen what gets through.
+
+  Answer if this PR touches ANY of:
+    - what a hook or compiled guard is allowed to permit (can it now fail open?)
+    - what the sandbox confines, or what sandboxAvailable() reports
+    - interceptTools / what a model is allowed to actually run
+    - whether a read-only path (audit, lint) can now execute something
+
+  Otherwise write: None.
+-->
+
+None.
+
+## Checks
+
+- [ ] `npm test` passes locally, or CI is green
+- [ ] New behaviour has a test — or there's a note below saying why it doesn't
+- [ ] Docs updated if this changes a rule, a CLI surface, or a documented guarantee

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,44 @@
+# Code of Conduct
+
+## Our pledge
+
+We want vigiles to be a project where people can report a bug, disagree with a design decision, or
+show up knowing nothing, without it costing them anything. Everyone participating — issues, pull
+requests, discussions, reviews — is expected to help keep it that way.
+
+## Expected behaviour
+
+- Assume the other person is acting in good faith, especially when reading a terse message.
+- Critique the code, the config, or the claim — not the person who wrote it.
+- Accept that maintainer time is finite. An unanswered issue is usually a queue, not a snub.
+- When you disagree, say what you'd do instead.
+
+## Unacceptable behaviour
+
+- Harassment, personal attacks, or demeaning comments — including about someone's experience level.
+- Sexualised language or imagery, or unwelcome attention of any kind.
+- Publishing someone's private information without their explicit permission.
+- Sustained disruption of discussions, or deliberately derailing threads.
+
+## Scope
+
+This applies in all project spaces — the repository, its issues and pull requests, and its
+discussions — and when someone is representing the project in public.
+
+## Reporting
+
+Report a concern privately to the maintainer, using the contact listed on
+[their GitHub profile](https://github.com/zernie). Reports are handled confidentially, and the
+person reporting will not be named without their agreement.
+
+Reports about a **security vulnerability** go somewhere else — see [SECURITY.md](SECURITY.md).
+
+## Enforcement
+
+vigiles is maintained by one person, so this is a statement of intent, not a committee process.
+Depending on severity, a response may be a private word, an edited or removed comment, or a block
+from the repository. Maintainers who don't follow this themselves should be called on it.
+
+## Attribution
+
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,11 +21,11 @@ expected the boundary to do instead.
 
 vigiles is maintained by one person, so these are honest targets rather than a corporate SLA:
 
-| Stage | Target |
-| --- | --- |
-| Acknowledge receipt | 5 business days |
-| Triage — confirmed, needs-info, or out of scope | 10 business days |
-| Fix for a confirmed high-impact issue | best effort, with progress notes in the advisory thread |
+| Stage                                           | Target                                                  |
+| ----------------------------------------------- | ------------------------------------------------------- |
+| Acknowledge receipt                             | 5 business days                                         |
+| Triage — confirmed, needs-info, or out of scope | 10 business days                                        |
+| Fix for a confirmed high-impact issue           | best effort, with progress notes in the advisory thread |
 
 The clock starts when a report is confirmed as a valid vulnerability, not on first receipt. If a
 report goes quiet for more than two weeks, please ping the advisory thread — that's a dropped ball,
@@ -62,13 +62,13 @@ Not vulnerabilities in vigiles. Reported in good faith, these get a pointer rath
 - **Vulnerabilities in the harness itself** — Claude Code, Codex, or another agent runtime. Report
   those to the vendor.
 - **Vulnerabilities in a third-party plugin, skill, or MCP server that vigiles audits.** Report to
-  that project. If vigiles *failed to warn* about it, that's a coverage gap (above).
+  that project. If vigiles _failed to warn_ about it, that's a coverage gap (above).
 - **Vulnerabilities in linters vigiles shells out to** (ESLint, Ruff, RuboCop, Clippy, …) or in npm
   dependencies with no vigiles-specific exposure — report upstream.
 - **Missing confinement on a platform where it is documented as unavailable** — bwrap is Linux-only
   by design and macOS confinement is not shipped yet ([`docs/sandboxing.md`](docs/sandboxing.md)).
   Running untrusted code there without a sandbox is documented behaviour, not a bypass. A case
-  where vigiles *claims* confinement it doesn't have is in scope, above.
+  where vigiles _claims_ confinement it doesn't have is in scope, above.
 
 If you're unsure which side of the line something falls on, report it anyway and we'll sort it out.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,83 @@
+# Security Policy
+
+vigiles audits an agent harness — and, at some tiers, **runs it**. Testing a hook, skill, or
+plugin means executing someone else's code with your privileges, and an `eval` lets a real model
+decide which tools to call. Both are deliberate (that's the point — test what actually ships), and
+both are where the interesting bugs live. See [`docs/safety.md`](docs/safety.md) and
+[`docs/sandboxing.md`](docs/sandboxing.md) for the full model.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security bug.**
+
+Use GitHub's private reporting: **[Report a vulnerability](https://github.com/zernie/vigiles/security/advisories/new)**
+(Security → Advisories → Report a vulnerability). That opens a private thread with the maintainer.
+
+Useful things to include, if you have them: the vigiles version (`npx vigiles --version`), your OS
+and whether `bwrap` is available, a minimal repo or fixture that reproduces it, and what you
+expected the boundary to do instead.
+
+## Response
+
+vigiles is maintained by one person, so these are honest targets rather than a corporate SLA:
+
+| Stage | Target |
+| --- | --- |
+| Acknowledge receipt | 5 business days |
+| Triage — confirmed, needs-info, or out of scope | 10 business days |
+| Fix for a confirmed high-impact issue | best effort, with progress notes in the advisory thread |
+
+The clock starts when a report is confirmed as a valid vulnerability, not on first receipt. If a
+report goes quiet for more than two weeks, please ping the advisory thread — that's a dropped ball,
+not a decision.
+
+## In scope
+
+The boundaries vigiles actually claims. A break in any of these is a vulnerability:
+
+- **Sandbox escape** — code under test reaching the host when confinement was reported as active
+  (tier A / `bwrap`), including egress that should have been denied.
+- **Confinement misreported** — `sandboxAvailable()` reporting a capability the host cannot
+  deliver, so a run claims a boundary that isn't there.
+- **`interceptTools` bypass** — a model-driven tool call proceeding despite a matching deny rule,
+  during an `eval`.
+- **A compiled hook that fails open** — hook codegen emitting a guard that permits what its source
+  spec denies. A guard that silently doesn't guard is the failure mode this project exists to find,
+  so it counts double here.
+- **Code execution from parsing alone** — a malicious `CLAUDE.md`, `AGENTS.md`, `SKILL.md`,
+  subagent, plugin manifest, or MCP config causing execution during a plain `audit` or `lint`,
+  which are meant to be pure reads.
+- **Secret disclosure** — credentials, tokens, or environment values leaking into report output,
+  `--json`, or on-disk state under `.vigiles/`.
+
+## Out of scope
+
+Not vulnerabilities in vigiles. Reported in good faith, these get a pointer rather than a fix:
+
+- **A low grade, or a finding you disagree with.** A false positive is a bug — file it as a normal
+  issue. It is not a security bug.
+- **A missed finding.** vigiles' checks are deliberately precision-first and have false negatives;
+  [`docs/what-vigiles-catches.md`](docs/what-vigiles-catches.md) describes what is and isn't
+  covered. A gap in coverage is a feature request.
+- **Vulnerabilities in the harness itself** — Claude Code, Codex, or another agent runtime. Report
+  those to the vendor.
+- **Vulnerabilities in a third-party plugin, skill, or MCP server that vigiles audits.** Report to
+  that project. If vigiles *failed to warn* about it, that's a coverage gap (above).
+- **Vulnerabilities in linters vigiles shells out to** (ESLint, Ruff, RuboCop, Clippy, …) or in npm
+  dependencies with no vigiles-specific exposure — report upstream.
+- **Missing confinement on a platform where it is documented as unavailable** — bwrap is Linux-only
+  by design and macOS confinement is not shipped yet ([`docs/sandboxing.md`](docs/sandboxing.md)).
+  Running untrusted code there without a sandbox is documented behaviour, not a bypass. A case
+  where vigiles *claims* confinement it doesn't have is in scope, above.
+
+If you're unsure which side of the line something falls on, report it anyway and we'll sort it out.
+
+## Disclosure
+
+Coordinated. Once a fix is available, we'll publish an advisory describing the issue and the
+affected versions. If a report is in scope and confirmed, **you'll be credited by name or handle
+in the advisory and the release notes** — tell us which you prefer, or say if you'd rather stay
+anonymous.
+
+Only the latest published version on npm is supported. If you're pinned to an older one, upgrade
+before reporting — the bug may already be gone.


### PR DESCRIPTION
## What and why

vigiles executes untrusted harness code by design, and at the eval tier lets a real model choose tool calls — but there was no way to report a break in either boundary privately. This adds the three community-health files the repo was missing. None of them existed and nothing referenced them, so there were no dangling links to fix.

**`SECURITY.md`** — scope is drawn from boundaries the project actually claims in `docs/safety.md` and `docs/sandboxing.md`, not invented:

- In scope: sandbox escape · `sandboxAvailable()` reporting confinement the host can't deliver · `interceptTools` bypass · a compiled hook that **fails open** · execution during a read-only `audit`/`lint` · secrets leaking into report output or `.vigiles/` state.
- Out of scope, stated explicitly so the inbox stays readable: a low grade or a disputed finding is a normal issue; a missed finding is a coverage gap; bugs in the harness, in audited third-party plugins, or in shelled-out linters go upstream. Missing macOS confinement is documented behaviour — *claiming* confinement we don't have is the in-scope version of that.
- Response targets are sized for a single maintainer (5 business days to acknowledge, 10 to triage) rather than copied from a corporate SLA. Reporters are credited by name or handle.

**`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1, trimmed for a single-maintainer project. Enforcement is stated as intent rather than a committee process, and reporting points at the maintainer's GitHub profile contact rather than publishing a personal address.

**`.github/PULL_REQUEST_TEMPLATE.md`** — carries a required **Safety impact** field. A change here can quietly widen what gets through, so the template makes a contributor state that explicitly, with `None.` as the one-word honest answer so the field doesn't get skipped. It also names the Conventional Commit title requirement inline, since `pr-title.yml` enforces it and the failure is otherwise found only after opening a PR. Template prose sits outside `pr-describe.yml`'s managed markers, so the auto-summary and the template don't fight.

## Safety impact

None. Documentation only — no source, config, or workflow behaviour changes.

## Checks

- [x] `tsc --noEmit` clean
- [x] `npm run lint` — 0 errors (196 pre-existing warnings, untouched)
- [x] `vitest run src/doc-command-coverage.test.ts` — 7 passed
- [x] `vigiles audit` self-run unchanged by this diff — C (70); Truthfulness / Triggering / Structure 100, Safety 70 from pre-existing lethal-trifecta findings on the repo's own skills, Tested 67 (advisory)
- [x] README deliberately untouched — GitHub surfaces these files on its own, and the README has a body-size and framing budget this doesn't need to spend

## Note for the maintainer

The code of conduct routes reports to "the contact listed on your GitHub profile." If no contact is public there, that path is a dead end — worth either publishing one or swapping in a preferred address.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UD5cpuTHJZqHAnunoXP3sk)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Docs**
- add SECURITY.md
- add a code of conduct and a PR template
- format SECURITY.md with prettier
<!-- vigiles:pr-summary:end -->

