### PR TITLE
fix(skills): declare tool contracts on the four model-invocable skills

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -27,9 +27,13 @@ discussions — and when someone is representing the project in public.
 
 ## Reporting
 
-Report a concern privately to the maintainer, using the contact listed on
-[their GitHub profile](https://github.com/zernie). Reports are handled confidentially, and the
-person reporting will not be named without their agreement.
+Report a concern privately to the maintainer — the contact on
+[their GitHub profile](https://github.com/zernie), or a DM on any platform linked there. If you'd
+rather not contact the maintainer directly, or the concern is about them, use GitHub's own
+[report abuse](https://github.com/contact/report-abuse) flow, which goes to GitHub staff instead.
+
+Reports are handled confidentially, and the person reporting will not be named without their
+agreement.
 
 Reports about a **security vulnerability** go somewhere else — see [SECURITY.md](SECURITY.md).
 

--- a/skills/debug-my-harness/SKILL.md
+++ b/skills/debug-my-harness/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: debug-my-harness
+allowed-tools: Read, Glob, Grep
 description: Diagnose why an agent harness misbehaved by reading the local flight-recorder ledger (.vigiles/runs.jsonl) — which skills fired or got hijacked, which hooks blocked or wrongly allowed, which subagent tool-contract violations happened, and how a skill's trigger rate moved. Use when asked why a skill stopped firing, why a hook didn't block, why the wrong skill ran, or to debug/investigate what the harness actually did. NOT for writing new rules (use strengthen) or editing the spec (use edit-spec).
 ---
 

--- a/skills/edit-spec/SKILL.md
+++ b/skills/edit-spec/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: edit-spec
+allowed-tools: Read, Edit, Write, Glob, Grep, Bash
 description: Edit a vigiles .spec.ts to change a compiled instruction file (CLAUDE.md / AGENTS.md) — add, modify, or remove a rule, section, command, or key file. Use whenever you need to change a CLAUDE.md/AGENTS.md that carries a vigiles hash (edit the spec, never the artifact), including adding a new enforce()/check()/guidance() rule.
 argument-hint: <what to change — e.g., "add a rule about error handling" or "update the testing section">
 ---

--- a/skills/strengthen/SKILL.md
+++ b/skills/strengthen/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: strengthen
+allowed-tools: Read, Edit, Write, Glob, Grep, Bash
 description: Upgrade a vigiles spec's guidance() rules to enforce() — scan the guidance rules in a CLAUDE.md/AGENTS.md spec and find existing linter rules (ESLint, Ruff, Clippy, Pylint, RuboCop, Stylelint) that back them. Use when asked to strengthen, harden, or make vigiles rules enforceable; NOT for general linting or fixing lint errors.
 ---
 

--- a/skills/test-harness/SKILL.md
+++ b/skills/test-harness/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: test-harness
+allowed-tools: Read, Edit, Write, Glob, Grep, Bash
 description: Install vigiles and test a Claude Code harness — hooks, skills, settings, CLAUDE.md — by picking the right tier (unit / deterministic / eval) and writing a test that passes. Use when the user wants to check that a hook fires or blocks, that a skill triggers, that injected context lands, or that a harness change moves what the agent does.
 ---
 


### PR DESCRIPTION
## What and why

The self-audit was **C (70)**, with Safety at 70. All four model-invocable skills declared no `allowed-tools`, so each inherited every tool and tripped the repo's own lethal-trifecta check as an advisory finding:

```
4 of 4 units can read data, reach the web, and run commands — the "lethal trifecta"
debug-my-harness inherits all tools — …
edit-spec inherits all tools — …
strengthen inherits all tools — …
test-harness inherits all tools — …
```

vigiles shipping a harness its own Safety ring marks down is exactly the false confidence this project exists to catch.

**The contracts are the real ones, not the minimum that silences the check.** None of the four needs web access, and that was verified rather than assumed — no `WebFetch`/`WebSearch` appears in any of them:

| Skill | Contract | Why |
| --- | --- | --- |
| `debug-my-harness` | `Read, Glob, Grep` | Reads the local flight-recorder ledger (`.vigiles/runs.jsonl`) and diagnoses. Read-only. |
| `edit-spec` | `Read, Edit, Write, Glob, Grep, Bash` | Edits local `.spec.ts`, shells out to `npx vigiles compile`. |
| `strengthen` | `Read, Edit, Write, Glob, Grep, Bash` | Reads specs, generated types, and the **bundled** `linter-docs` skill on disk; edits specs/config; runs `generate types`. |
| `test-harness` | `Read, Edit, Write, Glob, Grep, Bash` | Writes test files, runs `npm` / `npx vigiles test`. |

Without a leg-B tool these hold at most two trifecta legs, which is the Rule of Two the detector encodes — so the finding clears because the capability genuinely is narrower, not because it was papered over.

`adopt-spec` and `linter-docs` are untouched: they carry `disable-model-invocation`, so they're user-invoked and out of scope for the check.

Also gives the code of conduct a reporting path that resolves when the maintainer's profile carries no public contact, or when the concern is about the maintainer — GitHub's own report-abuse flow.

## Result

Self-audit **C (70) → A (100)**, Safety 100. Truthfulness / Triggering / Structure stay 100. Tested stays 67 and advisory (excluded from the overall).

## Safety impact

Narrows capability; nothing is widened. Each skill goes from implicitly holding every tool to an explicit contract covering only what its own instructions use. Worst case is a skill reaching for a tool now outside its contract — which is the contract working, and visible as an `agent`/tool-contract record rather than a silent capability.

## Checks

- [x] `npm run fmt:check` — clean (the gate that caught the last PR)
- [x] `tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (196 pre-existing warnings, untouched)
- [x] `vitest run --project unit` — 2371 passed, 4 failed: `pylint` and `rubocop` CLI tests, which need those binaries. The same 4 fail on a stashed clean tree in this container, so they're environment, not regression — CI installs both.

## Note

Pushed via the GitHub API rather than git: the session's proxy CA material was overwritten mid-run (`agent-proxy-ca.crt` truncated to 2 bytes), so git-over-HTTPS fails certificate verification for every remote. TLS verification was not disabled — the API path was used instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UD5cpuTHJZqHAnunoXP3sk)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Fixes**
- declare debug-my-harness's tool contract
- declare edit-spec's tool contract
- declare strengthen's tool contract
- declare test-harness's tool contract

**Docs**
- give the code of conduct a reporting path that always resolves
<!-- vigiles:pr-summary:end -->
