### PR TITLE
fix(audit): split Tested into Tested + Evaluated, and give Evaluated a `not measured` state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,16 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit
 
+      # 🔴 site/ and packages/report-view have their OWN tsconfig and were never typechecked here.
+      # A field added to the engine's inventory and not to the view's mirror therefore compiled
+      # clean through all three steps above and failed only for whoever ran
+      # `tsc -p site/tsconfig.json` by hand. That is precisely what happened to `untestedHarness`
+      # and `unevaluated` earlier in this PR: three green typecheck steps, none covering the project
+      # that broke. A check that passes without covering the thing that broke is the defect this
+      # whole PR is about, so it gets a step rather than a note.
+      - name: Type check (site + report-view)
+        run: npx tsc --noEmit -p site/tsconfig.json
+
       - name: Check generated types compile
         run: node dist/cli.js generate types && npx tsc --noEmit
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -18,6 +18,10 @@ api-surface/
 site/test-results/
 site/playwright-report/
 site/blob-report/
+# Generated per-rule check pages (`site` prebuild → `gen-check-pages.ts`,
+# gitignored by site/.gitignore) — same class: building the site locally would
+# otherwise redden `fmt:check` on files nobody commits.
+site/checks/
 
 # Ecosystem-benchmark run artifacts (machine-written JSON) + vendored upstream
 # SKILL.md snapshots (pinned by SHA, formatted by their upstreams, not us).

--- a/README.md
+++ b/README.md
@@ -130,13 +130,14 @@ It's free and open-source, runs entirely on your machine, and never bills per to
   <img src="vigiles-audit.png" width="760" alt="vigiles audit report for my-plugin: a verdict header reading 'Two one-line fixes away from a B.' next to a C (77/100) grade, a five-category strip (Truthfulness, Triggering, Structure, Safety, Tested), ranked fix cards with '+N pts' impact badges, broken-reference findings — and, lower down and badged experimental, a 'Your rules → enforced' preview mapping a prose rule the config silently turns off" />
 </p>
 
-**Like Google's Lighthouse, but for your agent harness.** One command grades it A–F across five categories, leads with a plain-English verdict — _"two one-line fixes away from a B"_ — and ranks every fix by the points it buys back:
+**Like Google's Lighthouse, but for your agent harness.** One command grades it A–F across six categories, leads with a plain-English verdict — _"two one-line fixes away from a B"_ — and ranks every fix by the points it buys back:
 
 - **Truthfulness** — do the references resolve?
 - **Triggering** — do skills fire, without colliding?
 - **Structure** — are tool contracts and configs valid?
 - **Safety** — any way for the agent to leak your data?
-- **Tested** — does the harness ship tests?
+- **Tested** — does the harness ship deterministic tests?
+- **Evaluated** — has anything measured whether your skills actually _fire_? (Distinct from `0`: if nothing asked, it says **not measured**.)
 
 And it closes the loop from prose to enforcement: **your rules → enforced** maps each rule you wrote to the lint rule that actually enforces it — already on, one config line away, or silently turned off (below).
 

--- a/README.md
+++ b/README.md
@@ -209,8 +209,10 @@ Or run it yourself:
 
 ```bash
 npx vigiles init   # sets up the typed spec for structural rules (non-destructive — eject reverses), adds CI,
-                   # installs vigiles's skills + hooks as a Claude Code plugin (in
-                   # ~/.claude/, not your repo). On Codex, skills install globally too.
+                   # installs vigiles's skills + hooks as a Claude Code plugin. The plugin
+                   # CONTENT goes to ~/.claude/, never your repo; init also commits a two-key
+                   # reference to it in .claude/settings.json so teammates get prompted to
+                   # install it rather than silently missing it. Codex: skills install globally.
 ```
 
 **Already have a harness, or a non-JS repo?** `npx vigiles init --ci-only` sets up just the CI integrity gate — nothing installed, zero conflict. **[When to use gate vs full →](docs/agent-setup.md#non-interactive-setup-agents--ci)**
@@ -231,6 +233,7 @@ The **hooks** keep it honest in-loop — nudging the agent to tag a linter-rule 
 - **Both lint and test** by default; scope with `--lint` / `--test`.
 - **Already have a CLAUDE.md / AGENTS.md, skills, or subagents? `audit` and `lint` read them as-is** — nothing is moved or rewritten. For the structural rules that want a typed spec, `init` sets one up **non-destructively** (`eject` undoes it).
 - Adds `vigiles` to `devDependencies`; installs the Claude Code plugin (skills + hooks) via the marketplace — globally, never vendored.
+- Declares that plugin in your repo's `.claude/settings.json` (`extraKnownMarketplaces` + `enabledPlugins`, merged into whatever is already there). This is a **reference, not content** — nothing is vendored, and it does **not** install the plugin for a teammate: an external-source plugin declared project-level [doesn't load until each person installs it](https://code.claude.com/docs/en/discover-plugins#configure-team-marketplaces). What it buys is that Claude Code **prompts** them with the install command, instead of a fresh clone silently having the npm package and none of its skills.
 - Wires CI as a `zernie/vigiles@v1` workflow (needs only read + PR-comment permissions) that posts a sticky PR comment + a `valid` output.
 
 Targets Claude Code and Codex out of the box, or [your own harness](docs/authoring-an-adapter.md). Prefer to write tests yourself? JS **or** TS (`*.harness.{mjs,ts}`) — run with `npx vigiles test`.

--- a/api-surface/vigiles-e2e.api.md
+++ b/api-surface/vigiles-e2e.api.md
@@ -368,22 +368,10 @@ export interface HookPropertyResult<E> {
 }
 
 // @public (undocumented)
-export interface HookRunResult {
+export interface HookRunResult extends ScriptRunResult {
     readonly blocked: boolean;
     readonly decision: HookOutput["decision"] | "allow" | "deny" | "ask" | undefined;
-    readonly egress: readonly EgressAttempt[];
-    readonly egressDropped?: {
-        readonly packets: number;
-        readonly bytes: number;
-    };
-    // (undocumented)
-    readonly exitCode: number;
-    readonly filesWritten: readonly string[];
     readonly json: HookOutput | null;
-    // (undocumented)
-    readonly stderr: string;
-    // (undocumented)
-    readonly stdout: string;
 }
 
 // @public
@@ -522,8 +510,14 @@ export interface RunHarnessTestOptions {
 // @public
 export function runHook(command: string, input: HookInput, opts?: RunHookOptions): HookRunResult;
 
+// @public
+export type RunHookOptions = Omit<RunScriptOptions, "stdin">;
+
+// @public
+export function runScript(command: string, opts?: RunScriptOptions): ScriptRunResult;
+
 // @public (undocumented)
-export interface RunHookOptions {
+export interface RunScriptOptions {
     readonly cwd?: string;
     readonly egress?: {
         readonly allow: readonly string[];
@@ -531,6 +525,7 @@ export interface RunHookOptions {
     readonly env?: Record<string, string>;
     readonly recordEgress?: boolean;
     readonly sandbox?: SandboxMode;
+    readonly stdin?: string;
     readonly timeoutMs?: number;
     readonly trusted?: boolean;
 }
@@ -540,6 +535,20 @@ export function sandboxAvailable(): boolean;
 
 // @public
 export type SandboxMode = "auto" | "strict" | false;
+
+// @public
+export interface ScriptRunResult {
+    readonly egress: readonly EgressAttempt[];
+    readonly egressDropped?: {
+        readonly packets: number;
+        readonly bytes: number;
+    };
+    readonly exitCode: number;
+    readonly filesWritten?: readonly string[];
+    readonly stderr: string;
+    // (undocumented)
+    readonly stdout: string;
+}
 
 // @public
 export function significantlyBeats(report: EvalReport, baseline: string, arm: string, metric: string, alpha?: number): boolean;

--- a/api-surface/vigiles-integration.api.md
+++ b/api-surface/vigiles-integration.api.md
@@ -368,22 +368,10 @@ export interface HookPropertyResult<E> {
 }
 
 // @public (undocumented)
-export interface HookRunResult {
+export interface HookRunResult extends ScriptRunResult {
     readonly blocked: boolean;
     readonly decision: HookOutput["decision"] | "allow" | "deny" | "ask" | undefined;
-    readonly egress: readonly EgressAttempt[];
-    readonly egressDropped?: {
-        readonly packets: number;
-        readonly bytes: number;
-    };
-    // (undocumented)
-    readonly exitCode: number;
-    readonly filesWritten: readonly string[];
     readonly json: HookOutput | null;
-    // (undocumented)
-    readonly stderr: string;
-    // (undocumented)
-    readonly stdout: string;
 }
 
 // @public
@@ -522,8 +510,14 @@ export interface RunHarnessTestOptions {
 // @public
 export function runHook(command: string, input: HookInput, opts?: RunHookOptions): HookRunResult;
 
+// @public
+export type RunHookOptions = Omit<RunScriptOptions, "stdin">;
+
+// @public
+export function runScript(command: string, opts?: RunScriptOptions): ScriptRunResult;
+
 // @public (undocumented)
-export interface RunHookOptions {
+export interface RunScriptOptions {
     readonly cwd?: string;
     readonly egress?: {
         readonly allow: readonly string[];
@@ -531,6 +525,7 @@ export interface RunHookOptions {
     readonly env?: Record<string, string>;
     readonly recordEgress?: boolean;
     readonly sandbox?: SandboxMode;
+    readonly stdin?: string;
     readonly timeoutMs?: number;
     readonly trusted?: boolean;
 }
@@ -540,6 +535,20 @@ export function sandboxAvailable(): boolean;
 
 // @public
 export type SandboxMode = "auto" | "strict" | false;
+
+// @public
+export interface ScriptRunResult {
+    readonly egress: readonly EgressAttempt[];
+    readonly egressDropped?: {
+        readonly packets: number;
+        readonly bytes: number;
+    };
+    readonly exitCode: number;
+    readonly filesWritten?: readonly string[];
+    readonly stderr: string;
+    // (undocumented)
+    readonly stdout: string;
+}
 
 // @public
 export function significantlyBeats(report: EvalReport, baseline: string, arm: string, metric: string, alpha?: number): boolean;

--- a/api-surface/vigiles-testing.api.md
+++ b/api-surface/vigiles-testing.api.md
@@ -528,22 +528,10 @@ export interface HookPropertyResult<E> {
 }
 
 // @public (undocumented)
-export interface HookRunResult {
+export interface HookRunResult extends ScriptRunResult {
     readonly blocked: boolean;
     readonly decision: HookOutput["decision"] | "allow" | "deny" | "ask" | undefined;
-    readonly egress: readonly EgressAttempt[];
-    readonly egressDropped?: {
-        readonly packets: number;
-        readonly bytes: number;
-    };
-    // (undocumented)
-    readonly exitCode: number;
-    readonly filesWritten: readonly string[];
     readonly json: HookOutput | null;
-    // (undocumented)
-    readonly stderr: string;
-    // (undocumented)
-    readonly stdout: string;
 }
 
 // @public
@@ -768,18 +756,8 @@ export interface RunHarnessTestOptions {
 // @public
 export function runHook(command: string, input: HookInput, opts?: RunHookOptions): HookRunResult;
 
-// @public (undocumented)
-export interface RunHookOptions {
-    readonly cwd?: string;
-    readonly egress?: {
-        readonly allow: readonly string[];
-    };
-    readonly env?: Record<string, string>;
-    readonly recordEgress?: boolean;
-    readonly sandbox?: SandboxMode;
-    readonly timeoutMs?: number;
-    readonly trusted?: boolean;
-}
+// @public
+export type RunHookOptions = Omit<RunScriptOptions, "stdin">;
 
 // @public
 export interface RunOut {
@@ -791,7 +769,38 @@ export interface RunOut {
 }
 
 // @public
+export function runScript(command: string, opts?: RunScriptOptions): ScriptRunResult;
+
+// @public (undocumented)
+export interface RunScriptOptions {
+    readonly cwd?: string;
+    readonly egress?: {
+        readonly allow: readonly string[];
+    };
+    readonly env?: Record<string, string>;
+    readonly recordEgress?: boolean;
+    readonly sandbox?: SandboxMode;
+    readonly stdin?: string;
+    readonly timeoutMs?: number;
+    readonly trusted?: boolean;
+}
+
+// @public
 export type SandboxMode = "auto" | "strict" | false;
+
+// @public
+export interface ScriptRunResult {
+    readonly egress: readonly EgressAttempt[];
+    readonly egressDropped?: {
+        readonly packets: number;
+        readonly bytes: number;
+    };
+    readonly exitCode: number;
+    readonly filesWritten?: readonly string[];
+    readonly stderr: string;
+    // (undocumented)
+    readonly stdout: string;
+}
 
 // @public
 export interface SelectionTrialResult {

--- a/api-surface/vigiles-unit.api.md
+++ b/api-surface/vigiles-unit.api.md
@@ -314,22 +314,10 @@ export interface HookPropertyResult<E> {
 }
 
 // @public (undocumented)
-export interface HookRunResult {
+export interface HookRunResult extends ScriptRunResult {
     readonly blocked: boolean;
     readonly decision: HookOutput["decision"] | "allow" | "deny" | "ask" | undefined;
-    readonly egress: readonly EgressAttempt[];
-    readonly egressDropped?: {
-        readonly packets: number;
-        readonly bytes: number;
-    };
-    // (undocumented)
-    readonly exitCode: number;
-    readonly filesWritten: readonly string[];
     readonly json: HookOutput | null;
-    // (undocumented)
-    readonly stderr: string;
-    // (undocumented)
-    readonly stdout: string;
 }
 
 // @public
@@ -424,8 +412,14 @@ export function requestContains(trace: Trace, needle: string | RegExp): boolean;
 // @public
 export function runHook(command: string, input: HookInput, opts?: RunHookOptions): HookRunResult;
 
+// @public
+export type RunHookOptions = Omit<RunScriptOptions, "stdin">;
+
+// @public
+export function runScript(command: string, opts?: RunScriptOptions): ScriptRunResult;
+
 // @public (undocumented)
-export interface RunHookOptions {
+export interface RunScriptOptions {
     readonly cwd?: string;
     readonly egress?: {
         readonly allow: readonly string[];
@@ -433,8 +427,23 @@ export interface RunHookOptions {
     readonly env?: Record<string, string>;
     readonly recordEgress?: boolean;
     readonly sandbox?: SandboxMode;
+    readonly stdin?: string;
     readonly timeoutMs?: number;
     readonly trusted?: boolean;
+}
+
+// @public
+export interface ScriptRunResult {
+    readonly egress: readonly EgressAttempt[];
+    readonly egressDropped?: {
+        readonly packets: number;
+        readonly bytes: number;
+    };
+    readonly exitCode: number;
+    readonly filesWritten?: readonly string[];
+    readonly stderr: string;
+    // (undocumented)
+    readonly stdout: string;
 }
 
 // @public

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -65,6 +65,18 @@ has to remember to compile:
 
 ⚠️ **Without the plugin**, run `vigiles compile` manually after editing specs. CI still catches stale files.
 
+⚠️ **`npm install vigiles` does NOT wire the skills.** The npm tarball ships them
+(it doubles as the plugin payload), so they land in `node_modules/vigiles/skills/`
+— a directory Claude Code never scans. Until the plugin install above has run, all
+six shipped skills, `test-harness` included, are present on disk and unselectable.
+`vigiles audit` says so out loud when it sees a repo in that state.
+
+Checking by hand? Look in **`~/.claude/plugins/installed_plugins.json`** for a
+`vigiles@vigiles` entry — that is what `claude plugin install` writes for a
+user-scope install. A repo's `.claude/settings.json` carries _project_-level
+`enabledPlugins`, and a correctly-installed user-scope plugin **does not appear
+there**; judging it from `settings.json` alone reports a working install as broken.
+
 ### Codex / GitHub Copilot
 
 Instruction file: `AGENTS.md`, read directly — there is no plugin or hook system.

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -77,6 +77,28 @@ user-scope install. A repo's `.claude/settings.json` carries _project_-level
 `enabledPlugins`, and a correctly-installed user-scope plugin **does not appear
 there**; judging it from `settings.json` alone reports a working install as broken.
 
+### Why the plugin isn't wired per-repo
+
+A reasonable question: why not commit `extraKnownMarketplaces` + `enabledPlugins`
+to the repo's `.claude/settings.json`, so every clone gets vigiles? Because that
+is not what those keys do. Per the Claude Code
+[team-marketplaces docs](https://code.claude.com/docs/en/discover-plugins#configure-team-marketplaces),
+as of CC v2.1.195:
+
+> A plugin that only the project's `.claude/settings.json` enables, and that
+> comes from an external source such as a GitHub repository or npm package,
+> doesn't load until the team member installs it. Until then, Claude Code reports
+> the plugin as not installed and shows the `claude plugin install` command to run.
+
+vigiles ships from a GitHub marketplace, so that is exactly our case. Committing
+those keys makes Claude Code **prompt** each collaborator to install — useful,
+but it does not install, and a fresh clone or a CI job still has no plugin.
+Plugins can execute arbitrary code with your privileges, so requiring a
+per-machine, trusted install is deliberate, not an oversight.
+
+That is why the reachability warning above is **advisory and never scored**: it
+reports machine state that no repo-committed file can determine.
+
 ### Codex / GitHub Copilot
 
 Instruction file: `AGENTS.md`, read directly — there is no plugin or hook system.

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -77,11 +77,25 @@ user-scope install. A repo's `.claude/settings.json` carries _project_-level
 `enabledPlugins`, and a correctly-installed user-scope plugin **does not appear
 there**; judging it from `settings.json` alone reports a working install as broken.
 
-### Why the plugin isn't wired per-repo
+### What `init` commits to your repo — and what it can't
 
-A reasonable question: why not commit `extraKnownMarketplaces` + `enabledPlugins`
-to the repo's `.claude/settings.json`, so every clone gets vigiles? Because that
-is not what those keys do. Per the Claude Code
+`init` writes a **declaration** into your `.claude/settings.json`:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "vigiles": { "source": { "source": "github", "repo": "zernie/vigiles" } }
+  },
+  "enabledPlugins": { "vigiles@vigiles": true }
+}
+```
+
+It is **merged**, never overwritten — your hooks, permissions and other plugins
+are preserved, an existing `vigiles` entry is left alone (it may point at a
+fork), and an explicit `"vigiles@vigiles": false` is respected as a deliberate
+disable. Re-running `init` changes nothing.
+
+**What this does NOT do: install the plugin for anyone.** Per the Claude Code
 [team-marketplaces docs](https://code.claude.com/docs/en/discover-plugins#configure-team-marketplaces),
 as of CC v2.1.195:
 
@@ -90,14 +104,30 @@ as of CC v2.1.195:
 > doesn't load until the team member installs it. Until then, Claude Code reports
 > the plugin as not installed and shows the `claude plugin install` command to run.
 
-vigiles ships from a GitHub marketplace, so that is exactly our case. Committing
-those keys makes Claude Code **prompt** each collaborator to install — useful,
-but it does not install, and a fresh clone or a CI job still has no plugin.
-Plugins can execute arbitrary code with your privileges, so requiring a
-per-machine, trusted install is deliberate, not an oversight.
+vigiles ships from a GitHub marketplace, so that is exactly our case, and the
+boundary is deliberate — plugins execute arbitrary code with your privileges, so
+a repo is not permitted to install one on your behalf.
 
-That is why the reachability warning above is **advisory and never scored**: it
-reports machine state that no repo-committed file can determine.
+So the declaration buys **one** thing, and it is worth having: a collaborator who
+clones and never runs `init` currently gets **silence** — the npm package is
+there, its six skills are unreachable, and nothing says so. With the declaration,
+Claude Code tells them the project wants this plugin and prints the install
+command. **Silent absence becomes a prompt.** A fresh clone and a CI job still
+have no plugin until someone installs it.
+
+Nothing is vendored: two small JSON keys are a _reference_; the plugin content
+stays in the global cache, one copy shared across your repos.
+
+That is also why the reachability warning above is **advisory and never scored**:
+it reports machine state that no repo-committed file can determine.
+
+**Removing it** is a two-key edit — delete `extraKnownMarketplaces.vigiles` and
+`enabledPlugins["vigiles@vigiles"]`. `eject` does **not** do this: `eject` is the
+per-file inverse of `compile` ("hand this compiled file back to me"), and
+repo-scoped plugin wiring isn't a property of any one file. Uninstalling the
+global plugin is deliberately separate too — that install is shared by every repo
+on your machine, so one project can't speak for the others (`claude plugin
+uninstall vigiles@vigiles` if you do want it gone everywhere).
 
 ### Codex / GitHub Copilot
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -295,7 +295,7 @@ type one yourself; `compile` wires them for you.
 
 **Lighthouse for your harness.** Point vigiles at any plugin or repo (defaults to
 `.`) and get a one-command report — **no model, no API key, safe to run
-anywhere**: five deterministic **category rings**, each finding's **fix** inline,
+anywhere**: six **category rings**, each finding's **fix** inline,
 and a self-contained **HTML report**. It's a local report, not a CI step (CI uses
 [`lint`](#lint-files)).
 
@@ -306,22 +306,47 @@ Harness audit
   ◑ Triggering      92  ████████████████████░░
   ● Structure      100  ██████████████████████
   ● Safety         100  ██████████████████████
-  ◑ Tested          88  ███████████████████░░░
+  ◑ Tested          88  ███████████████████░░░  · advisory (not graded)
+  ? Evaluated  not measured                      · advisory (not graded)
+       └ 6 surfaces whose firing was never measured; not measured — run `npx vigiles audit` interactively to measure, or add a `*.eval.mjs` (`measureTriggerRate`, vigiles/testing)
 
 Harness health: B (95/100)
 ```
 
-The five categories — **Truthfulness** (refs resolve) · **Triggering** (skills
+The six categories — **Truthfulness** (refs resolve) · **Triggering** (skills
 fire / don't collide) · **Structure** (tool contracts, MCP, frontmatter) ·
 **Safety** (no unit holds all three lethal-trifecta legs — a prompt-injection
-exfil path) · **Tested** (coverage) — are each 0–100, weighted into the overall
-grade; an n/a category is excluded, never a false 0. All five are
+exfil path) · **Tested** (deterministic harness coverage) · **Evaluated**
+(real-model eval coverage) — are each 0–100, weighted into the overall
+grade; an n/a category is excluded, never a false 0. The first five are
 **deterministic** (no execution): **Safety** is the **static** lethal-trifecta
 capability check over a unit's declared tool-set. (The **executing** "do your
 hooks actually block?" disaster-battery is NOT a ring: running arbitrary hooks
 safely needs cross-platform confinement that isn't shipped yet — so it lives in
 the [`vigiles/testing` API](harness-testing.md) via `guardrail-check` /
 `assertBlocksDisasters`, where you opt in explicitly.)
+
+**Tested and Evaluated are two rings, not one number.** A harness
+(`*.harness.mjs`, `*.test.*`) is free, runs in milliseconds on every push, and
+asks _does this gate still catch what it claims?_ An eval (`*.eval.mjs`) spends
+real model calls, runs on a schedule, and asks the one question a deterministic
+read cannot: _does this skill fire at all?_ Folded together, a repo with complete
+deterministic coverage and no evals scored identically to a repo with neither —
+and the prescription ("add a test/eval") spanned three orders of magnitude in cost
+without saying which. Both rings are **advisory**: neither moves your grade.
+
+**Evaluated has three states, and the third one matters.**
+
+| state          | meaning                                                                                                       |
+| -------------- | ------------------------------------------------------------------------------------------------------------- |
+| a number       | measured — evals exist here; this is their coverage                                                           |
+| `0`            | the firing tier ran this session and nothing covers these surfaces                                            |
+| `not measured` | nobody asked. No eval on disk **and** the executing checks were skipped (headless, `--json`, a remembered no) |
+
+`not measured` is deliberately not a `0`: reporting the absence of a check as the
+result of a check is the exact failure mode vigiles flags in other people's
+harnesses. In that state the ring names the command that would answer the
+question, instead of leaving it to a line of prose at the end of the report.
 
 Under the rings, the detailed report lists per-skill description + user-invoked
 flag, per-agent tool contract (and the "no `tools:` line → inherits every tool"
@@ -601,7 +626,7 @@ different contracts** — the classic gate-vs-report split (think `eslint .` /
   severities → stable CI codes (0/1/2)**. It blocks bad commits.
 - **`audit` is the report** (Lighthouse-style, local — not a CI step). Zero config,
   harness-aware, works on **any** plugin (including third-party ones with no spec).
-  It scores the five deterministic category rings, ranks a whole marketplace
+  It scores the six category rings, ranks a whole marketplace
   (leaderboard), and writes the HTML report — all a safe read. Two **executing**
   checks (live MCP resolution + "do skills fire?") run only on the interactive
   consent (`audit-side-effect-free`); for automation, run those — and the safety

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,6 +27,40 @@ npx vigiles generate schema         # Emit JSON Schema for vigiles: frontmatter 
 npx vigiles generate harness [dir]  # Emit harness.gen.ts — one typed registry over every spec (--check to verify)
 ```
 
+### Arguments the CLI does not recognise are refused
+
+Every verb **rejects an unknown flag** with a non-zero exit (`2`), names it, and
+suggests the nearest real one:
+
+```bash
+$ npx vigiles audit --no-htlm
+✗ vigiles audit: unknown flag "--no-htlm".
+  Did you mean `--no-html`?
+```
+
+This matters most on `audit`, whose flags decide what **leaves the machine**
+(`--no-html`, `--no-json`, `--out=<dir>`, `--serve`). A swallowed typo produced
+the opposite of what was asked for, silently. Value flags take their value with
+`=` only (`--out=dir`, never `--out dir`) — the space-separated form is rejected
+rather than being read as a positional.
+
+`vigiles <verb> --help` prints that verb's help and its complete flag list
+instead of running the verb.
+
+### Exit codes
+
+| Code | Meaning                                                                           |
+| ---- | --------------------------------------------------------------------------------- |
+| `0`  | ran, nothing blocking                                                             |
+| `1`  | ran, and what you asked about is bad — lint findings, a failing harness script    |
+| `2`  | **could not do what you asked** — unknown flag, unknown harness, nothing to audit |
+
+`audit` in particular exits `2` when the target has **no instruction file and no
+surface at all**: there was nothing to measure, so no grade is reported. That is
+deliberately distinct from a harness that was audited and scored badly (exit
+`0`) — a script must be able to tell "this repo is unhealthy" from "I was
+pointed at the wrong directory".
+
 `vigiles test` / `vigiles eval` run scripts in JS **or** TS and report each as
 **pass / skip / fail** — a tier that can't run (e.g. deterministic with no
 `claude`) reports a loud `⊘ SKIPPED`, tallied separately, never a fake green.

--- a/docs/harness-testing.md
+++ b/docs/harness-testing.md
@@ -63,16 +63,54 @@ Start here. Pick the row that matches your question — each links to its sectio
 
 | I want to check…                                             | Use                                                            | Needs               |
 | ------------------------------------------------------------ | -------------------------------------------------------------- | ------------------- |
+| my **helper script** does what it claims                     | [`runScript`](#test-a-plain-program-runscript)                 | nothing             |
 | my **hook** blocks/allows an event                           | [`runHook`](#test-a-hook-in-isolation-runhook)                 | nothing             |
 | my hook/skill is **wired in** and actually fires             | [`runHarnessTest`](#test-the-assembled-machine-runharnesstest) | harness CLI, no key |
 | my **skill fires** on the right prompts (recall + precision) | [`measureTriggerRate`](#test-a-skill-fires-measuretriggerrate) | a real model        |
 | a change **moves the agent's behaviour** (A/B, with stats)   | [`runEval`](#test-a-change-moves-behaviour-runeval)            | a real model        |
 | the **references** my CLAUDE.md cites are real               | [`vigiles lint`](verifying-instruction-files.md)               | nothing             |
 
-The first two are **deterministic** — assert pass/fail, run on every commit, free.
-The model tiers **measure** (a rate ± error across trials) — run them occasionally
-on a keyed job, never gate a single run. Full API detail lives in the
-**[Testing API reference](testing-api.md)**.
+The first three are **deterministic** — assert pass/fail, run on every commit,
+free. The model tiers **measure** (a rate ± error across trials) — run them
+occasionally on a keyed job, never gate a single run. Full API detail lives in
+the **[Testing API reference](testing-api.md)**.
+
+## Test a plain program (`runScript`)
+
+Your harness is not only hooks and skills — it's also the helper scripts they
+shell out to. `runScript` runs any program and reports **what it did**: exit
+code, **both** streams, and (when confined) what it wrote and what it reached.
+
+```ts
+import { runScript } from "vigiles/unit";
+
+const r = runScript("bash scripts/check-links.sh", { cwd: repoDir });
+assert.equal(r.exitCode, 0);
+assert.match(r.stderr, /0 broken links/); // advisory output lives on STDERR
+```
+
+> ⚠️ **Don't hand-roll this with `execFileSync`.** It returns **stdout alone** on
+> success, so advisory output — including vigiles's own compiled-hook `notice()`
+> — silently vanishes, and a perfectly healthy react hook reports as **dead**.
+> Every vigiles runner returns both streams, which makes that bug
+> unrepresentable.
+
+**`runScript` vs `runHook`.** `runHook` _is_ `runScript` plus the hook protocol
+(serialize the event to stdin, read the exit code as allow/deny). Pick by the
+question: a **hook** has a _decision_, a **script** has _effects_. That is why
+`ScriptRunResult` carries no `decision` field — an always-meaningless field
+teaches the reader the field means nothing.
+
+**Asserting what it wrote needs confinement.** `filesWritten` comes from diffing
+the work dir, which only a confined run does, so it is `undefined` after a plain
+run — deliberately not `[]` ("recorded, wrote nothing"). `assertNoWrite` /
+`assertWroteOnly` **throw** on an unrecorded result rather than pass having
+looked at nothing:
+
+```ts
+const r = runScript("bash scripts/build.sh", { cwd: repoDir, sandbox: "auto" });
+assertWroteOnly(r, [/^dist\//]); // meaningful: writes were actually recorded
+```
 
 ## Test a hook in isolation (`runHook`)
 

--- a/docs/non-js-harnesses.md
+++ b/docs/non-js-harnesses.md
@@ -15,10 +15,10 @@ through `npx vigiles`.
 Everything below runs with **only `npx`** (Node is fetched on demand) — no
 `package.json`, no install step, identical output on every OS:
 
-| Command             | Works? | What it checks                                                                                                                                                                                                                      |
-| ------------------- | :----: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `npx vigiles audit` |   ✅   | The four deterministic rings — Truthfulness (references resolve), Triggering (skills fire / don't collide), Structure (tool contracts, MCP, frontmatter), Safety — plus the advisory Tested count. A local report, like Lighthouse. |
-| `npx vigiles lint`  |   ✅   | The CI gate — reference integrity, subagent tool contracts, hook events/scripts, MCP resolution, skill triggers, lethal-trifecta. Exit codes 0/1/2.                                                                                 |
+| Command             | Works? | What it checks                                                                                                                                                                                                                                                                                                     |
+| ------------------- | :----: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `npx vigiles audit` |   ✅   | The four deterministic rings — Truthfulness (references resolve), Triggering (skills fire / don't collide), Structure (tool contracts, MCP, frontmatter), Safety — plus the advisory Tested (deterministic harnesses) and Evaluated (real-model evals, or `not measured`) counts. A local report, like Lighthouse. |
+| `npx vigiles lint`  |   ✅   | The CI gate — reference integrity, subagent tool contracts, hook events/scripts, MCP resolution, skill triggers, lethal-trifecta. Exit codes 0/1/2.                                                                                                                                                                |
 
 None of these read your repo's source language — they read the **harness**
 (`CLAUDE.md`/`AGENTS.md`, `skills/`, `agents/`, hooks, MCP config), which is
@@ -76,10 +76,14 @@ verify less):
 See [`docs/linter-support.md`](linter-support.md) for the full linter list and
 each tool's config conventions.
 
-## The Tested metric for a native test loop
+## The Tested / Evaluated metrics for a native test loop
 
-`audit`/`lint` count vigiles-native `*.eval.mjs` / `*.harness.mjs` files for the
-advisory **Tested** metric. If you test your skills through a native loop instead
+`audit`/`lint` count vigiles-native files for two advisory metrics, split by what
+they cost and what they answer: `*.harness.mjs` (plus `*.test.*`) feeds **Tested**
+— free, deterministic, every push — and `*.eval.mjs` feeds **Evaluated**, the
+paid real-model tier that is the only thing that can say whether a skill fires.
+A file matched by a custom `testGlobs` counts toward **Tested**. If you test your
+skills through a native loop instead
 (a Kotlin test suite, a Go benchmark, a promptfoo config), point `testGlobs` at
 it so those files count — see
 [the external-suite section in the untested-skill rule](rules/untested-skill.md#counting-an-external-test-suite-promptfoo-a-home-grown-eval-loop).

--- a/docs/rules/untested-hook.md
+++ b/docs/rules/untested-hook.md
@@ -34,9 +34,12 @@ only). Inline shell one-liners have nowhere to colocate a test and are not scann
 
 ## What counts as "tested"
 
-Two detectors, OR'd: **colocation** (`hooks/pre-edit.harness.mjs` next to
-`hooks/pre-edit.sh`) OR **content-reference** (any test naming the hook by path,
-e.g. `hooks/pre-edit.sh`).
+Three detectors, OR'd: **declaration** (`// vigiles:covers hooks/pre-edit.sh` in
+the test file) OR **colocation** (`hooks/pre-edit.harness.mjs` next to
+`hooks/pre-edit.sh`) OR **content-reference** (any test whose _code_ names the
+hook by path, e.g. `hooks/pre-edit.sh` — comments don't count). See
+[`untested-skill`](untested-skill.md#what-counts-as-tested) for the shared
+mechanics and why the three are reported separately.
 
 ## Exemptions
 

--- a/docs/rules/untested-skill.md
+++ b/docs/rules/untested-skill.md
@@ -48,11 +48,28 @@ skills — not vendored, fixture, or nested copies).
 
 ## What counts as "tested"
 
-Two detectors, OR'd — a test placed **anywhere** counts:
+Three detectors, OR'd — a test placed **anywhere** counts — and the audit report
+prints **which one** decided each surface, because the three are not equally
+strong:
 
-1. **Colocation** — a `*.{harness,eval}.mjs` inside the skill dir (`skills/foo/`).
-2. **Content-reference** — any discovered test (incl. `*.test.ts`) that names the
-   skill by **path** (`skills/foo`) or **namespace** (`vigiles:foo`).
+1. **Declaration** — a `vigiles:covers <surface>` marker in the test file. The
+   strongest evidence: it cannot happen by accident, and it is the only detector a
+   harness that builds its paths at **runtime** can reach.
+
+   ```js
+   // vigiles:covers skills/foo, skills/bar
+   for (const name of ["foo", "bar"]) assertSkill(join(root, "skills", name));
+   ```
+
+2. **Colocation** — a `*.{harness,eval}.mjs` inside the skill dir (`skills/foo/`).
+3. **Content-reference** — any discovered test (incl. `*.test.ts`) whose **code**
+   names the skill by **path** (`skills/foo`) or **namespace** (`vigiles:foo`).
+   The weakest: it only says the name appears.
+
+> **Comments do not count.** A skill path written in a comment is prose _about_ a
+> test, not a test — and counting it made the coverage number gameable by one
+> line. If a test really does cover a surface its code never names, say so with
+> `vigiles:covers`.
 
 ## Counting an external test suite (promptfoo, a home-grown eval loop)
 
@@ -79,16 +96,20 @@ surface reading as "untested":
 ```
 
 A discovered file counts as covering a skill when it **names that skill by its
-path or namespace token** (`skills/foo` or `vigiles:foo`) — the same
-content-reference rule above. So an external suite counts as long as it references
-each skill by path/namespace somewhere (a comment, a `file://` path, a
-`description` field), not only by free-text prompt.
+path or namespace token** (`skills/foo` or `vigiles:foo`) outside a comment — the
+same content-reference rule above — or when it **declares** the skill with
+`vigiles:covers`.
 
 > **Heads-up:** an external config that references a skill **only** by prose
-> prompt text (never its path/namespace) won't match yet, even when added to
-> `testGlobs` — add the skill's path in a comment or a `file://` reference to make
-> it count. A looser, name-based match is under consideration (it trades
-> precision, so it's not the default).
+> prompt text (never its path/namespace) won't match, even when added to
+> `testGlobs`. Declare it instead:
+>
+> ```yaml
+> # vigiles:covers skills/foo
+> ```
+>
+> Comment syntax is fine for the marker — the marker is read before comments are
+> stripped. What does _not_ work is hoping a bare mention in a comment is noticed.
 
 ## Exemptions
 

--- a/docs/rules/untested-subagent.md
+++ b/docs/rules/untested-subagent.md
@@ -34,10 +34,12 @@ Scans `agents/*.md` and `.claude/agents/*.md`.
 
 ## What counts as "tested"
 
-Two detectors, OR'd: **colocation** (`agents/bar.harness.mjs` next to
-`agents/bar.md`) OR **content-reference** (any test naming the agent by path,
-e.g. `agents/bar`). See [`untested-skill`](untested-skill.md#what-counts-as-tested)
-for the shared mechanics.
+Three detectors, OR'd: **declaration** (`// vigiles:covers agents/bar` in the test
+file) OR **colocation** (`agents/bar.harness.mjs` next to `agents/bar.md`) OR
+**content-reference** (any test whose _code_ names the agent by path, e.g.
+`agents/bar` — comments don't count). See
+[`untested-skill`](untested-skill.md#what-counts-as-tested) for the shared
+mechanics.
 
 ## Exemptions
 

--- a/docs/sandboxing.md
+++ b/docs/sandboxing.md
@@ -46,7 +46,7 @@ kernel.apparmor_restrict_unprivileged_userns=0` (see `.github/workflows/ci.yml`)
 1. ❌ **Reading is NOT isolated.** The whole host `/` is mounted read-only, so a hook can `cat /home/you/.ssh/id_rsa` or `cat /home/you/.aws/credentials`. Environment secrets are cleared (`--clearenv`, so `ANTHROPIC_API_KEY` isn't visible), but **secrets on disk are readable**. What saves you is that egress is blocked — it can read but can't send. (A future `strictFs` mode would bind a minimal rootfs instead of all of `/`, at the cost of compatibility.)
 2. ⚠️ **Only Tier A.** With `sandbox: false` / trusted-inline, the hook runs with **full host access** — `rm -rf ~` really deletes your home. That's by design (it's code you wrote), but it means the protection above applies only to _confined_ runs.
 
-**Record what it wrote.** A confined `runHook` also reports the files the hook touched in its work dir (`r.filesWritten`, relative paths) — so you can assert a hook stayed in its lane:
+**Record what it wrote.** A confined `runHook` / `runScript` also reports the files it touched in its work dir (`r.filesWritten`, relative paths) — so you can assert it stayed in its lane:
 
 ```ts
 import { assertWroteOnly, assertNoWrite } from "vigiles/testing";
@@ -56,6 +56,15 @@ const r = runHook(thirdPartyHookCmd, event, { trusted: false });
 assertWroteOnly(r, [/^\.omc\//]); // only its own state cache
 assertNoWrite(r, /\.(env|pem|key)$/); // never a secret-shaped file
 ```
+
+🔴 **Recording requires confinement, and an unrecorded run refuses.** The write list comes from diffing the work dir before and after, which only happens under confinement. An **unconfined** run therefore leaves `filesWritten` as **`undefined`** — which is deliberately _not_ `[]`:
+
+| Value       | Means                                      |
+| ----------- | ------------------------------------------ |
+| `undefined` | nobody looked — writes were never recorded |
+| `[]`        | looked, and it wrote nothing               |
+
+`assertNoWrite` / `assertWroteOnly` **throw** on `undefined` rather than return green, and the message tells you to pass `{ sandbox: "auto" }`. Collapsing the two would let a write assertion report success having inspected no evidence — a checker that passes while doing nothing is precisely what vigiles exists to catch elsewhere, so it must not be the default here.
 
 Dogfood: `src/run-hook.test.ts` confines oh-my-claudecode's `keyword-detector` and asserts it writes **only** under `.omc/` — its keyword-state cache, nothing else.
 

--- a/docs/testing-api.md
+++ b/docs/testing-api.md
@@ -6,6 +6,7 @@ how-to; this is the reference you reach for when you need the exact name or knob
 
 ## Contents
 
+- [Picking a runner](#picking-a-runner)
 - [The `Trace` model](#the-trace-model)
 - [Predicates](#predicates)
 - [Assertions](#assertions)
@@ -16,6 +17,37 @@ how-to; this is the reference you reach for when you need the exact name or knob
 - [`runEval`, `measure`, `measureArms`](#runeval-measure-measurearms)
 - [Significance &amp; regression gating](#significance--regression-gating)
 - [Imports &amp; harness selection](#imports--harness-selection)
+
+## Picking a runner
+
+Four runners, keyed on the question you actually have. The first three are free
+and deterministic; only the last needs a model.
+
+| Your question                                                  | Runner                           | Result              | Cost                |
+| -------------------------------------------------------------- | -------------------------------- | ------------------- | ------------------- |
+| does my **helper script** do what it claims?                   | `runScript`                      | `ScriptRunResult`   | free                |
+| does my **hook** block what it says it blocks?                 | `runHook`                        | `HookRunResult`     | free                |
+| does the **assembled harness** behave (hooks+settings+skills)? | `runHarnessTest`                 | `HarnessTestResult` | free, needs the CLI |
+| does the **real model** pick my skill / do the job?            | `measureTriggerRate` / `runEval` | reports             | **paid**            |
+
+`runHarnessTest` is deterministic and **free** despite its `model:` field — those
+are _scripted_ turns (`ModelTurn[]`) served by a mock. Nothing reaches a real
+model at that tier.
+
+**`runScript` is the primitive; `runHook` is it plus the hook protocol** (event →
+stdin, exit code → allow/deny). A **hook** has a _decision_; a **script** has
+_effects_ — so `ScriptRunResult` deliberately carries no `decision` field.
+
+**Both streams, always.** `ScriptRunResult`, `HookRunResult` and
+`HarnessTestResult` all carry `stdout` **and** `stderr`. That matters more than
+it looks: advisory output — including vigiles's own compiled-hook `notice()` —
+goes to **stderr**, so a hand-rolled `execFileSync` runner (which returns stdout
+alone on success) silently deletes it and reports a healthy react hook as dead.
+
+**`filesWritten` is `undefined` until something records it.** Writes are captured
+by diffing the work dir, which only a confined run does. `undefined` means
+"nobody looked"; `[]` means "looked, wrote nothing" — `assertNoWrite` /
+`assertWroteOnly` throw on the former instead of passing vacuously.
 
 ## The `Trace` model
 

--- a/packages/report-view/src/Report.tsx
+++ b/packages/report-view/src/Report.tsx
@@ -15,6 +15,7 @@ import type {
   Recommendation,
   Verdict,
 } from "./schema";
+import { categoryScoreLabel } from "./schema";
 import { Card } from "./components/ui/card";
 import { Badge } from "./components/ui/badge";
 import { Adoptability } from "./components/Adoptability";
@@ -275,8 +276,8 @@ function SafetyCard({ finding }: { finding: string }) {
   );
 }
 
-/** A compact category cell — a thin band bar + score, so the five read as one
- * scannable strip rather than five heavy rings competing with the verdict. */
+/** A compact category cell — a thin band bar + score, so the six read as one
+ * scannable strip rather than six heavy rings competing with the verdict. */
 function CategoryCell({ c }: { c: CategoryScore }) {
   const b: Band = c.advisory ? "na" : band(c.score);
   const pct = c.score === null ? 0 : Math.max(0, Math.min(100, c.score));
@@ -284,8 +285,21 @@ function CategoryCell({ c }: { c: CategoryScore }) {
     <Card className="flex flex-col gap-2 p-3">
       <div className="flex items-baseline justify-between gap-2">
         <span className="text-xs font-semibold">{c.key}</span>
-        <span className={cn("text-sm font-bold", TEXT[b])}>
-          {c.advisory ? "—" : c.score === null ? "n/a" : c.score}
+        {/* An UNASKED question gets its own label — never the advisory em-dash
+            (which reads "measured, just not graded") and never a 0. */}
+        <span
+          className={cn(
+            c.notMeasured ? "text-[11px] font-semibold" : "text-sm font-bold",
+            TEXT[b],
+          )}
+        >
+          {c.notMeasured
+            ? "not measured"
+            : c.advisory
+              ? "—"
+              : c.score === null
+                ? "n/a"
+                : c.score}
         </span>
       </div>
       <div className="h-1.5 overflow-hidden rounded-full bg-border">
@@ -295,7 +309,11 @@ function CategoryCell({ c }: { c: CategoryScore }) {
         />
       </div>
       <div className="h-8 overflow-hidden text-[11px] leading-tight text-muted-foreground">
-        {c.advisory ? (
+        {c.notMeasured ? (
+          <span className="line-clamp-2 text-na">
+            {c.findings[c.findings.length - 1] ?? "never measured"}
+          </span>
+        ) : c.advisory ? (
           <span className="text-na">advisory — not graded</span>
         ) : c.findings.length > 0 ? (
           <span className="line-clamp-2">
@@ -348,7 +366,10 @@ function CategoryRow({
   // move the grade. Show that number (muted, `na` tone) so the number and the bar
   // AGREE; the "advisory, not graded" tag in the finding line says it doesn't count.
   // (A "—" beside a 94%-filled bar reads as a rendering bug.)
-  const scoreLabel = c.score === null ? "n/a" : String(c.score);
+  // `categoryScoreLabel` keeps THREE states apart: a number, `n/a` (nothing to
+  // assess), and `not measured` (nobody asked). A 0 and an unasked question are
+  // different facts and must not render the same string.
+  const scoreLabel = categoryScoreLabel(c);
   return (
     <div className="py-3">
       <div className="flex items-baseline justify-between gap-3">
@@ -798,7 +819,7 @@ export function Report({
       <h2 className="mb-3 mt-9 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
         Categories
       </h2>
-      <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-3 lg:grid-cols-5">
+      <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-3 lg:grid-cols-6">
         {score.categories.map((c) => (
           <CategoryCell key={c.key} c={c} />
         ))}

--- a/packages/report-view/src/sample.ts
+++ b/packages/report-view/src/sample.ts
@@ -40,7 +40,22 @@ export const SAMPLE: AuditReport = {
         key: "Tested",
         score: 88,
         weight: 1,
-        findings: ["4 untested surfaces"],
+        advisory: true,
+        findings: ["4 surfaces with no vigiles harness (deterministic, free)"],
+      },
+      // The THIRD state, in the sample on purpose: a deterministic read never
+      // asks whether a skill fires, so the ring says so rather than reporting an
+      // unearned 0.
+      {
+        key: "Evaluated",
+        score: null,
+        weight: 1,
+        advisory: true,
+        notMeasured: true,
+        findings: [
+          "4 surfaces whose firing was never measured",
+          "not measured — run `npx vigiles audit` interactively to measure, or add a `*.eval.mjs` (`measureTriggerRate`, vigiles/testing)",
+        ],
       },
     ],
   },
@@ -81,6 +96,8 @@ export const SAMPLE: AuditReport = {
     commands: 0,
     mcp: false,
     untested: 4,
+    untestedHarness: 4,
+    unevaluated: 4,
   },
   adoptable: {
     createAllCommand: "npx vigiles init",

--- a/packages/report-view/src/schema.ts
+++ b/packages/report-view/src/schema.ts
@@ -97,6 +97,18 @@ export interface AuditInventory {
   commands: number;
   mcp: boolean;
   untested: number;
+  /**
+   * The per-tier split behind `untested`, emitted since the Evaluated ring landed: surfaces with no
+   * deterministic harness, and surfaces whose firing was never measured. Optional because a report
+   * produced before the split carries neither, and the view must still render an older artifact.
+   *
+   * 🔴 These reached the ENGINE's inventory and not this mirror, so `sample.ts` set two fields the
+   * type did not have. It went unnoticed because CI typechecks the root project and `test/types` and
+   * never `-p site/tsconfig.json` — the same shape as every other defect in this PR: a check that
+   * exists, passes, and does not cover the thing that broke.
+   */
+  untestedHarness?: number;
+  unevaluated?: number;
 }
 
 export interface BrokenRef {

--- a/packages/report-view/src/schema.ts
+++ b/packages/report-view/src/schema.ts
@@ -10,7 +10,10 @@ export type CategoryKey =
   | "Triggering"
   | "Structure"
   | "Safety"
-  | "Tested";
+  /** DETERMINISTIC harness coverage — free, milliseconds, every push. */
+  | "Tested"
+  /** REAL-MODEL eval coverage — paid, minutes, scheduled. Does a skill FIRE? */
+  | "Evaluated";
 
 export interface CategoryScore {
   key: CategoryKey;
@@ -23,7 +26,23 @@ export interface CategoryScore {
    * failing/red ring that appears to drag the grade.
    */
   advisory?: boolean;
+  /**
+   * `score: null` because this run never ASKED the question — distinct from `null`
+   * meaning "nothing to assess" (plain n/a) and from a measured `0`. Rendering an
+   * unasked question as a zero reports the absence of a check as the result of
+   * one. Carries a finding naming the command that would measure it.
+   */
+  notMeasured?: boolean;
   findings: string[];
+}
+
+/**
+ * The ring's number as the reader sees it — THREE labels, never two. Mirror of
+ * the CLI's `categoryScoreLabel` (src/audit-score.ts); keep them in step.
+ */
+export function categoryScoreLabel(c: CategoryScore): string {
+  if (c.score !== null) return String(c.score);
+  return c.notMeasured ? "not measured" : "n/a";
 }
 
 export interface AuditScore {

--- a/site/scripts/gen-parity-expected.mjs
+++ b/site/scripts/gen-parity-expected.mjs
@@ -10,6 +10,7 @@
  */
 import { readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { format } from "prettier";
 
 import { scanFiles } from "../../dist/scan-files.js";
 import { buildAuditReport } from "../../dist/audit-report.js";
@@ -32,9 +33,21 @@ const audit = buildAuditReport(report, {
 // Mirror runAudit's meta.dir override.
 const withSlug = { ...audit, meta: { ...audit.meta, dir: SLUG } };
 
+// Write through PRETTIER, not `JSON.stringify` alone. The repo gates CI on
+// `prettier --check .`, and prettier's JSON printer is not `JSON.stringify(…, 2)`
+// (it collapses short arrays onto one line). So every regeneration used to leave
+// a committed file that fails the format check LATER and far from the cause —
+// the same shape as the stale-prebundle defect this fixture's own test hit.
+// Formatting here removes the state instead of asking the next person to
+// remember a follow-up command. Not `.prettierignore`: the fixture is committed
+// and reviewed, so its diffs should look like every other file's.
+const out = here("../src/demo/__fixtures__/sample-repo.expected.json");
 writeFileSync(
-  here("../src/demo/__fixtures__/sample-repo.expected.json"),
-  JSON.stringify(withSlug, null, 2) + "\n",
+  out,
+  await format(JSON.stringify(withSlug, null, 2), {
+    parser: "json",
+    filepath: out,
+  }),
 );
 console.log(
   `wrote expected: grade ${withSlug.score.grade} (${withSlug.score.overall}), ${withSlug.recommendations.length} recs`,

--- a/site/src/checks/checks.ts
+++ b/site/src/checks/checks.ts
@@ -31,7 +31,10 @@ export interface CheckDoc {
     | "Triggering"
     | "Structure"
     | "Safety"
-    | "Tested";
+    /** Deterministic harness coverage — free, every push. */
+    | "Tested"
+    /** Real-model eval coverage — paid, scheduled. Does a skill FIRE? */
+    | "Evaluated";
 }
 
 const GH = "https://github.com/zernie/vigiles/blob/main/docs/rules";

--- a/site/src/components/sections/VerbMap.tsx
+++ b/site/src/components/sections/VerbMap.tsx
@@ -25,7 +25,7 @@ const VERBS: {
     answers: "Everything, graded A–F",
     model: "no model · read-only · anytime",
     detail:
-      "The zero-config front door. One command reads your whole harness and grades it across five categories — truthful references, skills that trigger, sound structure, safety, test coverage. Nothing executes; it's a local report, like Lighthouse.",
+      "The zero-config front door. One command reads your whole harness and grades it across six categories — truthful references, skills that trigger, sound structure, safety, deterministic test coverage, and whether anything has measured that your skills actually fire. Nothing executes; it's a local report, like Lighthouse.",
     before: 'hook on event "Setup" — no such event, never fires',
     after: 'hook on event "SessionStart" — fires every session',
   },

--- a/site/src/components/sections/Wedge.tsx
+++ b/site/src/components/sections/Wedge.tsx
@@ -98,7 +98,7 @@ export function Wedge() {
           ))}
         </div>
 
-        {/* The resolution — one line (the five graded categories are shown live in
+        {/* The resolution — one line (the six categories are shown live in
             the report above, so we don't re-list them here), then the linter strip
             as Truthfulness's deepest detail. */}
         <div className="mt-16 border-t border-border pt-12">
@@ -106,9 +106,9 @@ export function Wedge() {
             <span className="font-semibold text-foreground">
               vigiles grades all of it
             </span>{" "}
-            — one deterministic, model-free score across five categories (see
-            the report above). The deepest check: every rule your instructions
-            name is resolved against your real linter — it must exist{" "}
+            — one deterministic, model-free score across six categories (see the
+            report above). The deepest check: every rule your instructions name
+            is resolved against your real linter — it must exist{" "}
             <span className="text-foreground">and</span> be enabled — across
             eleven linters, from JS to Rust to Go to Kotlin:
           </p>

--- a/site/src/demo/__fixtures__/sample-repo.expected.json
+++ b/site/src/demo/__fixtures__/sample-repo.expected.json
@@ -24,17 +24,13 @@
         "key": "Triggering",
         "score": 92,
         "weight": 1,
-        "findings": [
-          "1 near-identical skill description (wrong one fires)"
-        ]
+        "findings": ["1 near-identical skill description (wrong one fires)"]
       },
       {
         "key": "Structure",
         "score": 92,
         "weight": 1,
-        "findings": [
-          "1 unavailable agent tool (typo / never-available)"
-        ]
+        "findings": ["1 unavailable agent tool (typo / never-available)"]
       },
       {
         "key": "Safety",
@@ -51,9 +47,7 @@
         "score": 91,
         "weight": 1,
         "advisory": true,
-        "findings": [
-          "3 surfaces with no vigiles harness (deterministic, free)"
-        ]
+        "findings": ["3 surfaces with no vigiles harness (deterministic, free)"]
       },
       {
         "key": "Evaluated",
@@ -130,7 +124,5 @@
       "mention": 0
     }
   },
-  "brokenReferences": [
-    "hooks/guard.sh"
-  ]
+  "brokenReferences": ["hooks/guard.sh"]
 }

--- a/site/src/demo/__fixtures__/sample-repo.expected.json
+++ b/site/src/demo/__fixtures__/sample-repo.expected.json
@@ -24,13 +24,17 @@
         "key": "Triggering",
         "score": 92,
         "weight": 1,
-        "findings": ["1 near-identical skill description (wrong one fires)"]
+        "findings": [
+          "1 near-identical skill description (wrong one fires)"
+        ]
       },
       {
         "key": "Structure",
         "score": 92,
         "weight": 1,
-        "findings": ["1 unavailable agent tool (typo / never-available)"]
+        "findings": [
+          "1 unavailable agent tool (typo / never-available)"
+        ]
       },
       {
         "key": "Safety",
@@ -47,7 +51,20 @@
         "score": 91,
         "weight": 1,
         "advisory": true,
-        "findings": ["3 surfaces with no vigiles test/eval"]
+        "findings": [
+          "3 surfaces with no vigiles harness (deterministic, free)"
+        ]
+      },
+      {
+        "key": "Evaluated",
+        "score": null,
+        "weight": 1,
+        "advisory": true,
+        "notMeasured": true,
+        "findings": [
+          "3 surfaces whose firing was never measured",
+          "not measured — run `npx vigiles audit` interactively to measure, or add a `*.eval.mjs` (`measureTriggerRate`, vigiles/testing)"
+        ]
       }
     ],
     "empty": false
@@ -104,7 +121,11 @@
     "hooks": 1,
     "commands": 0,
     "mcp": false,
-    "untested": 3
+    "untested": 3,
+    "untestedHarness": 3,
+    "unevaluated": 3
   },
-  "brokenReferences": ["hooks/guard.sh"]
+  "brokenReferences": [
+    "hooks/guard.sh"
+  ]
 }

--- a/site/src/demo/__fixtures__/sample-repo.expected.json
+++ b/site/src/demo/__fixtures__/sample-repo.expected.json
@@ -123,7 +123,12 @@
     "mcp": false,
     "untested": 3,
     "untestedHarness": 3,
-    "unevaluated": 3
+    "unevaluated": 3,
+    "coverageEvidence": {
+      "declared": 0,
+      "colocated": 0,
+      "mention": 0
+    }
   },
   "brokenReferences": [
     "hooks/guard.sh"

--- a/site/src/demo/browser-parity.browser.test.ts
+++ b/site/src/demo/browser-parity.browser.test.ts
@@ -11,6 +11,16 @@
  * If it fails: pako and node:zlib disagree on this input — do NOT paper over it;
  * report it. (Regenerate the expected only after an intentional engine change:
  * `node site/scripts/gen-parity-expected.mjs`.)
+ *
+ * That instruction used to be correct for only ONE of the two states this test
+ * could be in. Vite's dependency prebundle (`site/node_modules/.vite`) survived
+ * `npm run build`, so the browser could compute against a PREVIOUS engine and
+ * fail with a field-level diff indistinguishable from a real divergence —
+ * sending the reader after a pako bug that did not exist (observed 2026-08-07).
+ * `site/vitest.config.ts` now keys the prebundle cache DIRECTORY on a fingerprint
+ * of `dist/`, so "the browser ran an older engine than Node" is no longer a
+ * reachable state, and the instruction above is true again for every way this
+ * test can fail. See site/vite.engine-stamp.ts.
  */
 import { describe, it, expect } from "vitest";
 import { runAudit } from "./runAudit";
@@ -20,7 +30,13 @@ import expected from "./__fixtures__/sample-repo.expected.json";
 describe("browser audit parity (pako === node:zlib)", () => {
   it("produces the identical AuditReport in-browser as Node does", () => {
     const got = runAudit(files as Record<string, string>, "acme/widgets");
-    expect(got).toEqual(expected);
+    expect(
+      got,
+      "in-browser AuditReport differs from the Node-generated expected. The " +
+        "prebundle cache is keyed to dist/, so this should be a REAL pako-vs-" +
+        "node:zlib divergence or an intentional engine change (regenerate with " +
+        "`node site/scripts/gen-parity-expected.mjs`) — not a stale cache.",
+    ).toEqual(expected);
   });
 
   it("the sample actually exercises the NCD overlap path (non-A grade)", () => {

--- a/site/vite.engine-stamp.ts
+++ b/site/vite.engine-stamp.ts
@@ -1,0 +1,82 @@
+import { createHash } from "node:crypto";
+import { readdirSync, rmSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * A fingerprint of the BUILT engine (`dist/`), used to key the browser-test
+ * dependency-prebundle cache so a stale prebundle is unrepresentable.
+ *
+ * ## Why this exists
+ *
+ * `site/vitest.config.ts` pre-bundles `@engine/scan-files` and
+ * `@engine/audit-report` — the repo-root `dist/` CJS — via `optimizeDeps`, and
+ * Vite caches the result under `site/node_modules/.vite`. That cache SURVIVES
+ * `npm run build`: Vite invalidates it on config/lockfile changes, not on the
+ * mtimes of an aliased path outside `node_modules`. So the browser side can run
+ * against a PREVIOUS engine while Node runs against the current one, and
+ * `browser-parity.browser.test.ts` then fails with a field-level diff that looks
+ * EXACTLY like a genuine pako-vs-node:zlib divergence.
+ *
+ * Observed 2026-08-07: after an engine change added a report field, the parity
+ * test failed showing the field present on the Node side and absent on the
+ * browser side. That was read aloud as a real engine divergence and a hunt began
+ * for a parity bug that did not exist. `rm -rf site/node_modules/.vite` → 42/42.
+ *
+ * ## Why a cache KEY and not a staleness check
+ *
+ * The alternatives were: compare the cache's mtime against `dist/` and force a
+ * re-bundle when it loses, or clear `.vite` in the test script. Both work, and
+ * both leave a state that has to be DETECTED — a comparison someone can get
+ * wrong, or a script step someone can bypass by running `vitest` directly. Keying
+ * the cache DIRECTORY on the engine fingerprint removes the state instead: a
+ * different `dist/` is a different cache path, so "prebundle built from another
+ * engine" cannot be reached, and an unchanged `dist/` still gets a warm cache. By
+ * construction rather than by check — the same argument this project makes about
+ * removing a capability instead of policing its use.
+ */
+export function engineStamp(distDir: string): string {
+  const hash = createHash("sha1");
+  const walk = (dir: string): void => {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+        a.name < b.name ? -1 : 1,
+      );
+    } catch {
+      // No dist yet (a fresh clone running tests before `npm run build`). An
+      // empty stamp is honest: there is no engine to be stale against.
+      return;
+    }
+    for (const e of entries) {
+      const p = join(dir, e.name);
+      if (e.isDirectory()) {
+        walk(p);
+      } else if (e.name.endsWith(".js")) {
+        const s = statSync(p);
+        hash.update(`${p}:${String(s.size)}:${String(s.mtimeMs)}\n`);
+      }
+    }
+  };
+  walk(distDir);
+  return hash.digest("hex").slice(0, 12);
+}
+
+/**
+ * Delete the prebundle caches keyed to OTHER engine fingerprints, so keying the
+ * directory doesn't turn into an unbounded pile of them under `node_modules`.
+ * Best-effort: a failure here costs disk, never correctness.
+ */
+export function sweepStaleEngineCaches(
+  nodeModulesDir: string,
+  keep: string,
+): void {
+  try {
+    for (const name of readdirSync(nodeModulesDir)) {
+      if (name.startsWith(".vite-engine-") && name !== keep) {
+        rmSync(join(nodeModulesDir, name), { recursive: true, force: true });
+      }
+    }
+  } catch {
+    /* no node_modules yet, or a read-only FS — nothing to sweep */
+  }
+}

--- a/site/vitest.config.ts
+++ b/site/vitest.config.ts
@@ -4,6 +4,23 @@ import react from "@vitejs/plugin-react";
 import { playwright } from "@vitest/browser-playwright";
 import { aliases } from "./vite.aliases";
 import { ENGINE_VERSION } from "./vite.engine-version";
+import { engineStamp, sweepStaleEngineCaches } from "./vite.engine-stamp";
+
+// Key the dependency-prebundle cache on the BUILT engine's fingerprint. Vite
+// otherwise keeps a prebundle of the PREVIOUS `dist/` across `npm run build` (it
+// invalidates on config/lockfile changes, not on the mtimes of an aliased path
+// outside node_modules), so the browser side computes against a stale engine and
+// `browser-parity.browser.test.ts` fails with a field-level diff that looks
+// exactly like a genuine pako-vs-node:zlib divergence. A different `dist/` is now
+// a different cache directory, so that state is unreachable rather than merely
+// detected. Full incident + why a key beats a check: ./vite.engine-stamp.ts.
+const engineCacheDir = `.vite-engine-${engineStamp(
+  fileURLToPath(new URL("../dist", import.meta.url)),
+)}`;
+sweepStaleEngineCaches(
+  fileURLToPath(new URL("./node_modules", import.meta.url)),
+  engineCacheDir,
+);
 
 // Browser-mode tests for the live demo (real Chromium + real pako, so the
 // pako-vs-node-zlib parity is closed for real, not mocked). Runs
@@ -12,6 +29,7 @@ import { ENGINE_VERSION } from "./vite.engine-version";
 // engine's own suites); this config never touches those.
 export default defineConfig({
   plugins: [react()],
+  cacheDir: `node_modules/${engineCacheDir}`,
   resolve: { alias: aliases },
   // The engine dist is CJS living OUTSIDE node_modules. Have Vite's optimizer
   // (esbuild) pre-bundle it via the aliases — esbuild's CJS→ESM interop exposes

--- a/skills/test-harness/SKILL.md
+++ b/skills/test-harness/SKILL.md
@@ -187,24 +187,32 @@ unrepresentable:
 
 | Runner           | Result              | Carries                                             |
 | ---------------- | ------------------- | --------------------------------------------------- |
-| `runHook`        | `HookRunResult`     | `exitCode`, `stdout`, `stderr`, `blocked`           |
+| `runScript`      | `ScriptRunResult`   | `exitCode`, `stdout`, `stderr`, `filesWritten?`     |
+| `runHook`        | `HookRunResult`     | all of the above, **plus** `blocked` / `decision`   |
 | `runHarnessTest` | `HarnessTestResult` | `exitCode`, `stdout`, `stderr`, `cwd` + the `Trace` |
 
 **Testing a plain helper script** (a bash/node/python program that isn't a hook)?
-`runHook` is the right tier: it runs any command, pipes it the event JSON on
-stdin (a script that ignores stdin simply ignores it), and hands back exit code
-plus both streams.
+Use **`runScript`** — it runs any command and reports what it did:
 
 ```ts
-const r = runHook("bash scripts/check-links.sh", {}, { cwd: repoDir });
+import { runScript } from "vigiles/testing";
+
+const r = runScript("bash scripts/check-links.sh", { cwd: repoDir });
 assert.equal(r.exitCode, 0);
 assert.match(r.stderr, /0 broken links/); // advisory output lives HERE
 ```
 
-⚠️ One real limit: `r.filesWritten` is recorded only on **confined** runs, so
-`assertNoWrite` / `assertWroteOnly` pass **vacuously** after a plain unconfined
-run. Pass `{ sandbox: "auto" }` (Linux + bubblewrap) when you actually need to
-assert on what the script wrote.
+`runHook` is exactly `runScript` plus the hook protocol (event → stdin, exit code
+→ allow/deny). Pick by the question you're asking: a **hook** has a _decision_, a
+**script** has _effects_. That's why `ScriptRunResult` has no `decision` field —
+a field that is always meaningless is worse than no field.
+
+⚠️ **Asserting what a script wrote requires confinement.** `filesWritten` is
+recorded by diffing the work dir, which only a confined run does — so it is
+`undefined` after a plain run. That is deliberately _not_ the same as `[]`
+("recorded, wrote nothing"): `assertNoWrite` / `assertWroteOnly` **throw** on an
+unrecorded result rather than pass having inspected nothing. Pass
+`{ sandbox: "auto" }` (Linux + bubblewrap) to actually record writes.
 
 ## Step 4 — Run it
 

--- a/skills/test-harness/SKILL.md
+++ b/skills/test-harness/SKILL.md
@@ -173,6 +173,39 @@ const report = await runEval({
 assertSignificant(report, { baseline: "off", arm: "on", metric: "ok" });
 ```
 
+### Never hand-roll the runner — it silently eats stderr
+
+Do **not** reach for `execFileSync` / `spawnSync` to drive the thing under test.
+The failure is quiet and repeats: `execFileSync` returns **stdout only** on
+success, while advisory output — including vigiles's own compiled-hook
+`notice()` — is written to **stderr**. A hand-rolled runner therefore reports a
+perfectly healthy react hook as **dead**, and an assertion about a warning can
+never pass. (Observed three times in one repo, twice after the first fix.)
+
+Every vigiles result already carries **both streams**, so the bug is
+unrepresentable:
+
+| Runner           | Result              | Carries                                             |
+| ---------------- | ------------------- | --------------------------------------------------- |
+| `runHook`        | `HookRunResult`     | `exitCode`, `stdout`, `stderr`, `blocked`           |
+| `runHarnessTest` | `HarnessTestResult` | `exitCode`, `stdout`, `stderr`, `cwd` + the `Trace` |
+
+**Testing a plain helper script** (a bash/node/python program that isn't a hook)?
+`runHook` is the right tier: it runs any command, pipes it the event JSON on
+stdin (a script that ignores stdin simply ignores it), and hands back exit code
+plus both streams.
+
+```ts
+const r = runHook("bash scripts/check-links.sh", {}, { cwd: repoDir });
+assert.equal(r.exitCode, 0);
+assert.match(r.stderr, /0 broken links/); // advisory output lives HERE
+```
+
+⚠️ One real limit: `r.filesWritten` is recorded only on **confined** runs, so
+`assertNoWrite` / `assertWroteOnly` pass **vacuously** after a plain unconfined
+run. Pass `{ sandbox: "auto" }` (Linux + bubblewrap) when you actually need to
+assert on what the script wrote.
+
 ## Step 4 — Run it
 
 In a runner (node:test / vitest / jest) the tests are plain async functions. Or

--- a/src/audit-html.test.ts
+++ b/src/audit-html.test.ts
@@ -70,6 +70,39 @@ describe("injectReportData", () => {
     expect(html).toMatch(/^<!doctype html>/);
   });
 
+  it("🔴 carries `not measured` into the HTML, distinguishably from a measured 0", () => {
+    // The rendered artifact — the thing a human actually opens — must not flatten
+    // "nobody asked whether your skills fire" into "we asked and the answer is 0".
+    const withRing = (c: AuditReport["score"]["categories"][number]) =>
+      injectReportData(TEMPLATE, {
+        ...report,
+        score: { ...report.score, categories: [...report.score.categories, c] },
+      });
+    const unasked = withRing({
+      key: "Evaluated",
+      score: null,
+      weight: 1,
+      advisory: true,
+      notMeasured: true,
+      findings: [
+        "3 surfaces whose firing was never measured",
+        "not measured —",
+      ],
+    });
+    const measuredZero = withRing({
+      key: "Evaluated",
+      score: 0,
+      weight: 1,
+      advisory: true,
+      findings: ["3 surfaces whose firing was never measured"],
+    });
+    expect(unasked).toContain('"notMeasured":true');
+    expect(unasked).toContain('"key":"Evaluated","score":null');
+    expect(measuredZero).toContain('"key":"Evaluated","score":0');
+    expect(measuredZero).not.toContain("notMeasured");
+    expect(unasked).not.toBe(measuredZero);
+  });
+
   it("escapes <, >, & so report text can't break out of the <script>", () => {
     const evil: AuditReport = {
       ...report,

--- a/src/audit-report.test.ts
+++ b/src/audit-report.test.ts
@@ -68,7 +68,7 @@ describe("buildAuditReport", () => {
       makeReport({ untested: 3, commands: 2, mcp: true }),
       { harness: "codex", vigilesVersion: "1.0.0" },
     );
-    expect(r.score.categories.length).toBe(5); // five deterministic rings
+    expect(r.score.categories.length).toBe(6); // + the Evaluated ring
     expect(typeof r.score.overall).toBe("number");
     expect(r.inventory).toEqual({
       skills: 0,
@@ -78,6 +78,48 @@ describe("buildAuditReport", () => {
       mcp: true,
       untested: 3,
     });
+  });
+
+  it("the inventory carries BOTH tiers when the scan split them", () => {
+    // Same repo, two different gaps at two different costs — a consumer must be
+    // able to tell "has harnesses, no evals" from "has neither".
+    const r = buildAuditReport(
+      makeReport({ untested: 1, untestedHarness: 1, unevaluated: 4 }),
+      { harness: "claude-code", vigilesVersion: "1.0.0" },
+    );
+    expect(r.inventory.untestedHarness).toBe(1);
+    expect(r.inventory.unevaluated).toBe(4);
+    // A producer predating the split omits them entirely (additive/optional).
+    const legacy = buildAuditReport(makeReport({ untested: 1 }), {
+      harness: "claude-code",
+      vigilesVersion: "1.0.0",
+    });
+    expect(legacy.inventory.untestedHarness).toBeUndefined();
+    expect(legacy.inventory.unevaluated).toBeUndefined();
+  });
+
+  it("🔴 the JSON distinguishes `not measured` from a measured 0 on Evaluated", () => {
+    const report = makeReport({ evaluable: 4, unevaluated: 4 });
+    const opts = { harness: "claude-code", vigilesVersion: "1.0.0" };
+    const evalRing = (firingMeasured: boolean) =>
+      buildAuditReport(report, {
+        ...opts,
+        firingMeasured,
+      }).score.categories.find((c) => c.key === "Evaluated");
+
+    // Headless read: the firing question was never asked. The wire shape has to
+    // SAY that — a 0 here would report the absence of a check as its result.
+    expect(evalRing(false)?.score).toBeNull();
+    expect(evalRing(false)?.notMeasured).toBe(true);
+
+    // The firing tier ran and found nothing covered: an earned, literal 0.
+    expect(evalRing(true)?.score).toBe(0);
+    expect(evalRing(true)?.notMeasured).toBeUndefined();
+
+    // And the two serialize differently — the distinction survives the wire.
+    expect(JSON.stringify(evalRing(false))).not.toBe(
+      JSON.stringify(evalRing(true)),
+    );
   });
 
   it("includes the deterministic recommendations (a typo'd tool → a fix)", () => {
@@ -210,6 +252,35 @@ describe("buildAuditReport", () => {
       "mcp",
       "skills",
       "untested",
+    ]);
+    // The two-tier fields are ADDITIVE: present only when the scan split them,
+    // and pinned here so the mirror is updated with them (never silently).
+    const split = buildAuditReport(
+      makeReport({ untestedHarness: 2, unevaluated: 5 }),
+      { harness: "claude-code", vigilesVersion: "1.0.0" },
+    );
+    expect(Object.keys(split.inventory).sort()).toEqual([
+      "agents",
+      "commands",
+      "hooks",
+      "mcp",
+      "skills",
+      "unevaluated",
+      "untested",
+      "untestedHarness",
+    ]);
+    // …and the ring's third state adds exactly one key to a CategoryScore.
+    const notMeasured = buildAuditReport(
+      makeReport({ evaluable: 1, unevaluated: 1 }),
+      { harness: "claude-code", vigilesVersion: "1.0.0" },
+    ).score.categories.find((c) => c.key === "Evaluated");
+    expect(Object.keys(notMeasured ?? {}).sort()).toEqual([
+      "advisory",
+      "findings",
+      "key",
+      "notMeasured",
+      "score",
+      "weight",
     ]);
   });
 

--- a/src/audit-report.ts
+++ b/src/audit-report.ts
@@ -24,6 +24,7 @@ import type { ScanReport, MarketplaceInfo } from "./scan.js";
 import type { PluginScore } from "./score-core.js";
 import type { RuleInventoryItem } from "./rule-inventory.js";
 import type { RuleRouting } from "./rule-routing.js";
+import type { EvidenceCounts } from "./coverage-evidence.js";
 
 /**
  * The current schema version. Bump only on a BREAKING change to the shape.
@@ -72,6 +73,16 @@ export interface AuditInventory {
    */
   readonly untestedHarness?: number;
   readonly unevaluated?: number;
+  /**
+   * HOW the covered surfaces were decided to be covered — `declared` (an explicit
+   * `vigiles:covers` marker), `colocated` (a test placed at the surface), or
+   * `mention` (the surface's path/namespace appears in a test's code). Carried in
+   * the product boundary because a coverage count without its derivation is not
+   * auditable: a repo whose coverage is entirely `mention` looks, in a bare
+   * number, exactly like one with real tests. Additive/optional — schema version
+   * unchanged.
+   */
+  readonly coverageEvidence?: EvidenceCounts;
 }
 
 /**
@@ -254,6 +265,9 @@ export function buildAuditReport(
         : {}),
       ...(report.unevaluated !== undefined
         ? { unevaluated: report.unevaluated }
+        : {}),
+      ...(report.coverageEvidence
+        ? { coverageEvidence: report.coverageEvidence }
         : {}),
     },
     ...(report.danglingRefs.length

--- a/src/audit-report.ts
+++ b/src/audit-report.ts
@@ -11,7 +11,11 @@
  * timestamp is attached by the CLI at write time, never by this pure builder, so
  * the embedded-in-HTML form stays deterministic).
  */
-import { auditScore, type AuditScore } from "./audit-score.js";
+import {
+  auditScore,
+  type AuditScore,
+  type AuditScoreOptions,
+} from "./audit-score.js";
 import { optimize, type Recommendation } from "./optimize.js";
 import { computeVerdict, type Verdict } from "./audit-verdict.js";
 import type { LedgerSummary } from "./observe.js";
@@ -58,7 +62,16 @@ export interface AuditInventory {
   readonly hooks: number;
   readonly commands: number;
   readonly mcp: boolean;
+  /** Surfaces covered by NEITHER tier — the union count (unchanged). */
   readonly untested: number;
+  /**
+   * The two tiers, carried SEPARATELY so a consumer can tell "has deterministic
+   * coverage, no evals" from "has neither" — a distinction the single `untested`
+   * count erased. `untestedHarness` is free-and-every-push work; `unevaluated` is
+   * paid real-model work. Additive/optional — schema version unchanged.
+   */
+  readonly untestedHarness?: number;
+  readonly unevaluated?: number;
 }
 
 /**
@@ -92,7 +105,7 @@ export interface Adoptable {
  */
 export interface AuditReport {
   readonly meta: AuditReportMeta;
-  /** The five deterministic category rings + the weighted overall + grade. */
+  /** The six category rings + the weighted overall + grade. */
   readonly score: AuditScore;
   /**
    * The one-line verdict + per-recommendation `pointsIfFixed`, both derived by
@@ -154,7 +167,7 @@ export interface AuditReport {
   readonly ruleRouting?: RuleRouting;
 }
 
-export interface BuildAuditReportOptions {
+export interface BuildAuditReportOptions extends AuditScoreOptions {
   readonly harness: string;
   readonly vigilesVersion: string;
   /** The flight-recorder summary from the local ledger (omit when empty). */
@@ -211,7 +224,7 @@ export function buildAuditReport(
   opts: BuildAuditReportOptions,
 ): AuditReport {
   const adoptable = buildAdoptable(opts.adoptableSurfaces);
-  const score = auditScore(report);
+  const score = auditScore(report, { firingMeasured: opts.firingMeasured });
   const recommendations = optimize(report).recommendations;
   const verdict = computeVerdict({ report, score, recommendations });
   return {
@@ -236,6 +249,12 @@ export function buildAuditReport(
       commands: report.commands,
       mcp: report.mcp,
       untested: report.untested,
+      ...(report.untestedHarness !== undefined
+        ? { untestedHarness: report.untestedHarness }
+        : {}),
+      ...(report.unevaluated !== undefined
+        ? { unevaluated: report.unevaluated }
+        : {}),
     },
     ...(report.danglingRefs.length
       ? { brokenReferences: report.danglingRefs }

--- a/src/audit-score.test.ts
+++ b/src/audit-score.test.ts
@@ -2,12 +2,21 @@
  * Category-scoring suite (vitest): pure over a hand-built ScanReport (no fs/model)
  * — each finding buckets into the right deterministic category, the overall
  * excludes n/a categories, an empty machine is empty (but an instruction-only
- * repo is NOT), and the formatter renders rings + the overall. The five rings are
- * all deterministic; Safety is fed by the STATIC lethal-trifecta check (the
- * EXECUTING disaster-battery is still not an `audit` ring).
+ * repo is NOT), and the formatter renders rings + the overall. Safety is fed by
+ * the STATIC lethal-trifecta check (the EXECUTING disaster-battery is still not
+ * an `audit` ring).
+ *
+ * Tested and Evaluated are two rings on purpose (defect #9): a harness and an
+ * eval differ on cost, cadence and the question they answer, and `Evaluated` has
+ * a THIRD state (`not measured`) that must stay distinguishable from a measured 0.
  */
 import { describe, it, expect } from "vitest";
-import { auditScore, formatAuditScore } from "./audit-score.js";
+import {
+  auditScore,
+  categoryScoreLabel,
+  formatAuditScore,
+} from "./audit-score.js";
+import type { CategoryScore } from "./audit-score.js";
 import type { ScanReport } from "./scan.js";
 
 /** A clean, loaded report; override fields per test. */
@@ -49,6 +58,14 @@ function makeReport(over: Partial<ScanReport> = {}): ScanReport {
 const cat = (s: ReturnType<typeof auditScore>, key: string) =>
   s.categories.find((c) => c.key === key);
 
+/** `cat`, but it fails loudly instead of yielding `undefined` — for assertions
+ *  that pass the ring itself to a helper (no non-null assertions in tests). */
+const ring = (s: ReturnType<typeof auditScore>, key: string): CategoryScore => {
+  const c = cat(s, key);
+  if (!c) throw new Error(`no ${key} ring`);
+  return c;
+};
+
 describe("auditScore", () => {
   it("a clean report scores 100 on every (deterministic) category", () => {
     const s = auditScore(makeReport());
@@ -62,7 +79,7 @@ describe("auditScore", () => {
     expect(s.grade).toBe("A");
   });
 
-  it("has five deterministic rings — Safety fed by the static lethal-trifecta check", () => {
+  it("has six rings — Safety fed by the static lethal-trifecta check, Tested and Evaluated split", () => {
     const keys = auditScore(makeReport()).categories.map((c) => c.key);
     expect(keys).toEqual([
       "Truthfulness",
@@ -70,6 +87,7 @@ describe("auditScore", () => {
       "Structure",
       "Safety",
       "Tested",
+      "Evaluated",
     ]);
   });
 
@@ -191,10 +209,15 @@ describe("auditScore", () => {
     // the overall ignores the advisory Tested ring — a clean-but-untested repo is A
     expect(s.overall).toBe(100);
     expect(s.grade).toBe("A");
-    // The finding names the vigiles-native tier, not a bare "untested" (honesty).
-    expect(cat(s, "Tested")?.findings.some((f) => /vigiles test/.test(f))).toBe(
-      true,
-    );
+    // The finding names the vigiles-native tier, not a bare "untested" (honesty),
+    // and names the DETERMINISTIC tier specifically — no "test/eval" slash, which
+    // spanned two prescriptions three orders of magnitude apart in one sentence.
+    expect(
+      cat(s, "Tested")?.findings.some((f) => /vigiles harness/.test(f)),
+    ).toBe(true);
+    expect(
+      cat(s, "Tested")?.findings.some((f) => f.includes("test/eval")),
+    ).toBe(false);
   });
 
   it("own-test signal contextualizes Tested — never reads as 'you don't test'", () => {
@@ -210,6 +233,182 @@ describe("auditScore", () => {
     expect(
       cat(bare, "Tested")?.findings.some((f) => /your own test setup/.test(f)),
     ).toBe(false);
+  });
+
+  // ── Tested vs Evaluated: two tiers, not one number ────────────────────────
+  // A harness (`*.harness.mjs`, `*.test.*`) is free, runs on every push, and asks
+  // "does this gate still catch what it claims?". An eval (`*.eval.mjs`) costs
+  // real model calls, runs on a schedule, and asks "does this skill FIRE at all?".
+  // Collapsed into one ring, a repo with complete deterministic coverage and no
+  // evals scored IDENTICALLY to a repo with neither.
+
+  it("Tested reads the DETERMINISTIC tier, not the union — eval-only coverage is not a harness", () => {
+    // 4 surfaces: 3 have no harness, only 1 has neither harness nor eval. The old
+    // single count would have read 1 (the union) and called the repo nearly clean.
+    const s = auditScore(
+      makeReport({
+        untested: 1,
+        untestedHarness: 3,
+        evaluable: 4,
+        unevaluated: 2,
+      }),
+    );
+    expect(cat(s, "Tested")?.score).toBe(91); // 100 − 3×3
+    expect(cat(s, "Evaluated")?.score).toBe(50); // 2 of 4 covered
+    // Two different sentences, two different prescriptions.
+    expect(cat(s, "Tested")?.findings[0]).toMatch(/no vigiles harness/);
+    expect(cat(s, "Evaluated")?.findings[0]).toMatch(
+      /firing was never measured/,
+    );
+    // Neither sentence carries the old "test/eval" slash.
+    for (const c of s.categories)
+      for (const f of c.findings) expect(f).not.toContain("test/eval");
+  });
+
+  it("Tested falls back to the union count for a report predating the split", () => {
+    const s = auditScore(makeReport({ untested: 3 }));
+    expect(cat(s, "Tested")?.score).toBe(91);
+  });
+
+  it("Evaluated is plain n/a when there is no surface whose firing could be measured", () => {
+    const e = ring(auditScore(makeReport({ evaluable: 0 })), "Evaluated");
+    expect(e.score).toBeNull();
+    // n/a is NOT the "nobody asked" state — nothing was there to ask about.
+    expect(e.notMeasured).toBeUndefined();
+    expect(categoryScoreLabel(e)).toBe("n/a");
+  });
+
+  it("🔴 Evaluated: `not measured` is a THIRD state, distinguishable from a measured 0", () => {
+    // The SAME report, differing only in whether this run asked the question.
+    const report = makeReport({ evaluable: 4, unevaluated: 4 });
+
+    // (a) headless read — the executing checks never ran, no eval file on disk.
+    //     The audit knows NOTHING about firing. Reporting 0 here would present
+    //     the ABSENCE of a check as the RESULT of one.
+    const unasked = ring(auditScore(report), "Evaluated");
+    expect(unasked.score).toBeNull();
+    expect(unasked.notMeasured).toBe(true);
+    expect(categoryScoreLabel(unasked)).toBe("not measured");
+
+    // (b) the firing tier RAN and found nothing covered → an earned, literal 0.
+    const asked = ring(
+      auditScore(report, { firingMeasured: true }),
+      "Evaluated",
+    );
+    expect(asked.score).toBe(0);
+    expect(asked.notMeasured).toBeUndefined();
+    expect(categoryScoreLabel(asked)).toBe("0");
+
+    // The whole point: these two must not be the same value OR the same label.
+    expect(unasked.score).not.toBe(asked.score);
+    expect(categoryScoreLabel(unasked)).not.toBe(categoryScoreLabel(asked));
+  });
+
+  it("Evaluated nudges with the COMMAND when it wasn't measured (no bare zero)", () => {
+    const e = cat(
+      auditScore(makeReport({ evaluable: 2, unevaluated: 2 })),
+      "Evaluated",
+    );
+    expect(e?.findings.some((f) => f.startsWith("not measured —"))).toBe(true);
+    expect(e?.findings.some((f) => f.includes("npx vigiles audit"))).toBe(true);
+    expect(e?.findings.some((f) => f.includes("measureTriggerRate"))).toBe(
+      true,
+    );
+    // And it still NAMES the gap in skills-whose-firing terms.
+    expect(e?.findings[0]).toBe("2 surfaces whose firing was never measured");
+  });
+
+  it("Evaluated is a real number as soon as ANY eval exists — the read doesn't have to run", () => {
+    // One of four covered by an on-disk `*.eval.mjs`: something DOES measure
+    // firing here, so the ring reports coverage rather than "not measured".
+    const e = cat(
+      auditScore(makeReport({ evaluable: 4, unevaluated: 3 })),
+      "Evaluated",
+    );
+    expect(e?.score).toBe(25);
+    expect(e?.notMeasured).toBeUndefined();
+    expect(e?.findings[0]).toBe("3 surfaces whose firing was never measured");
+  });
+
+  it("Evaluated is a clean 100 with no findings when every surface has an eval", () => {
+    const e = cat(
+      auditScore(makeReport({ evaluable: 3, unevaluated: 0 })),
+      "Evaluated",
+    );
+    expect(e?.score).toBe(100);
+    expect(e?.notMeasured).toBeUndefined();
+    expect(e?.findings).toEqual([]);
+  });
+
+  it("both tiers are ADVISORY — the split moves NO grade, in any of the three states", () => {
+    const base = auditScore(makeReport()).overall;
+    for (const over of [
+      { untestedHarness: 9, evaluable: 9, unevaluated: 9 }, // not measured
+      { untestedHarness: 9, evaluable: 9, unevaluated: 0 }, // fully evaluated
+      { untestedHarness: 0, evaluable: 0, unevaluated: 0 }, // n/a
+    ]) {
+      for (const firingMeasured of [false, true]) {
+        const s = auditScore(makeReport(over), { firingMeasured });
+        expect(cat(s, "Tested")?.advisory).toBe(true);
+        expect(cat(s, "Evaluated")?.advisory).toBe(true);
+        expect(s.overall).toBe(base);
+        expect(s.grade).toBe("A");
+      }
+    }
+  });
+
+  it("RENDERED: the terminal keeps `not measured`, `n/a` and `0` apart", () => {
+    const report = makeReport({ evaluable: 4, unevaluated: 4 });
+    const unasked = formatAuditScore(auditScore(report));
+    const asked = formatAuditScore(
+      auditScore(report, { firingMeasured: true }),
+    );
+
+    const line = (out: string, key: string): string =>
+      out.split("\n").find((l) => l.includes(key)) ?? "";
+
+    // The unasked run says so, in the ring itself — not only in tail prose.
+    expect(line(unasked, "Evaluated")).toContain("not measured");
+    expect(line(unasked, "Evaluated")).toMatch(/^\s*\?/); // its own glyph
+    // The asked run renders a real 0 with a real (empty) bar and the ✗ band.
+    expect(line(asked, "Evaluated")).toMatch(/Evaluated\s+0\s+░+/);
+    expect(line(asked, "Evaluated")).not.toContain("not measured");
+    expect(line(asked, "Evaluated")).toMatch(/^\s*✗/);
+    // Plain n/a is a third, distinct rendering.
+    const na = formatAuditScore(auditScore(makeReport({ evaluable: 0 })));
+    expect(line(na, "Evaluated")).toContain("n/a");
+    expect(line(na, "Evaluated")).not.toContain("not measured");
+    expect(line(na, "Evaluated")).toMatch(/^\s*○/);
+    // The nudge names the command right under the ring.
+    expect(unasked).toContain("npx vigiles audit");
+  });
+
+  it("categoryScoreLabel is total over the three states", () => {
+    expect(
+      categoryScoreLabel({
+        key: "Evaluated",
+        score: 0,
+        weight: 1,
+        findings: [],
+      }),
+    ).toBe("0");
+    expect(
+      categoryScoreLabel({
+        key: "Evaluated",
+        score: null,
+        weight: 1,
+        findings: [],
+      }),
+    ).toBe("n/a");
+    expect(
+      categoryScoreLabel({
+        key: "Evaluated",
+        score: null,
+        notMeasured: true,
+        weight: 1,
+        findings: [],
+      }),
+    ).toBe("not measured");
   });
 
   it("Safety is clean (100) when there IS a tool-bearing surface but no trifecta", () => {
@@ -428,9 +627,13 @@ describe("auditScore", () => {
     expect(s.empty).toBe(true);
     expect(s.overall).toBe(0);
     expect(s.categories.every((c) => c.score === null)).toBe(true);
-    // Safety is included in the empty-machine null list (5 categories, all n/a).
+    // Safety is included in the empty-machine null list (6 categories, all n/a).
     expect(s.categories.map((c) => c.key)).toContain("Safety");
-    expect(s.categories.length).toBe(5);
+    expect(s.categories.map((c) => c.key)).toContain("Evaluated");
+    expect(s.categories.length).toBe(6);
+    // An empty machine has nothing to measure — that's plain n/a, NOT the
+    // "nobody asked" state (which is reserved for a real surface + no answer).
+    expect(s.categories.every((c) => c.notMeasured)).toBe(false);
   });
 
   it("an inline-hook-only harness is NOT empty (inline hooks are a real surface)", () => {

--- a/src/audit-score.ts
+++ b/src/audit-score.ts
@@ -3,8 +3,8 @@
  *
  * A single structural-health number (the leaderboard's `scoreReport`) ranks
  * plugins, but it hides WHERE a harness is weak. This buckets the SAME
- * deterministic findings into five categories — Truthfulness, Triggering,
- * Structure, Safety, Tested — each a 0–100 ring, as a DIAGNOSTIC breakdown
+ * deterministic findings into six categories — Truthfulness, Triggering,
+ * Structure, Safety, Tested, Evaluated — each a 0–100 ring, as a DIAGNOSTIC breakdown
  * beneath one headline `overall` = `100 − Σ(all graded penalties)` (the SAME
  * summed model as the leaderboard's single health number, via the shared
  * `computeIntegrityScore` — so the two surfaces never disagree). Same detectors,
@@ -26,8 +26,16 @@
  * shipped yet, so the battery lives in the `vigiles/testing` API via
  * `guardrail-check`/`assertBlocksDisasters`, where you opt in explicitly.
  *
+ * TESTED vs EVALUATED are two rings, not one, because a harness and an eval differ
+ * on COST (free vs paid model calls), on CADENCE (every push vs scheduled) and on
+ * the QUESTION ANSWERED (does this gate still catch what it claims? vs does this
+ * skill fire at all?). Folded together, a repo with complete deterministic coverage
+ * and no evals scored identically to a repo with neither.
+ *
  * A category that can't be assessed scores `null` (n/a) and is EXCLUDED from the
- * overall — never a false 0. Pure over the `ScanReport`, so it's fully testable.
+ * overall — never a false 0. `Evaluated` adds a THIRD state on top of that
+ * (`notMeasured`): the run never asked the firing question, which is not the same
+ * fact as "asked and got zero". Pure over the `ScanReport`, so it's fully testable.
  */
 import {
   gradeFor,
@@ -50,7 +58,8 @@ export type CategoryKey =
   | "Triggering"
   | "Structure"
   | "Safety"
-  | "Tested";
+  | "Tested"
+  | "Evaluated";
 
 export interface CategoryScore {
   readonly key: CategoryKey;
@@ -58,6 +67,15 @@ export interface CategoryScore {
   readonly score: number | null;
   /** Relative weight in the overall (equal by default — tune later). */
   readonly weight: number;
+  /**
+   * `score: null` because this run never ASKED the question — as distinct from
+   * `null` because there was nothing to ask about (plain n/a) and from a measured
+   * `0`. Reporting the absence of a check as the result of a check is exactly what
+   * this tool flags in other people's harnesses; the `Evaluated` ring would do it
+   * if a headless read scored 0 for "no firing measured". A `notMeasured` ring
+   * carries a finding NAMING the command that would measure it.
+   */
+  readonly notMeasured?: boolean;
   /**
    * Advisory categories are shown but EXCLUDED from the overall grade. An untested
    * surface (or any best-practice gap) is a HARDENING signal, not a broken harness
@@ -89,6 +107,23 @@ export interface AuditScore {
 // category rings and the single health number can never drift. W_UNTESTED is
 // audit-only — untested surfaces are advisory (shown, never scored into overall).
 const W_UNTESTED = 3;
+
+/** The command that answers the firing question — named, not alluded to. */
+const MEASURE_FIRING_COMMAND =
+  "run `npx vigiles audit` interactively to measure, or add a `*.eval.mjs` " +
+  "(`measureTriggerRate`, vigiles/testing)";
+
+export interface AuditScoreOptions {
+  /**
+   * Did THIS run actually execute the skill-firing tier? A plain `audit` is a
+   * deterministic read: headless (`--json`, `--no-interactive`, a pipe) it never
+   * runs the executing checks and prints "Executing checks (safety battery · live
+   * MCP · skill firing) skipped". That skip is a real signal and it is threaded
+   * here, so the `Evaluated` ring can say "not measured" instead of scoring a 0 it
+   * did not earn. Default false — the honest default for a pure read.
+   */
+  readonly firingMeasured?: boolean;
+}
 
 /** One deduction: a count, its per-item weight, and the label if non-zero. */
 interface Deduction {
@@ -304,14 +339,28 @@ function safety(r: ScanReport): CategoryScore {
   };
 }
 
+/**
+ * TESTED — DETERMINISTIC harness coverage only (`*.harness.mjs`, `*.test.*`):
+ * free, milliseconds, every push. It answers "does this gate still catch what it
+ * claims?" The real-model tier is a SEPARATE ring ({@link evaluated}) because it
+ * differs on cost, on cadence AND on the question it answers — folding both into
+ * one number made "complete deterministic coverage, no evals" score identically
+ * to "neither", and made the prescription ("add a test/eval") span three orders of
+ * magnitude in cost without saying which.
+ *
+ * Falls back to the union `untested` when a producer predates the split, so the
+ * ring never silently reports 0 for a report that simply doesn't carry the field.
+ */
 function tested(r: ScanReport): CategoryScore {
+  const untestedHarness = r.untestedHarness ?? r.untested;
   const { score, findings } = scoreFrom([
     {
-      n: r.untested,
-      // Say VIGILES-NATIVE explicitly — this counts `.eval.mjs`/`.harness.mjs`, not
+      n: untestedHarness,
+      // Say VIGILES-NATIVE explicitly — this counts `.harness.mjs`/`.test.*`, not
       // whether a surface is tested at all, so the label must not read as "untested".
+      // No slash: this sentence is about the FREE tier and nothing else.
       weight: W_UNTESTED,
-      label: "surface(s) with no vigiles test/eval",
+      label: "surface(s) with no vigiles harness (deterministic, free)",
     },
   ]);
   // ADVISORY: a hardening gap, not breakage — shown but EXCLUDED from the overall
@@ -320,7 +369,7 @@ function tested(r: ScanReport): CategoryScore {
   // note so the number is read as "optional", not "you don't test" (G3 — don't
   // measure the wrong thing).
   const contextualized =
-    r.ownTestSignal && r.untested > 0
+    r.ownTestSignal && untestedHarness > 0
       ? [
           ...findings,
           "your own test setup detected — vigiles-native skill coverage is optional",
@@ -336,6 +385,70 @@ function tested(r: ScanReport): CategoryScore {
 }
 
 /**
+ * EVALUATED — REAL-MODEL coverage (`*.eval.mjs`): paid, minutes, scheduled. It
+ * answers the one question the deterministic read cannot — does a skill FIRE at
+ * all? Advisory, like Tested.
+ *
+ * THREE states, not two, and the third is the point:
+ *
+ *   - a NUMBER  — measured: evals exist here, this is their coverage percentage.
+ *   - `0`       — the firing tier RAN this session and nothing covers these
+ *                 surfaces. A real, earned zero.
+ *   - NOT MEASURED (`score: null` + `notMeasured`) — nothing asked. No evals on
+ *                 disk AND the executing checks were skipped (headless / `--json`
+ *                 / a remembered no). The audit knows NOTHING about firing here.
+ *
+ * Collapsing the third into the first would report the ABSENCE of a check as the
+ * RESULT of a check — precisely the pattern this product exists to name in other
+ * people's repositories. The report already states the distinction in prose ("Do
+ * your N skills actually fire? The deterministic read can't tell…") and used to
+ * fold it into one score anyway. In the `notMeasured` state the ring NUDGES with
+ * the command that would answer the question.
+ *
+ * `null` WITHOUT `notMeasured` is the ordinary n/a: no surface to evaluate at all.
+ */
+function evaluated(r: ScanReport, firingMeasured: boolean): CategoryScore {
+  const evaluable = r.evaluable ?? 0;
+  if (evaluable === 0) {
+    return {
+      key: "Evaluated",
+      score: null,
+      weight: 1,
+      advisory: true,
+      findings: ["no surface whose firing could be measured"],
+    };
+  }
+  const unevaluated = r.unevaluated ?? evaluable;
+  const evalCovered = evaluable - unevaluated;
+  const gap = `${String(unevaluated)} ${pluralizeLabel(
+    unevaluated,
+    "surface(s) whose firing was never measured",
+  )}`;
+  // Nothing on disk measures firing AND nothing ran this session → the question
+  // was never asked. Say that, and name the command — do NOT score it a 0.
+  if (evalCovered === 0 && !firingMeasured) {
+    return {
+      key: "Evaluated",
+      score: null,
+      weight: 1,
+      advisory: true,
+      notMeasured: true,
+      findings: [gap, `not measured — ${MEASURE_FIRING_COMMAND}`],
+    };
+  }
+  // A straight coverage percentage, so the zero state is a LITERAL 0 — "the
+  // firing tier was available and nothing covers these surfaces" — and can never
+  // be confused with the null above.
+  return {
+    key: "Evaluated",
+    score: Math.round((100 * evalCovered) / evaluable),
+    weight: 1,
+    advisory: true,
+    findings: unevaluated > 0 ? [gap] : [],
+  };
+}
+
+/**
  * An instruction-only repo (just a CLAUDE.md/AGENTS.md, no plugin surface) is NOT
  * empty — the scan records `instructions` precisely so it isn't graded F/0 "no
  * loadable surface". Only a dir with NO instruction file AND no surface is empty.
@@ -347,13 +460,17 @@ function isEmptyAudit(r: ScanReport): boolean {
 }
 
 /**
- * Bucket a scan report into the five deterministic Lighthouse categories as a
- * DIAGNOSTIC breakdown, with the headline `overall` = `100 − Σ(all graded
- * penalties)` (the shared summed model — NOT the average of the rings — so it
- * equals the leaderboard's single health number). The advisory Tested ring and
- * any n/a ring are shown but excluded from the headline.
+ * Bucket a scan report into the six Lighthouse categories as a DIAGNOSTIC
+ * breakdown, with the headline `overall` = `100 − Σ(all graded penalties)` (the
+ * shared summed model — NOT the average of the rings — so it equals the
+ * leaderboard's single health number). The advisory Tested / Evaluated rings and
+ * any n/a ring are shown but excluded from the headline — the grade weighting is
+ * UNCHANGED by the Tested/Evaluated split.
  */
-export function auditScore(report: ScanReport): AuditScore {
+export function auditScore(
+  report: ScanReport,
+  opts: AuditScoreOptions = {},
+): AuditScore {
   if (isEmptyAudit(report)) {
     const categories: CategoryKey[] = [
       "Truthfulness",
@@ -361,6 +478,7 @@ export function auditScore(report: ScanReport): AuditScore {
       "Structure",
       "Safety",
       "Tested",
+      "Evaluated",
     ];
     return {
       overall: 0,
@@ -380,11 +498,12 @@ export function auditScore(report: ScanReport): AuditScore {
     structure(report),
     safety(report),
     tested(report),
+    evaluated(report, opts.firingMeasured === true),
   ];
   // The headline is the SUMMED model (the shared integrity score), NOT the average
   // of the rings — averaging would let a real problem in one category be diluted
-  // by clean siblings. The rings above stay a diagnostic breakdown; Tested
-  // (advisory) is never summed in (untested surfaces don't drag the grade).
+  // by clean siblings. The rings above stay a diagnostic breakdown; Tested and
+  // Evaluated (both advisory) are never summed in (neither drags the grade).
   const { score: overall } = computeIntegrityScore(reportDeductions(report));
   return { overall, grade: gradeFor(overall), categories, empty: false };
 }
@@ -392,29 +511,41 @@ export function auditScore(report: ScanReport): AuditScore {
 // A 22-cell bar gauge ("ring" in the terminal; the real rings are the HTML).
 const BAR_CELLS = 22;
 
-/** A glyph that signals the band at a glance (green/amber/red, no ANSI needed). */
-function bandGlyph(score: number | null): string {
-  if (score === null) return "○";
-  if (score >= 90) return "●";
-  if (score >= 70) return "◑";
+/** A glyph that signals the band at a glance (green/amber/red, no ANSI needed).
+ *  `?` is its own glyph: an UNASKED question is not the same as "not applicable"
+ *  (`○`) and emphatically not the same as a measured failure (`✗`). */
+function bandGlyph(c: CategoryScore): string {
+  if (c.score === null) return c.notMeasured ? "?" : "○";
+  if (c.score >= 90) return "●";
+  if (c.score >= 70) return "◑";
   return "✗";
 }
 
-function bar(score: number | null): string {
-  if (score === null) return "n/a";
-  const filled = Math.round((score / 100) * BAR_CELLS);
+function bar(c: CategoryScore): string {
+  if (c.score === null) return c.notMeasured ? "not measured" : "n/a";
+  const filled = Math.round((c.score / 100) * BAR_CELLS);
   return "█".repeat(filled) + "░".repeat(BAR_CELLS - filled);
+}
+
+/**
+ * The ring's number as the reader sees it — THREE distinct labels, never two.
+ * A measured `0` and an unasked question are different facts and must not render
+ * the same; `n/a` (nothing to assess) is a third, also distinct.
+ */
+export function categoryScoreLabel(c: CategoryScore): string {
+  if (c.score !== null) return String(c.score);
+  return c.notMeasured ? "not measured" : "n/a";
 }
 
 /** Render the category rings (diagnostic) + the summed overall for the terminal. */
 export function formatAuditScore(s: AuditScore): string {
   const lines: string[] = ["Harness audit", ""];
   for (const c of s.categories) {
-    const glyph = bandGlyph(c.score);
+    const glyph = bandGlyph(c);
     const label = c.key.padEnd(13);
-    const num = (c.score === null ? "n/a" : String(c.score)).padStart(4);
+    const num = categoryScoreLabel(c).padStart(4);
     const tag = c.advisory ? "  · advisory (not graded)" : "";
-    lines.push(`  ${glyph} ${label} ${num}  ${bar(c.score)}${tag}`);
+    lines.push(`  ${glyph} ${label} ${num}  ${bar(c)}${tag}`);
     if (c.findings.length > 0) {
       lines.push(`       └ ${c.findings.join("; ")}`);
     }

--- a/src/cli-flag-check.test.ts
+++ b/src/cli-flag-check.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for the known-flag registry — the half of the "audit silently
+ * swallows unknown flags" defect that can be tested without spawning the CLI.
+ * The behavioural half (exit codes, `--help`, the nothing-to-audit outcome)
+ * lives in src/scan-cli.test.ts, which drives the real built binary.
+ */
+import { test } from "vitest";
+import assert from "node:assert/strict";
+
+import {
+  COMMAND_FLAGS,
+  formatUnknownFlag,
+  knownFlagsFor,
+  nearestFlag,
+  unknownFlags,
+} from "./cli-flag-check.js";
+import { VERBS } from "./cli-commands.js";
+
+test("an unrecognised flag is reported, per verb", () => {
+  // The measured reproduction: this ran a complete audit and exited 0.
+  assert.deepEqual(unknownFlags("audit", ["--this-flag-does-not-exist"]), [
+    "--this-flag-does-not-exist",
+  ]);
+  // …and a typo of a REAL flag, which is the dangerous case: `--no-htlm` used
+  // to write the HTML report while the author believed they had suppressed it.
+  assert.deepEqual(unknownFlags("audit", ["--no-htlm"]), ["--no-htlm"]);
+});
+
+test("every flag a verb actually reads is accepted", () => {
+  // Guards the other direction: over-rejecting is worse than the defect, since
+  // it breaks working invocations.
+  for (const verb of VERBS) {
+    for (const spec of COMMAND_FLAGS[verb]) {
+      const arg = spec.endsWith("=") ? `${spec}value` : spec;
+      assert.deepEqual(
+        unknownFlags(verb, [arg]),
+        [],
+        `${verb} must accept its own flag ${arg}`,
+      );
+    }
+  }
+});
+
+test("shared flags are accepted everywhere; positionals are never flags", () => {
+  for (const verb of VERBS) {
+    assert.deepEqual(unknownFlags(verb, ["--harness=codex", "--help"]), []);
+  }
+  assert.deepEqual(
+    unknownFlags("audit", ["./some/dir", "-", "--", "--wat"]),
+    [],
+    "a positional, a lone dash, and everything after `--` are not flags",
+  );
+});
+
+test("hook-runtime is exempt — its argv comes from the harness, not a human", () => {
+  assert.deepEqual(unknownFlags("hook-runtime", ["--anything-at-all"]), []);
+});
+
+test("a value flag rejects the space-separated form it cannot read", () => {
+  // `flagValue()` only ever reads `--out=x`. `--out dir` used to leave `--out`
+  // unread and `dir` interpreted as the scan target — the exact shape of the
+  // bug that made an audit run over the wrong directory.
+  assert.deepEqual(unknownFlags("audit", ["--out", "/tmp/x"]), ["--out"]);
+  assert.deepEqual(unknownFlags("audit", ["--out=/tmp/x"]), []);
+});
+
+test("the nearest-flag suggestion fires on a typo and stays quiet otherwise", () => {
+  const known = knownFlagsFor("audit");
+  assert.equal(nearestFlag("--no-htlm", known), "--no-html");
+  assert.equal(nearestFlag("--jsonn", known), "--json");
+  // Nothing close: a wrong suggestion invites "fixing" a flag never meant.
+  assert.equal(nearestFlag("--completely-unrelated-thing", known), undefined);
+});
+
+test("the message names the flag, the verb, and where to look", () => {
+  const msg = formatUnknownFlag("audit", "--no-htlm");
+  assert.ok(msg.includes('unknown flag "--no-htlm"'), msg);
+  assert.ok(msg.includes("Did you mean `--no-html`?"), msg);
+  assert.ok(msg.includes("vigiles audit --help"), msg);
+});

--- a/src/cli-flag-check.ts
+++ b/src/cli-flag-check.ts
@@ -1,0 +1,216 @@
+/**
+ * The known-flag registry, and the rejection of everything else.
+ *
+ * ## The defect this closes
+ *
+ * Every subcommand parsed its own flags by asking `args.includes("--x")` and
+ * ignored the rest. So a typo was accepted in silence:
+ *
+ * ```
+ * $ npx vigiles audit --this-flag-does-not-exist
+ * Detected harness: claude-code
+ * …a complete, confident audit…
+ * EXIT=0
+ * ```
+ *
+ * That is not cosmetic, because audit's flags govern what LEAVES THE MACHINE:
+ * `--no-html`, `--no-json`, `--out=<dir>`, `--serve`. `--no-htlm` writes the HTML
+ * report while the author believes they suppressed it. For a tool whose thesis is
+ * "prose isn't policy", accepting an argument it did not understand and carrying
+ * on is the same class of error it names elsewhere: the argument is PRESENT, so
+ * the property is assumed enforced.
+ *
+ * The sharper case, observed: `vigiles audit --json /some/path`. `--json` is real
+ * but takes no value, so the PATH fell through to the positional scan directory.
+ * The audit then ran over a directory with no harness in it and reported
+ * "No loadable harness surface — nothing to grade yet", `skills: 0`, grade F,
+ * exit 0 — output indistinguishable from a genuine audit of a repo that scores
+ * badly. A confident measurement OF THE WRONG OBJECT, silently.
+ *
+ * ## Why a table and not a parser library
+ *
+ * The flags are already parsed at their point of use, and moving that would be a
+ * large behavioural change for a validation fix. This adds the ONE thing the
+ * ad-hoc parsing cannot do — say no to what it doesn't recognise. A dogfood test
+ * (src/scan-cli.test.ts, "every flag the help text advertises is accepted")
+ * drives the real `vigiles --help` and asserts the table hasn't drifted from it,
+ * so a flag documented but not registered is a test failure rather than a
+ * rejection in a user's face.
+ */
+
+import type { Verb } from "./cli-commands.js";
+
+/**
+ * A known flag. `--foo` is a bare switch; `--foo=` takes a value with `=`
+ * (`flagValue()` only ever reads the `=` form, so a space-separated value is
+ * genuinely NOT supported and must not be silently accepted).
+ */
+export type FlagSpec = string;
+
+/**
+ * Flags every verb accepts: the config overrides applied in `main()` before
+ * dispatch (see `applyConfigFlags`) plus the harness override, which the shared
+ * `harnessFlagFrom` reads for lint/compile/audit/generate/init.
+ */
+export const SHARED_FLAGS: readonly FlagSpec[] = [
+  "--max-rules=",
+  "--catalog-only",
+  "--harness=",
+  "--help",
+];
+
+/**
+ * Per-verb flags, derived from what each handler actually READS (not from the
+ * help text — the help text is checked AGAINST this, in src/scan-cli.test.ts).
+ */
+export const COMMAND_FLAGS: Record<Verb, readonly FlagSpec[]> = {
+  // parseSetupArgs() + the --target= fast path in main().
+  init: [
+    "--target=",
+    "--strict",
+    "--report-only",
+    "--yes",
+    "-y",
+    "--force",
+    "--lint",
+    "--no-lint",
+    "--test",
+    "--no-test",
+    "--no-gha",
+    "--no-plugin",
+    "--ci-only",
+  ],
+  compile: [],
+  eject: ["--keep-spec"],
+  lint: ["--summary", "--json"],
+  // handleRunScripts (free tier — no lock flags).
+  test: ["--min=", "--all", "--yes", "--no-interactive", "--no-skip"],
+  // handleRunScripts + resolveEvalLockEnv + the trials knob.
+  eval: [
+    "--min=",
+    "--all",
+    "--yes",
+    "--no-interactive",
+    "--no-skip",
+    "--trials=",
+    "--check",
+    "--update",
+  ],
+  audit: [
+    "--json",
+    "--md",
+    "--out=",
+    "--no-html",
+    "--no-json",
+    "--no-open",
+    "--serve",
+    "--no-serve",
+    "--no-interactive",
+    "--yes",
+    "--capability-diff=",
+    "--fail-on-widen",
+    // The model trigger tier, reached from audit under consent (handleMeasure /
+    // runAutoTrigger).
+    "--prompts=",
+    "--model=",
+    "--concurrency=",
+    "--min-prompts=",
+    "--trials=",
+  ],
+  generate: ["--check", "--files=", "--spec-import="],
+  // Emitted into hooks configs, never typed by hand: its argv is whatever the
+  // harness passes through, so validating it would break the runtime contract.
+  "hook-runtime": [],
+};
+
+/** Verbs whose argv is machine-supplied and must NOT be validated. */
+const UNVALIDATED: ReadonlySet<string> = new Set(["hook-runtime"]);
+
+/** The flag token of an arg, without its `=value` (`--out=x` → `--out`). */
+function tokenOf(arg: string): string {
+  const eq = arg.indexOf("=");
+  return eq === -1 ? arg : arg.slice(0, eq);
+}
+
+function accepts(spec: FlagSpec, arg: string): boolean {
+  return spec.endsWith("=")
+    ? arg.startsWith(spec)
+    : arg === spec || tokenOf(arg) === spec;
+}
+
+/** Every flag this verb knows, shared ones included. */
+export function knownFlagsFor(command: string): readonly FlagSpec[] {
+  const own = COMMAND_FLAGS[command as Verb] ?? [];
+  return [...SHARED_FLAGS, ...own];
+}
+
+/**
+ * Args that look like flags but no spec accepts. `--` (the argv terminator) and
+ * anything after it are left alone; a lone `-` is a positional by convention.
+ */
+export function unknownFlags(
+  command: string,
+  argv: readonly string[],
+): string[] {
+  if (UNVALIDATED.has(command)) return [];
+  const known = knownFlagsFor(command);
+  const out: string[] = [];
+  for (const arg of argv) {
+    if (arg === "--") break;
+    if (!arg.startsWith("-") || arg === "-") continue;
+    if (known.some((spec) => accepts(spec, arg))) continue;
+    out.push(arg);
+  }
+  return out;
+}
+
+/** Levenshtein distance, iterative two-row. Small inputs; clarity over speed. */
+function distance(a: string, b: string): number {
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= a.length; i++) {
+    const row = [i];
+    for (let j = 1; j <= b.length; j++) {
+      row[j] = Math.min(
+        prev[j] + 1,
+        row[j - 1] + 1,
+        prev[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1),
+      );
+    }
+    prev = row;
+  }
+  return prev[b.length];
+}
+
+/**
+ * The closest known flag to a typo, or undefined when nothing is close enough.
+ * The threshold is deliberately tight — a wrong suggestion is worse than none,
+ * because it invites the reader to "fix" a flag they never meant to type.
+ */
+export function nearestFlag(
+  unknown: string,
+  known: readonly FlagSpec[],
+): string | undefined {
+  const target = tokenOf(unknown);
+  let best: { flag: string; d: number } | undefined;
+  for (const spec of known) {
+    const flag = spec.endsWith("=") ? spec.slice(0, -1) : spec;
+    const d = distance(target, flag);
+    if (!best || d < best.d) best = { flag: spec, d };
+  }
+  return best && best.d <= Math.max(2, Math.floor(target.length / 4))
+    ? best.flag
+    : undefined;
+}
+
+/** The message printed to stderr for one unrecognised flag. */
+export function formatUnknownFlag(command: string, flag: string): string {
+  const known = knownFlagsFor(command);
+  const near = nearestFlag(flag, known);
+  const lines = [`✗ vigiles ${command}: unknown flag "${flag}".`];
+  if (near) lines.push(`  Did you mean \`${near}\`?`);
+  lines.push(
+    `  Flags for \`${command}\`: ${[...known].sort().join(" ")}`,
+    `  \`vigiles ${command} --help\` lists them with descriptions.`,
+  );
+  return lines.join("\n");
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1485,12 +1485,19 @@ describe("CLI: vigiles init — both pillars + workflow", () => {
     }
   });
 
-  it("clean break: old --pillars / --verify flags no longer scope a pillar", () => {
+  it("clean break: old --pillars / --verify flags are REJECTED, not ignored", () => {
     const dir = freshProject();
     try {
-      // --verify is now an unknown flag — both pillars stay on (the default).
-      const out = run("init --verify --no-plugin --no-gha", dir).stdout;
-      assert.match(out, /pillars: lint \+ test/);
+      // These flags were removed. They used to be silently ignored, so `init
+      // --verify` ran the full default setup while the author believed they had
+      // scoped it — the same "the argument is present, so the property must be
+      // enforced" failure the unknown-flag check exists to stop. A removed flag
+      // now stops the run and says so.
+      for (const stale of ["--verify", "--pillars=lint"]) {
+        const r = run(`init ${stale} --no-plugin --no-gha`, dir);
+        assert.equal(r.exitCode, 2, `${stale}: ${r.stdout}${r.stderr}`);
+        assert.match(r.stderr, /unknown flag/);
+      }
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -87,6 +87,7 @@ import {
   isMeteredAccess,
   decideExecute,
   formatExecuteSkip,
+  type ExecuteDecision,
 } from "./scan-trigger-suggest.js";
 import { checkDialectDrift, formatDialectDrift } from "./dialect-drift.js";
 import {
@@ -6730,20 +6731,10 @@ interface ExecutableSurfaces {
  */
 async function resolveExecution(
   s: ExecutableSurfaces,
+  decision: ExecuteDecision,
   json: boolean,
-  args: string[],
   harness: string,
 ): Promise<{ execute: boolean; note: string | null }> {
-  const decision = decideExecute({
-    hasExecutable: s.hasMcp || s.triggerableSkills > 0 || s.adoptableRefs,
-    // A human is "interactive" only when BOTH streams are a terminal — `askOnce`
-    // reads stdin, so a TTY stdout with piped/redirected stdin (agents, shell
-    // pipelines) must NOT block on a read that never gets input.
-    isTTY: process.stdout.isTTY && process.stdin.isTTY,
-    json,
-    noInteractive: args.includes("--no-interactive") || args.includes("--yes"),
-    remembered: loadConfig().audit?.measure,
-  });
   if (decision.kind === "run") return { execute: true, note: null };
   if (decision.kind === "skip")
     return {
@@ -7075,6 +7066,43 @@ async function main(): Promise<void> {
         // Read the local flight recorder ONCE — feeds both the JSON report
         // (structured summary, the product boundary) and the terminal render.
         const ledgerRecords = readObservations(root);
+        // What the EXECUTING checks would have to work with. Computed BEFORE the
+        // report is built (it's a pure read off the scan) because the report's
+        // `Evaluated` ring needs to know whether this run will ever ask the
+        // skill-firing question — see `firingMeasured` below.
+        const isForeign = root !== process.cwd();
+        const surfaces: ExecutableSurfaces = {
+          hasMcp: report.mcp && !isForeign,
+          triggerableSkills: report.skills.filter(
+            (s) => s.hasDescription && !s.userInvoked,
+          ).length,
+          gateSkills: detectGateSkills(report.skills).length,
+          adoptableRefs:
+            adapter.name === "claude-code" &&
+            existsSync(resolve(root, adapter.layout.instructionFile)),
+        };
+        // `decideExecute` is PURE and prompt-free, so the read-vs-run outcome can
+        // be known before anything prints. Only a settled `run` (a remembered yes)
+        // means the firing question actually gets asked on this run; a `skip`
+        // (headless / `--json` / a remembered no) means it never does, and an
+        // `ask` isn't resolved until after the read has printed. Anything but a
+        // certain `run` → the `Evaluated` ring reports "not measured" rather than
+        // scoring a 0 it never earned.
+        const execDecision = decideExecute({
+          hasExecutable:
+            surfaces.hasMcp ||
+            surfaces.triggerableSkills > 0 ||
+            surfaces.adoptableRefs,
+          isTTY: process.stdout.isTTY && process.stdin.isTTY,
+          json,
+          noInteractive:
+            args.includes("--no-interactive") || args.includes("--yes"),
+          remembered: config.audit?.measure,
+        });
+        const firingMeasured =
+          execDecision.kind === "run" &&
+          surfaces.triggerableSkills > 0 &&
+          (adapter.name === "codex" || hasModelAccess(process.env));
         // The report scaffold WITHOUT the rule map — the map's catalog
         // enrichment (enabled-state / "documented but OFF") enumerates the repo's
         // linter, which is gated on the SAME audit.measure consent as the
@@ -7090,6 +7118,7 @@ async function main(): Promise<void> {
             root,
             adapter.layout.instructionFile,
           ),
+          firingMeasured,
         });
         const sc = auditReportBase.score;
         const plan = optimize(report);
@@ -7133,21 +7162,12 @@ async function main(): Promise<void> {
         // BEFORE the rule map is routed, so a first-time "yes" enriches THIS run.
         // (The safety battery is NOT here — it needs cross-platform confinement
         // that isn't shipped, so it lives in the vigiles/testing API.)
-        const isForeign = root !== process.cwd();
-        const surfaces: ExecutableSurfaces = {
-          hasMcp: report.mcp && !isForeign,
-          triggerableSkills: report.skills.filter(
-            (s) => s.hasDescription && !s.userInvoked,
-          ).length,
-          gateSkills: detectGateSkills(report.skills).length,
-          adoptableRefs:
-            adapter.name === "claude-code" &&
-            existsSync(resolve(root, adapter.layout.instructionFile)),
-        };
+        // `surfaces` + `execDecision` were resolved above (the ring needed them);
+        // this only turns an `ask` into a prompt and remembers the answer.
         const { execute, note: execNote } = await resolveExecution(
           surfaces,
+          execDecision,
           json,
-          args,
           adapter.name,
         );
         // Consent is now settled (and remembered via .vigilesrc.json, which

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -97,6 +97,10 @@ import {
 } from "./scan-trigger-suggest.js";
 import { checkDialectDrift, formatDialectDrift } from "./dialect-drift.js";
 import {
+  checkSkillReachability,
+  formatSkillReachability,
+} from "./skill-reachability.js";
+import {
   probePluginTriggers,
   formatBehavioralReport,
   measurePluginSelection,
@@ -7143,6 +7147,13 @@ async function main(): Promise<void> {
           if (adapter.name === "claude-code") {
             const drift = formatDialectDrift(checkDialectDrift());
             if (drift) console.log(drift);
+            // Adoption: this repo depends on vigiles, but can the agent SEE the
+            // skills it ships? `npm install` drops them in node_modules, which
+            // Claude Code never scans — the plugin install is what wires them,
+            // and until it runs the whole teaching surface is silently absent.
+            // Advisory only (machine state, not repo state) — never scored.
+            const reach = formatSkillReachability(checkSkillReachability(root));
+            if (reach) console.log(reach);
           }
           console.log("");
         }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -100,6 +100,7 @@ import {
   checkSkillReachability,
   formatSkillReachability,
 } from "./skill-reachability.js";
+import { addVigilesDeclaration } from "./plugin-declaration.js";
 import {
   probePluginTriggers,
   formatBehavioralReport,
@@ -3301,6 +3302,74 @@ function installPlugins(harnesses: string[]): void {
   // global store, so wire vigiles's proactive nudge hooks into the repo's
   // .codex/config.toml directly (the idiomatic, repo-committed place).
   if (harnesses.includes("codex")) wireCodexHooks();
+  // Claude Code additionally gets a committed DECLARATION, so a collaborator who
+  // clones and never runs `init` is told the project wants this plugin instead
+  // of hitting the silence that costs a day. It does not install anything.
+  if (harnesses.includes("claude")) declareVigilesPlugin();
+}
+
+/**
+ * Write the project-level plugin declaration into `.claude/settings.json`.
+ *
+ * 🔴 **The honest claim.** This does NOT make the plugin available to a
+ * collaborator: an external-source plugin declared project-level does not load
+ * until each person installs it on their own machine (the boundary is
+ * deliberate — plugins run arbitrary code with the user's privileges). What it
+ * buys is that Claude Code then PROMPTS them with the install command, instead
+ * of the silence a fresh clone gets today. Silent absence → a prompt.
+ *
+ * MERGES, never clobbers: this file holds the user's hooks, permissions and
+ * other plugins. The merge rules are the pure, unit-tested
+ * `addVigilesDeclaration`; this is only the IO around it. Invalid JSON is a loud
+ * skip, never a rewrite — mirrors `wireCodexHooks`.
+ */
+function declareVigilesPlugin(): void {
+  const path = resolve(process.cwd(), ".claude", "settings.json");
+  // The vigiles repo IS the plugin — it must not declare itself as a consumer.
+  const pkgPath = resolve(process.cwd(), "package.json");
+  if (existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+        name?: string;
+      };
+      if (pkg.name === "vigiles") return;
+    } catch {
+      /* unreadable package.json — fall through, the declaration is harmless */
+    }
+  }
+
+  let settings: Record<string, unknown> = {};
+  if (existsSync(path)) {
+    try {
+      settings = JSON.parse(readFileSync(path, "utf-8")) as Record<
+        string,
+        unknown
+      >;
+    } catch {
+      console.log(
+        "⚠ .claude/settings.json is not valid JSON — skipping the project plugin declaration (fix it, then re-run `vigiles init`).",
+      );
+      return;
+    }
+  }
+
+  const edit = addVigilesDeclaration(settings);
+  if (!edit.changed) {
+    console.log(
+      "  .claude/settings.json already declares the vigiles plugin — left as-is.",
+    );
+    return;
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(edit.settings, null, 2) + "\n");
+  console.log(
+    "✓ Declared the vigiles plugin in .claude/settings.json (commit it)\n" +
+      "  This does NOT install it for anyone else — Claude Code will PROMPT a\n" +
+      "  collaborator to run `claude plugin install vigiles@vigiles`, instead of\n" +
+      "  the silence a fresh clone gets today.\n" +
+      "  Nothing is vendored: the entry is a reference; the plugin still lives in\n" +
+      "  the global cache, one copy shared across your repos.",
+  );
 }
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -50,6 +50,12 @@ import {
   DEFAULT_LOCK_DIR,
 } from "./eval-lock.js";
 import { applyConfigFlags } from "./cli-flags.js";
+import { VERBS, type Verb } from "./cli-commands.js";
+import {
+  formatUnknownFlag,
+  knownFlagsFor,
+  unknownFlags,
+} from "./cli-flag-check.js";
 import {
   parseSetupArgs,
   shouldPrompt,
@@ -5304,44 +5310,113 @@ function capabilitiesOfReport(
   return computeHarnessCapabilities(agents, dialect);
 }
 
+/**
+ * The help text, ONE entry per verb, so `vigiles --help` (all of them) and
+ * `vigiles <verb> --help` (one of them) cannot drift apart. `vigiles audit
+ * --help` used to RUN AN AUDIT — help lived only on the bare invocation — which
+ * is the least helpful possible response to someone asking what a flag is
+ * called, and part of the same defect as silently swallowing an unknown flag.
+ */
+interface CommandHelp {
+  /** The signature line, aligned with its description in the banner. */
+  readonly usage: string;
+  /** Continuation lines (flags, caveats), indented under the signature. */
+  readonly detail?: readonly string[];
+}
+
+const COMMAND_HELP: Record<Verb, CommandHelp> = {
+  init: {
+    usage:
+      "  vigiles init [flags]           Setup project (--ci-only for the CI gate only; --lint, --test, --harness=, --strict, --report-only, --no-gha, --force)",
+  },
+  compile: { usage: "  vigiles compile [files...]     Compile .spec.ts → .md" },
+  eject: {
+    usage:
+      "  vigiles eject [file]           Un-manage a compiled file → plain hand-owned markdown (--keep-spec)",
+  },
+  lint: {
+    usage:
+      "  vigiles lint [files...]        Verify references, find gaps in instruction files",
+  },
+  audit: {
+    usage:
+      "  vigiles audit [dir...]          Lighthouse for your harness — a LOCAL report: rings + what's broken + fixes (a deterministic read; 2+ dirs → leaderboard)",
+    detail: [
+      "                                 writes vigiles-report.html + .json (auto-gitignored; --out=<dir> · --no-html/--no-json · --no-open · --json for machine output). NOT a CI step — use `vigiles lint` in CI.",
+      "                                 the executing checks (run your hooks · live MCP · do skills fire?) run only interactively — `audit` asks once (remembered); automation uses the vigiles/testing API",
+      "                                 --serve opens a LIVE local report whose buttons create specs in one click (own repo only; loopback + token-guarded) · --no-serve to skip the prompt",
+    ],
+  },
+  test: {
+    usage:
+      "  vigiles test [files...]        Run *.harness.mjs deterministic harness tests",
+  },
+  eval: {
+    usage:
+      "  vigiles eval [files...]        Run *.eval.mjs real-model harness evals (--trials=N, --min=N, --no-skip)",
+    detail: [
+      "                                 --update records each named eval's result to a committed lock (run locally on your subscription)",
+      "                                 --check verifies committed eval results against current inputs WITHOUT a model — the CI staleness gate",
+    ],
+  },
+  generate: {
+    usage:
+      "  vigiles generate <kind>       Emit a dev-toolchain artifact: types (.d.ts) · schema (JSON Schema) · harness (harness.gen.ts)",
+    detail: [
+      "  vigiles generate <kind> --check  Verify the generated file is up to date",
+    ],
+  },
+  "hook-runtime": {
+    usage:
+      "  vigiles hook-runtime <kind>   (emitted into hooks configs — never typed by hand)",
+  },
+};
+
+/** Display order of the human-facing verbs in the banner's "Commands:" block. */
+const HELP_ORDER: readonly Verb[] = [
+  "init",
+  "compile",
+  "eject",
+  "lint",
+  "audit",
+  "test",
+  "eval",
+];
+
+function printHelpEntry(v: Verb): void {
+  console.log(COMMAND_HELP[v].usage);
+  for (const line of COMMAND_HELP[v].detail ?? []) console.log(line);
+}
+
+/**
+ * The loud "there is nothing here to audit" block. Deliberately says WHAT was
+ * looked at and WHY it found nothing, because the commonest cause is that the
+ * target isn't the directory the operator thinks it is.
+ */
+function formatNothingToAudit(root: string, harness: string): string {
+  return [
+    `✗ vigiles audit: nothing to audit in ${root}`,
+    `  No instruction file and no ${harness} surface (skills / subagents / hooks / commands / MCP) was found there.`,
+    "  This is NOT a grade — there was nothing to measure, so no score is reported.",
+    "  Check that the path is the repo you meant, and that a flag didn't swallow it",
+    "  (flags take values with `=`: `--out=dir`, never `--out dir`).",
+  ].join("\n");
+}
+
+/** `vigiles <verb> --help` — that verb's entry plus its complete flag list. */
+function printCommandHelp(command: Verb): void {
+  printHelpEntry(command);
+  const flags = knownFlagsFor(command);
+  console.log("");
+  console.log(`Flags: ${[...flags].sort().join(" ")}`);
+  console.log("(`vigiles --help` lists every command.)");
+}
+
 function printUsage(command: string | undefined): void {
   console.log("vigiles — compile typed specs to instruction files");
   console.log("");
   console.log("Commands:");
-  console.log(
-    "  vigiles init [flags]           Setup project (--ci-only for the CI gate only; --lint, --test, --harness=, --strict, --report-only, --no-gha, --force)",
-  );
-  console.log("  vigiles compile [files...]     Compile .spec.ts → .md");
-  console.log(
-    "  vigiles eject [file]           Un-manage a compiled file → plain hand-owned markdown (--keep-spec)",
-  );
-  console.log(
-    "  vigiles lint [files...]        Verify references, find gaps in instruction files",
-  );
-  console.log(
-    "  vigiles audit [dir...]          Lighthouse for your harness — a LOCAL report: rings + what's broken + fixes (a deterministic read; 2+ dirs → leaderboard)",
-  );
-  console.log(
-    "                                 writes vigiles-report.html + .json (auto-gitignored; --out=<dir> · --no-html/--no-json · --no-open · --json for machine output). NOT a CI step — use `vigiles lint` in CI.",
-  );
-  console.log(
-    "                                 the executing checks (run your hooks · live MCP · do skills fire?) run only interactively — `audit` asks once (remembered); automation uses the vigiles/testing API",
-  );
-  console.log(
-    "                                 --serve opens a LIVE local report whose buttons create specs in one click (own repo only; loopback + token-guarded) · --no-serve to skip the prompt",
-  );
-  console.log(
-    "  vigiles test [files...]        Run *.harness.mjs deterministic harness tests",
-  );
-  console.log(
-    "  vigiles eval [files...]        Run *.eval.mjs real-model harness evals (--trials=N, --min=N, --no-skip)",
-  );
-  console.log(
-    "                                 --update records each named eval's result to a committed lock (run locally on your subscription)",
-  );
-  console.log(
-    "                                 --check verifies committed eval results against current inputs WITHOUT a model — the CI staleness gate",
-  );
+  for (const v of HELP_ORDER) printHelpEntry(v);
   console.log("");
   console.log("Examples:");
   console.log(
@@ -5353,12 +5428,7 @@ function printUsage(command: string | undefined): void {
   );
   console.log("");
   console.log("Plumbing:");
-  console.log(
-    "  vigiles generate <kind>       Emit a dev-toolchain artifact: types (.d.ts) · schema (JSON Schema) · harness (harness.gen.ts)",
-  );
-  console.log(
-    "  vigiles generate <kind> --check  Verify the generated file is up to date",
-  );
+  printHelpEntry("generate");
   console.log("  vigiles --version             Print the version number");
   if (command && command !== "--help") {
     console.log(`\nUnknown command: "${command}"`);
@@ -6875,6 +6945,31 @@ async function main(): Promise<void> {
     return;
   }
 
+  // Refuse an argument we did not understand, BEFORE anything runs. Every verb
+  // parses its own flags by asking `args.includes("--x")` and ignoring the rest,
+  // so `audit --this-flag-does-not-exist` used to run a complete audit and exit
+  // 0. audit's flags govern what LEAVES the machine (`--no-html`, `--no-json`,
+  // `--out=`, `--serve`), so a typo silently produced the opposite of what was
+  // asked for. `<verb> --help` is handled here too: it used to fall through and
+  // RUN the verb, the least useful answer to "what is this flag called?".
+  // `hook-runtime` is exempt — its argv comes from the harness, not a human.
+  if (VERBS.includes(command as Verb) && command !== "hook-runtime") {
+    const flagArgs = args.slice(1);
+    if (flagArgs.includes("--help")) {
+      printCommandHelp(command as Verb);
+      return;
+    }
+    const bad = unknownFlags(command, flagArgs);
+    if (bad.length > 0) {
+      for (const flag of bad) console.error(formatUnknownFlag(command, flag));
+      // 2, not 1. Across this CLI, 1 means "I ran, and the thing you asked about
+      // is bad" (lint findings, a failing harness script); 2 means "I could not
+      // do what you asked" (the top-level error handler, `eval`'s refusal,
+      // `generate` with an unknown kind). A misspelled flag is the second.
+      process.exit(2);
+    }
+  }
+
   const restArgs = args.slice(1).filter((a) => !a.startsWith("--"));
   // Shared flags (--max-rules, --catalog-only) override the loaded config so
   // every GitHub Action input maps to a real CLI flag. See src/cli-flags.ts.
@@ -7121,6 +7216,31 @@ async function main(): Promise<void> {
           firingMeasured,
         });
         const sc = auditReportBase.score;
+        // NOTHING TO AUDIT is not a bad grade — and it used to be reported as
+        // one. `score.empty` means the target has no instruction file AND no
+        // surface: there was never anything to measure. That printed as rings of
+        // `F (0)` at exit 0, which is BYTE-INDISTINGUISHABLE from a genuine audit
+        // of a harness that scores badly. The way it actually bit: `vigiles audit
+        // --json /some/path` — `--json` takes no value, so the path fell through
+        // to the positional scan dir, the audit ran over a directory with no
+        // harness in it, and reported `skills: 0`, grade F, exit 0. A confident
+        // measurement of the wrong object, silently. The flag check added
+        // alongside this does NOT catch that one — `--json` is a real flag and
+        // `audit --json ./dir` is legitimate — so THIS branch is what makes it
+        // visible, and it covers every other way of pointing at the wrong place
+        // too (a moved repo, a bad `$PWD`, a path that doesn't exist).
+        //
+        // Exit 2, matching the unknown-flag decision above: 1 is "I measured, and
+        // it's bad"; 2 is "I could not do what you asked". A script that greps for
+        // a grade needs those to differ, and a grade is exactly what this run does
+        // NOT have. `--json` still emits the report (it self-describes with
+        // `score.empty: true`), so a machine consumer keeps its contract; the
+        // human-readable explanation goes to stderr either way.
+        if (sc.empty) {
+          if (json) console.log(JSON.stringify(auditReportBase, null, 2));
+          console.error(formatNothingToAudit(root, adapter.name));
+          process.exit(2);
+        }
         const plan = optimize(report);
         // The deterministic READ leads: rings + report + fixes + nudges print
         // BEFORE the consent prompt, so a plain `audit` shows its findings first.

--- a/src/coverage-evidence.ts
+++ b/src/coverage-evidence.ts
@@ -1,0 +1,314 @@
+/**
+ * HOW a surface was decided to be covered — the provenance of every coverage
+ * decision, and the fix for a detector that measured the presence of a STRING
+ * rather than the presence of a test.
+ *
+ * ## The defect this exists to close
+ *
+ * Coverage used to be: "does any discovered test file contain this surface's path
+ * or namespace as a substring?" Measured on a real repo (37 skills, 14 hooks),
+ * appending ONE LINE to an existing harness —
+ *
+ * ```js
+ * // probe: skills/argument-arc
+ * ```
+ *
+ * — a COMMENT, not a test, moved the untested count 33 → 32. The metric was
+ * trivially gameable, and the gaming was indistinguishable from real work.
+ *
+ * The second half was worse. A harness that genuinely asserts over all 21 of a
+ * repo's pipeline skills, but builds its paths at RUNTIME
+ * (`join(root, ".claude", "skills", name, "SKILL.md")`), contains zero literal
+ * `skills/<name>` strings and therefore covered NOTHING. Generality was
+ * penalised: 21 trivial files each naming their subject scored better than one
+ * harness that actually tested all 21.
+ *
+ * This is the exact substitution vigiles names in other people's repos —
+ * *presence of a surface taken for presence of the property*, the way
+ * `noExplicitAny` sitting in a config is taken for the rule being enforced. The
+ * tool was committing it in its own scoring.
+ *
+ * ## The three kinds of evidence, weakest last
+ *
+ * | evidence | how it is established | can it happen by accident? |
+ * |---|---|---|
+ * | `declared` | a `vigiles:covers <surface> …` marker in the test file | no — the marker is reserved |
+ * | `colocated` | the test sits inside/next to the surface | no — it is a placement decision |
+ * | `mention`   | the surface's path/namespace appears in the test's CODE | yes |
+ *
+ * `declared` is the answer to the false NEGATIVE: a runtime-path harness can now
+ * say what it covers, structurally, instead of being guessed at by substring.
+ * Declaration beats inference — the same move as declaring `allowed-tools`
+ * instead of inferring capability from behaviour.
+ *
+ * `mention` is KEPT, deliberately, but narrowed to code: it is the zero-config
+ * path that makes an ordinary `foo.test.ts` naming `skills/foo` count without
+ * anyone learning a marker, and removing it would flip thousands of honestly
+ * covered surfaces to "untested" overnight. What it no longer reads is COMMENTS.
+ * A path inside a comment is prose about the test; a path in executable code is
+ * the test reaching for the surface. Prose isn't policy — including ours. And
+ * because the evidence is now REPORTED, a repo whose coverage rests entirely on
+ * substring matches can finally see that about itself.
+ *
+ * Browser-safe and pure (no `node:*`): the disk detector (`test-coverage.ts`) and
+ * its in-browser twin (`test-coverage-files.ts`) both route through here, so the
+ * two cannot drift on the part that decides coverage.
+ */
+
+/** How a covered surface was decided to be covered, strongest first. */
+export type CoverageEvidence = "declared" | "colocated" | "mention";
+
+/** Ranking used when several test files cover the same surface — strongest wins. */
+const RANK: Record<CoverageEvidence, number> = {
+  declared: 3,
+  colocated: 2,
+  mention: 1,
+};
+
+/**
+ * The explicit declaration marker. Mirrors the existing `vigiles:ignore-test`
+ * opt-out marker convention, on the other side: `ignore-test` says "hold this
+ * surface to nothing", `covers` says "this test holds these surfaces".
+ *
+ * ```js
+ * // vigiles:covers skills/argument-arc, skills/tighten-paper
+ * ```
+ *
+ * Everything after the marker to end-of-line is the list (whitespace- or
+ * comma-separated). Repeat the marker on as many lines as you need.
+ */
+export const COVERS_MARKER = "vigiles:covers";
+
+/** The minimum a surface must expose to be matched — structural, no import cycle. */
+export interface CoverableSurface {
+  /** Repo-relative path of the surface file (SKILL.md / agent .md / hook script). */
+  readonly path: string;
+  /** Stable name: skill dir, agent basename, or hook script basename. */
+  readonly name: string;
+  /** Substrings a test may reference to "cover" this surface (path / namespace). */
+  readonly tokens: readonly string[];
+}
+
+/** A discovered test file, with the two derived views coverage is decided from. */
+export interface PreparedTest {
+  readonly path: string;
+  /** Surfaces the file explicitly declares it covers (`vigiles:covers`). */
+  readonly declares: readonly string[];
+  /** The file with comments removed — what `mention` matching may read. */
+  readonly code: string;
+}
+
+// ---------------------------------------------------------------------------
+// Comment stripping
+// ---------------------------------------------------------------------------
+
+/** `//` + `/* *\/` languages — every default test glob lands here. */
+const SLASH_COMMENT_EXT = /\.[cm]?[jt]sx?$/;
+
+/** `#` languages — reachable only via a user-supplied `testGlobs`. */
+const HASH_COMMENT_EXT = /\.(?:py|rb|sh|bash|zsh|ya?ml|toml)$/;
+
+interface CommentSyntax {
+  /** Line-comment openers (to end of line). */
+  readonly line: readonly string[];
+  /** Whether `/* … *\/` block comments apply. */
+  readonly block: boolean;
+}
+
+/**
+ * Comment syntax by extension, or `null` for "unknown format — don't touch it".
+ *
+ * Deliberately conservative. An unrecognised `testGlobs` entry (a promptfoo
+ * `.yaml` is covered; a bespoke `.conf` is not) keeps the OLD raw-substring
+ * behaviour rather than being mangled by a guess: a wrong strip would silently
+ * DROP real coverage, and losing a true positive is worse here than keeping a
+ * weak one that is now labelled `mention` in the report anyway.
+ */
+function commentSyntaxFor(path: string): CommentSyntax | null {
+  if (SLASH_COMMENT_EXT.test(path)) return { line: ["//"], block: true };
+  if (HASH_COMMENT_EXT.test(path)) return { line: ["#"], block: false };
+  return null;
+}
+
+/**
+ * Remove comments while preserving string literals — a small hand scanner rather
+ * than a regex, because the interesting inputs are exactly the ones a regex gets
+ * wrong: `"https://example.com"` must survive (it is data), `// see skills/foo`
+ * must not (it is prose).
+ *
+ * Not a parser. A regex literal containing two adjacent unescaped slashes would
+ * be mis-read as a comment; that is unreachable in practice (`//` is not a valid
+ * empty regex) and the failure direction is safe — it can only DROP a mention,
+ * never invent one.
+ *
+ * The metric rules are disabled for this one function: its branch count IS the
+ * lexer state machine (quote open / quote close / escape / line comment / block
+ * comment), and splitting it across helpers to satisfy a threshold would hide
+ * that state, not simplify it. Same call as `posix-path.ts` makes for its ported
+ * scanner.
+ */
+/* eslint-disable complexity, sonarjs/cognitive-complexity, sonarjs/nested-control-flow */
+function stripComments(src: string, syntax: CommentSyntax): string {
+  let out = "";
+  let i = 0;
+  let quote = "";
+  while (i < src.length) {
+    const c = src[i];
+    if (quote) {
+      if (c === "\\") {
+        out += c + (src[i + 1] ?? "");
+        i += 2;
+        continue;
+      }
+      if (c === quote) quote = "";
+      out += c;
+      i++;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      quote = c;
+      out += c;
+      i++;
+      continue;
+    }
+    const opener = syntax.line.find((l) => src.startsWith(l, i));
+    if (opener) {
+      while (i < src.length && src[i] !== "\n") i++;
+      continue;
+    }
+    if (syntax.block && c === "/" && src[i + 1] === "*") {
+      i += 2;
+      while (i < src.length && !(src[i] === "*" && src[i + 1] === "/")) {
+        // Keep newlines so line numbers (and any line-oriented reading of the
+        // stripped text) stay aligned with the original file.
+        if (src[i] === "\n") out += "\n";
+        i++;
+      }
+      i += 2;
+      continue;
+    }
+    out += c;
+    i++;
+  }
+  return out;
+}
+/* eslint-enable complexity, sonarjs/cognitive-complexity, sonarjs/nested-control-flow */
+
+// ---------------------------------------------------------------------------
+// Declarations
+// ---------------------------------------------------------------------------
+
+/** Parse every `vigiles:covers …` line into the surfaces it names. */
+function parseDeclarations(content: string): string[] {
+  const out: string[] = [];
+  let from = content.indexOf(COVERS_MARKER);
+  while (from !== -1) {
+    const lineEnd = content.indexOf("\n", from);
+    const rest = content.slice(
+      from + COVERS_MARKER.length,
+      lineEnd === -1 ? undefined : lineEnd,
+    );
+    for (const raw of rest.split(/[\s,]+/)) {
+      // Trim the punctuation a marker picks up from its host comment syntax:
+      // a trailing `*/`, a leading `*` in a JSDoc block, quotes, `-->`.
+      const tok = raw.replace(/^["'`*]+|["'`]+$|\*\/$|-->$/g, "").trim();
+      if (tok) out.push(tok);
+    }
+    from = content.indexOf(COVERS_MARKER, from + COVERS_MARKER.length);
+  }
+  return out;
+}
+
+/** Does one declared token name this surface? */
+function declarationMatches(
+  surface: CoverableSurface,
+  declaration: string,
+): boolean {
+  const d = declaration.replace(/\/+$/, "");
+  if (!d) return false;
+  return (
+    d === surface.path ||
+    d === surface.name ||
+    surface.tokens.includes(d) ||
+    // `.claude/skills/foo` naming `.claude/skills/foo/SKILL.md`.
+    surface.path.startsWith(`${d}/`)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** Derive the two views coverage is decided from. Do this ONCE per test file. */
+export function prepareTest(path: string, content: string): PreparedTest {
+  const syntax = commentSyntaxFor(path);
+  return {
+    path,
+    // Declarations are read from the RAW file — the marker lives in a comment by
+    // construction, so it must be parsed before comments are removed.
+    declares: parseDeclarations(content),
+    code: syntax ? stripComments(content, syntax) : content,
+  };
+}
+
+/**
+ * The evidence one test file provides for one surface, or `null` for none.
+ * `colocated` is passed in because placement is a path question the two twins
+ * answer with their own (disk vs POSIX-string) path helpers.
+ */
+export function evidenceFor(
+  surface: CoverableSurface,
+  test: PreparedTest,
+  colocated: boolean,
+): CoverageEvidence | null {
+  if (test.declares.some((d) => declarationMatches(surface, d)))
+    return "declared";
+  if (colocated) return "colocated";
+  if (surface.tokens.some((tok) => test.code.includes(tok))) return "mention";
+  return null;
+}
+
+/** Is `a` STRICTLY stronger evidence than `b`? (Ties keep the incumbent.) */
+export function isStronger(a: CoverageEvidence, b: CoverageEvidence): boolean {
+  return RANK[a] > RANK[b];
+}
+
+/** Per-evidence tallies — the provenance summary the report prints. */
+export interface EvidenceCounts {
+  readonly declared: number;
+  readonly colocated: number;
+  readonly mention: number;
+}
+
+/** Tally a list of decisions by evidence kind. */
+export function countEvidence(
+  decisions: readonly { readonly evidence: CoverageEvidence }[],
+): EvidenceCounts {
+  const counts = { declared: 0, colocated: 0, mention: 0 };
+  for (const d of decisions) counts[d.evidence]++;
+  return counts;
+}
+
+/**
+ * One line naming how the coverage was established. Printed wherever a coverage
+ * count is printed: a number with no provenance is the thing this module exists
+ * to stop shipping.
+ */
+export function formatEvidence(counts: EvidenceCounts): string {
+  const total = counts.declared + counts.colocated + counts.mention;
+  if (total === 0) return "";
+  const parts = [
+    `${String(counts.declared)} declared (\`${COVERS_MARKER}\`)`,
+    `${String(counts.colocated)} colocated`,
+    `${String(counts.mention)} name-mentioned`,
+  ];
+  let tail = "";
+  if (counts.mention > 0) {
+    tail =
+      counts.declared + counts.colocated === 0
+        ? " — ALL of it is a name appearing in a test file, which is the weakest" +
+          " evidence there is; declare what a test covers to make it real."
+        : " (a mention is the weakest evidence — it only says the name appears)";
+  }
+  return `How coverage was decided: ${parts.join(" · ")}${tail}`;
+}

--- a/src/harness-assert.test.ts
+++ b/src/harness-assert.test.ts
@@ -867,3 +867,49 @@ test("assertHookNotices / assertHookSilent test a react hook in-process", () => 
     });
   }, /expected a react hook, got allow \(a gate decision\)/);
 });
+
+// --- "nobody looked" is not "nothing happened" -----------------------------
+//
+// `filesWritten` is recorded only on CONFINED runs. Before this, an unconfined
+// run produced `[]`, so `assertNoWrite(r, /secret/)` returned GREEN having
+// inspected nothing — a checker reporting success while doing no work, the
+// exact class this repo keeps finding in other people's harnesses. The two
+// states are now structurally distinct: `undefined` = never recorded,
+// `[]` = recorded and genuinely empty.
+
+test("assertNoWrite THROWS when writes were never recorded, instead of passing vacuously", () => {
+  const unrecorded = {}; // an unconfined runHook result: no filesWritten
+  assert.throws(
+    () => {
+      assertNoWrite(unrecorded, /\.env$/);
+    },
+    /never (recorded|captured)|not recorded/i,
+    "an unrecorded run must not report a clean bill of health",
+  );
+});
+
+test("assertWroteOnly THROWS when writes were never recorded", () => {
+  assert.throws(() => {
+    assertWroteOnly({}, [/^\.omc\//]);
+  }, /never (recorded|captured)|not recorded/i);
+});
+
+test("the throw says HOW to record writes, so the fix isn't a doc hunt", () => {
+  let msg = "";
+  try {
+    assertNoWrite({}, ".env");
+  } catch (e) {
+    msg = (e as Error).message;
+  }
+  // Naming the option is the whole point — confinement is what records writes.
+  assert.match(msg, /sandbox/i);
+});
+
+test("a RECORDED-but-empty write list still passes — nothing happened is a real answer", () => {
+  assert.doesNotThrow(() => {
+    assertNoWrite({ filesWritten: [] }, /\.env$/);
+  });
+  assert.doesNotThrow(() => {
+    assertWroteOnly({ filesWritten: [] }, [/^\.omc\//]);
+  });
+});

--- a/src/harness-assert.ts
+++ b/src/harness-assert.ts
@@ -271,17 +271,44 @@ export function assertEgressOnly(
 // (`r.filesWritten`, relative paths). These assert a hook touched only the files
 // it should — e.g. "wrote nothing but its own state cache".
 
-/** Anything carrying recorded file writes (a confined runHook result). */
+/**
+ * Anything carrying recorded file writes (a confined `runHook`/`runScript`
+ * result). `filesWritten` is OPTIONAL on purpose: `undefined` means the run
+ * never recorded writes at all, which is a different fact from `[]` ("recorded,
+ * and it wrote nothing"). See {@link requireWrites}.
+ */
 interface HasWrites {
-  readonly filesWritten: readonly string[];
+  readonly filesWritten?: readonly string[];
 }
 
 const matches = (f: string, p: string | RegExp): boolean =>
   typeof p === "string" ? f.includes(p) : p.test(f);
 
+/**
+ * The recorded write list, or a THROW when the run never recorded one.
+ *
+ * Writes are captured by diffing the work dir, which only happens on a confined
+ * run. An unconfined run therefore knows nothing about what the program wrote —
+ * and an assertion that silently treats "nobody looked" as "nothing happened"
+ * reports success while inspecting no evidence. That is the failure mode this
+ * whole library exists to catch in other people's harnesses, so it must not be
+ * this library's own default. Refuse instead, and name the fix.
+ */
+function requireWrites(r: HasWrites, assertion: string): readonly string[] {
+  if (r.filesWritten !== undefined) return r.filesWritten;
+  return fail(
+    `${assertion} cannot run: this result never recorded file writes, so ` +
+      `passing it would assert nothing. Writes are captured by diffing the work ` +
+      `dir, which only a CONFINED run does — pass \`{ sandbox: "auto" }\` (or ` +
+      `\`"strict"\`) to record them. Note confinement needs Linux + bubblewrap.`,
+  );
+}
+
 /** Assert the run wrote NO file matching `pattern` (substring or regex). */
 export function assertNoWrite(r: HasWrites, pattern: string | RegExp): void {
-  const bad = r.filesWritten.filter((f) => matches(f, pattern));
+  const bad = requireWrites(r, "assertNoWrite").filter((f) =>
+    matches(f, pattern),
+  );
   if (bad.length > 0) {
     fail(
       `expected no write matching ${String(pattern)}, but wrote: ${bad.join(", ")}`,
@@ -294,7 +321,9 @@ export function assertWroteOnly(
   r: HasWrites,
   allowed: ReadonlyArray<string | RegExp>,
 ): void {
-  const bad = r.filesWritten.filter((f) => !allowed.some((a) => matches(f, a)));
+  const bad = requireWrites(r, "assertWroteOnly").filter(
+    (f) => !allowed.some((a) => matches(f, a)),
+  );
   if (bad.length > 0) {
     fail(`run wrote file(s) outside the allowlist: ${bad.join(", ")}`);
   }

--- a/src/plugin-declaration.test.ts
+++ b/src/plugin-declaration.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for the project-level plugin DECLARATION (`src/plugin-declaration.ts`).
+ *
+ * What this is and is not: writing `extraKnownMarketplaces` + `enabledPlugins`
+ * into a repo's `.claude/settings.json` does NOT make the plugin available to a
+ * collaborator. Per the Claude Code team-marketplace docs, an external-source
+ * plugin declared project-level "doesn't load until the team member installs
+ * it". What the declaration buys is that Claude Code then TELLS them the project
+ * wants it and how to install it, instead of the silence they get today.
+ *
+ * The load-bearing property under test is therefore not "does it enable the
+ * plugin" but **"does it leave everything else alone"**. This file is the user's
+ * hooks, permissions and other plugins — one real example is 100+ hand-written
+ * lines wiring four compiled hooks. Clobbering it would be far worse than the
+ * silence being fixed.
+ */
+import { test } from "vitest";
+import assert from "node:assert/strict";
+
+import {
+  addVigilesDeclaration,
+  removeVigilesDeclaration,
+  VIGILES_PLUGIN_ID,
+} from "./plugin-declaration.js";
+
+/** A settings.json shaped like a real one: hooks, permissions, another plugin. */
+function realisticSettings(): Record<string, unknown> {
+  return {
+    $schema: "https://json.schemastore.org/claude-code-settings.json",
+    permissions: { allow: ["Bash(npm run test:*)"], deny: ["Read(./.env)"] },
+    extraKnownMarketplaces: {
+      mattpocock: { source: { source: "github", repo: "mattpocock/skills" } },
+    },
+    enabledPlugins: { "mattpocock-skills@mattpocock": true },
+    hooks: {
+      PreToolUse: [
+        {
+          matcher: "Edit|Write",
+          hooks: [{ type: "command", command: "bash .claude/hooks/guard.sh" }],
+        },
+      ],
+    },
+  };
+}
+
+test("adds both keys to a settings file that has neither", () => {
+  const r = addVigilesDeclaration({});
+  assert.equal(r.changed, true);
+  assert.deepEqual(r.settings, {
+    extraKnownMarketplaces: {
+      vigiles: { source: { source: "github", repo: "zernie/vigiles" } },
+    },
+    enabledPlugins: { [VIGILES_PLUGIN_ID]: true },
+  });
+});
+
+test("MERGES — every unrelated key survives untouched", () => {
+  const before = realisticSettings();
+  const r = addVigilesDeclaration(realisticSettings());
+  assert.equal(r.changed, true);
+
+  // The user's own config is byte-identical.
+  assert.deepEqual(r.settings.permissions, before.permissions);
+  assert.deepEqual(r.settings.hooks, before.hooks);
+  assert.equal(r.settings.$schema, before.$schema);
+
+  // Their other marketplace and plugin are still there, beside ours.
+  const mk = r.settings.extraKnownMarketplaces as Record<string, unknown>;
+  assert.deepEqual(mk.mattpocock, {
+    source: { source: "github", repo: "mattpocock/skills" },
+  });
+  assert.deepEqual(mk.vigiles, {
+    source: { source: "github", repo: "zernie/vigiles" },
+  });
+  const en = r.settings.enabledPlugins as Record<string, unknown>;
+  assert.equal(en["mattpocock-skills@mattpocock"], true);
+  assert.equal(en[VIGILES_PLUGIN_ID], true);
+});
+
+test("does not mutate the object it was given", () => {
+  const input = realisticSettings();
+  addVigilesDeclaration(input);
+  assert.equal(
+    (input.extraKnownMarketplaces as Record<string, unknown>).vigiles,
+    undefined,
+    "the caller's object must be untouched",
+  );
+});
+
+test("leaves an existing vigiles marketplace entry alone — it may point at a fork", () => {
+  const forked = {
+    extraKnownMarketplaces: {
+      vigiles: { source: { source: "github", repo: "myorg/vigiles-fork" } },
+    },
+  };
+  const r = addVigilesDeclaration(forked);
+  assert.deepEqual(
+    (r.settings.extraKnownMarketplaces as Record<string, unknown>).vigiles,
+    { source: { source: "github", repo: "myorg/vigiles-fork" } },
+    "a hand-pointed source must not be rewritten",
+  );
+});
+
+test("does not flip an explicit `false` back to true — that is a deliberate disable", () => {
+  const disabled = { enabledPlugins: { [VIGILES_PLUGIN_ID]: false } };
+  const r = addVigilesDeclaration(disabled);
+  assert.equal(
+    (r.settings.enabledPlugins as Record<string, unknown>)[VIGILES_PLUGIN_ID],
+    false,
+  );
+});
+
+test("is idempotent — running init twice changes nothing the second time", () => {
+  const once = addVigilesDeclaration(realisticSettings());
+  const twice = addVigilesDeclaration(once.settings);
+  assert.equal(twice.changed, false, "second run is a no-op");
+  assert.deepEqual(twice.settings, once.settings);
+});
+
+test("removal takes out exactly the two keys and leaves the siblings", () => {
+  const withOurs = addVigilesDeclaration(realisticSettings()).settings;
+  const r = removeVigilesDeclaration(withOurs);
+  assert.equal(r.changed, true);
+
+  const mk = r.settings.extraKnownMarketplaces as Record<string, unknown>;
+  assert.equal(mk.vigiles, undefined, "ours is gone");
+  assert.deepEqual(
+    mk.mattpocock,
+    { source: { source: "github", repo: "mattpocock/skills" } },
+    "theirs is not",
+  );
+  const en = r.settings.enabledPlugins as Record<string, unknown>;
+  assert.equal(en[VIGILES_PLUGIN_ID], undefined);
+  assert.equal(en["mattpocock-skills@mattpocock"], true);
+
+  // And nothing else was touched.
+  assert.deepEqual(r.settings.hooks, realisticSettings().hooks);
+  assert.deepEqual(r.settings.permissions, realisticSettings().permissions);
+});
+
+test("add → remove round-trips a file that started with neither key", () => {
+  const original = { permissions: { allow: ["Bash(ls)"] } };
+  const there = addVigilesDeclaration(original).settings;
+  const back = removeVigilesDeclaration(there);
+  assert.deepEqual(back.settings, original, "no litter left behind");
+});
+
+test("removing drops an emptied parent, but keeps one that still has entries", () => {
+  const onlyOurs = addVigilesDeclaration({}).settings;
+  const cleaned = removeVigilesDeclaration(onlyOurs).settings;
+  assert.equal(cleaned.extraKnownMarketplaces, undefined);
+  assert.equal(cleaned.enabledPlugins, undefined);
+
+  const shared = addVigilesDeclaration(realisticSettings()).settings;
+  const stillShared = removeVigilesDeclaration(shared).settings;
+  assert.ok(
+    stillShared.extraKnownMarketplaces,
+    "theirs keeps the parent alive",
+  );
+  assert.ok(stillShared.enabledPlugins);
+});
+
+test("removing from a file that never had it is a no-op", () => {
+  const r = removeVigilesDeclaration(realisticSettings());
+  assert.equal(r.changed, false);
+  assert.deepEqual(r.settings, realisticSettings());
+});

--- a/src/plugin-declaration.ts
+++ b/src/plugin-declaration.ts
@@ -1,0 +1,178 @@
+/**
+ * The project-level plugin DECLARATION that `vigiles init` writes into a repo's
+ * `.claude/settings.json`.
+ *
+ * ⚠️ **What this does and does not buy — the claim matters.** Writing
+ * `extraKnownMarketplaces` + `enabledPlugins` does **NOT** make the plugin
+ * available to a collaborator. Per the Claude Code docs (Discover plugins →
+ * "Configure team marketplaces"), as of CC v2.1.195:
+ *
+ * > A plugin that only the project's `.claude/settings.json` enables, and that
+ * > comes from an external source such as a GitHub repository or npm package,
+ * > doesn't load until the team member installs it. Until then, Claude Code
+ * > reports the plugin as not installed and shows the `claude plugin install`
+ * > command to run.
+ *
+ * vigiles ships from a GitHub marketplace, so that is exactly our case, and the
+ * boundary is deliberate: plugins "can execute arbitrary code on your machine
+ * with your user privileges", so a repo is not allowed to install one for you.
+ *
+ * The declaration buys exactly one thing, and it is worth having: a collaborator
+ * who clones the repo and never runs `vigiles init` currently gets **silence** —
+ * the package is in `node_modules`, its six skills are unreachable, and nothing
+ * says so. With the declaration, Claude Code tells them the project wants this
+ * plugin and prints the command that installs it. **Silent absence becomes a
+ * prompt.** It does not become a working install.
+ *
+ * Nothing is vendored: what lands in the repo is a *reference* (a marketplace
+ * source plus an enabled flag). The plugin content still lives in the global
+ * cache, one copy shared across every repo on the machine.
+ *
+ * Both directions are PURE functions over the parsed settings object, so the
+ * merge rules are unit-tested without touching a file. The rule that matters
+ * most is **never clobber**: this file holds the user's hooks, permissions and
+ * other plugins, and destroying it would be far worse than the silence.
+ */
+
+/** The marketplace name vigiles registers under. */
+export const VIGILES_MARKETPLACE_NAME = "vigiles";
+
+/** The plugin id `claude plugin install` records — `<plugin>@<marketplace>`. */
+export const VIGILES_PLUGIN_ID = "vigiles@vigiles";
+
+/** The marketplace entry `init` writes (a reference, not vendored content). */
+export const VIGILES_MARKETPLACE_ENTRY = {
+  source: { source: "github", repo: "zernie/vigiles" },
+} as const;
+
+/** The result of an edit: the new settings, whether anything moved, and why. */
+export interface DeclarationEdit {
+  /** A NEW object — the input is never mutated. */
+  readonly settings: Record<string, unknown>;
+  /** False when the file already said what we wanted it to say. */
+  readonly changed: boolean;
+  /** Human-readable notes for the CLI to print (never invented state). */
+  readonly notes: readonly string[];
+}
+
+/** A shallow object clone, or a fresh object when the value isn't one. */
+function objectAt(
+  settings: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> {
+  const v = settings[key];
+  return typeof v === "object" && v !== null && !Array.isArray(v)
+    ? { ...(v as Record<string, unknown>) }
+    : {};
+}
+
+/** A copy of `obj` without `key`. Pure — the input is untouched. */
+function omit(
+  obj: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(obj).filter(([k]) => k !== key));
+}
+
+/** Is `key` an own property of the object at `settings[parent]`? */
+function has(
+  settings: Record<string, unknown>,
+  parent: string,
+  key: string,
+): boolean {
+  const v = settings[parent];
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    Object.prototype.hasOwnProperty.call(v, key)
+  );
+}
+
+/**
+ * Add the vigiles marketplace + enabled flag, **merging** into whatever is
+ * already there. Pure — returns a new object.
+ *
+ * Two deliberate non-actions, both cases of "an existing answer is the user's
+ * answer, not a gap to fill":
+ *
+ * - An existing `extraKnownMarketplaces.vigiles` is left **exactly** as-is. It
+ *   may point at a fork or a pinned ref, and rewriting it to upstream would
+ *   silently retarget their install.
+ * - An existing `enabledPlugins["vigiles@vigiles"]` is left as-is **including
+ *   when it is `false`** — that is a deliberate disable, and flipping it back
+ *   would be the clobber this function exists to avoid.
+ */
+export function addVigilesDeclaration(
+  settings: Record<string, unknown>,
+): DeclarationEdit {
+  const notes: string[] = [];
+  const next = { ...settings };
+
+  const haveMarketplace = has(
+    settings,
+    "extraKnownMarketplaces",
+    VIGILES_MARKETPLACE_NAME,
+  );
+  const haveEnabled = has(settings, "enabledPlugins", VIGILES_PLUGIN_ID);
+
+  if (!haveMarketplace) {
+    const marketplaces = objectAt(settings, "extraKnownMarketplaces");
+    marketplaces[VIGILES_MARKETPLACE_NAME] = VIGILES_MARKETPLACE_ENTRY;
+    next.extraKnownMarketplaces = marketplaces;
+    notes.push("registered the vigiles marketplace");
+  } else {
+    notes.push("left the existing vigiles marketplace entry alone");
+  }
+
+  if (!haveEnabled) {
+    const enabled = objectAt(settings, "enabledPlugins");
+    enabled[VIGILES_PLUGIN_ID] = true;
+    next.enabledPlugins = enabled;
+    notes.push(`declared ${VIGILES_PLUGIN_ID}`);
+  } else {
+    notes.push(`left the existing ${VIGILES_PLUGIN_ID} setting alone`);
+  }
+
+  return { settings: next, changed: !haveMarketplace || !haveEnabled, notes };
+}
+
+/**
+ * Remove exactly what {@link addVigilesDeclaration} writes, and nothing else.
+ * Pure. Other marketplaces and other plugins are never touched; a parent object
+ * left empty is dropped so the file isn't littered with `{}`.
+ *
+ * Note what this deliberately does NOT do: uninstall the global plugin. That
+ * install is shared by every repo on the machine, so one project cannot speak
+ * for the others.
+ */
+export function removeVigilesDeclaration(
+  settings: Record<string, unknown>,
+): DeclarationEdit {
+  const notes: string[] = [];
+  let next = { ...settings };
+  let changed = false;
+
+  // Each removal is a pure rebuild: drop our key from the child, then either
+  // keep the trimmed child or drop the parent when we emptied it (so the file
+  // isn't littered with `{}` we introduced).
+  const strip = (parent: string, key: string, note: string): void => {
+    if (!has(settings, parent, key)) return;
+    const kept = omit(objectAt(settings, parent), key);
+    next =
+      Object.keys(kept).length === 0
+        ? omit(next, parent)
+        : { ...next, [parent]: kept };
+    changed = true;
+    notes.push(note);
+  };
+
+  strip(
+    "extraKnownMarketplaces",
+    VIGILES_MARKETPLACE_NAME,
+    "removed the vigiles marketplace entry",
+  );
+  strip("enabledPlugins", VIGILES_PLUGIN_ID, `removed ${VIGILES_PLUGIN_ID}`);
+
+  if (!changed) notes.push("no vigiles declaration was present");
+  return { settings: next, changed, notes };
+}

--- a/src/run-hook.test.ts
+++ b/src/run-hook.test.ts
@@ -442,3 +442,50 @@ test.skipIf(!sandboxAvailable())(
     assertWroteOnly(r, [/^\.omc\//]); // …and only under .omc/
   },
 );
+
+// --- the contract the `test-harness` skill teaches for plain helper scripts ---
+//
+// A knowledgeable user hand-rolled an `execFileSync` runner to test 13 helper
+// scripts and hit the same bug three times: `execFileSync` returns stdout ALONE
+// on success, so advisory output — which tools (including vigiles's own compiled
+// hook `notice()`) write to stderr — vanished, and healthy react hooks were
+// reported dead. `runHook` is the tier for a plain program, and it carries BOTH
+// streams. These pin that promise so a refactor can't quietly invalidate the
+// skill's advice.
+
+test("runHook drives a plain helper script and returns BOTH streams, not just stdout", () => {
+  const dir = mkdtempSync(join(tmpdir(), "vigiles-script-"));
+  writeFileSync(
+    join(dir, "check-links.sh"),
+    'echo "scanning..."\necho "0 broken links" >&2\nexit 0\n',
+  );
+  // A plain script ignores the event payload entirely — `{}` is fine.
+  const r = runHook("bash check-links.sh", {}, { cwd: dir });
+  assert.equal(r.exitCode, 0);
+  assert.equal(r.stdout, "scanning...\n");
+  // The load-bearing one: an execFileSync-shaped runner drops exactly this.
+  assert.equal(r.stderr, "0 broken links\n");
+});
+
+test("a failing script still surfaces its stdout AND stderr, not an exception", () => {
+  const dir = mkdtempSync(join(tmpdir(), "vigiles-script-"));
+  writeFileSync(
+    join(dir, "fail.sh"),
+    'echo "partial output"\necho "boom" >&2\nexit 3\n',
+  );
+  const r = runHook("bash fail.sh", {}, { cwd: dir });
+  assert.equal(r.exitCode, 3);
+  assert.equal(r.stdout, "partial output\n");
+  assert.equal(r.stderr, "boom\n");
+});
+
+test("filesWritten is EMPTY on an unconfined run — so a write assertion is vacuous there", () => {
+  // The skill warns about this explicitly: `assertNoWrite`/`assertWroteOnly`
+  // read `filesWritten`, which is only recorded under confinement. Pinned so
+  // the warning stays true (and so a future always-on snapshot must update it).
+  const dir = mkdtempSync(join(tmpdir(), "vigiles-script-"));
+  writeFileSync(join(dir, "w.sh"), "echo hi > wrote-a-file.txt\n");
+  const r = runHook("bash w.sh", {}, { cwd: dir });
+  assert.equal(r.exitCode, 0);
+  assert.deepEqual([...r.filesWritten], []);
+});

--- a/src/run-hook.test.ts
+++ b/src/run-hook.test.ts
@@ -14,6 +14,7 @@ import {
   assertNoEgress,
   assertEgressOnly,
   assertWroteOnly,
+  assertNoWrite,
 } from "./harness-assert.js";
 import {
   runHook,
@@ -22,9 +23,8 @@ import {
   decideHook,
   propertyHook,
   type HookOutput,
-  type RunHookDeps,
-  type HookSpawnResult,
 } from "./run-hook.js";
+import type { RunScriptDeps, ScriptSpawnResult } from "./run-script.js";
 import { sandboxAvailable } from "./sandbox.js";
 
 test("propertyHook: holds for a correct guard, finds a counterexample for a buggy one", () => {
@@ -188,7 +188,7 @@ test("runHook: governs MCP tools by name (no server needed)", () => {
 
 // --- the sandbox seam (runHookWith with fake spawners) ---------------------
 
-const spawnRes = (o: Partial<HookSpawnResult> = {}): HookSpawnResult => ({
+const spawnRes = (o: Partial<ScriptSpawnResult> = {}): ScriptSpawnResult => ({
   status: 0,
   signal: null,
   stdout: "",
@@ -198,7 +198,7 @@ const spawnRes = (o: Partial<HookSpawnResult> = {}): HookSpawnResult => ({
 
 test("runHookWith routes direct vs sandbox by policy, refuses when unavailable", () => {
   let used = "";
-  const deps = (available: boolean): RunHookDeps => ({
+  const deps = (available: boolean): RunScriptDeps => ({
     available,
     egressAvailable: available,
     direct: () => {
@@ -235,7 +235,7 @@ test("runHookWith routes direct vs sandbox by policy, refuses when unavailable",
 
 test("runHookWith: trusted:false confines by default, refuses without bwrap", () => {
   let used = "";
-  const deps = (available: boolean): RunHookDeps => ({
+  const deps = (available: boolean): RunScriptDeps => ({
     available,
     egressAvailable: available,
     direct: () => {
@@ -280,7 +280,7 @@ test("runHookWith: trusted:false confines by default, refuses without bwrap", ()
 
 test("runHookWith routes egress:{allow} to the egress seam, refuses when unavailable", () => {
   let used = "";
-  const deps = (egressAvailable: boolean): RunHookDeps => ({
+  const deps = (egressAvailable: boolean): RunScriptDeps => ({
     available: true,
     egressAvailable,
     direct: () => {
@@ -326,7 +326,7 @@ test("runHookWith routes egress:{allow} to the egress seam, refuses when unavail
 });
 
 test("runHookWith maps a signal kill to exit 1", () => {
-  const deps: RunHookDeps = {
+  const deps: RunScriptDeps = {
     available: true,
     egressAvailable: true,
     direct: () => spawnRes({ status: null, signal: "SIGKILL" }),
@@ -438,6 +438,8 @@ test.skipIf(!sandboxAvailable())(
       },
       { sandbox: "auto", env: { CLAUDE_PLUGIN_ROOT: root }, timeoutMs: 30000 },
     );
+    // A confined run RECORDS writes, so this is a real list, not `undefined`.
+    assert.ok(r.filesWritten, "a confined run records writes");
     assert.ok(r.filesWritten.length > 0, "it writes its state cache");
     assertWroteOnly(r, [/^\.omc\//]); // …and only under .omc/
   },
@@ -479,13 +481,22 @@ test("a failing script still surfaces its stdout AND stderr, not an exception", 
   assert.equal(r.stderr, "boom\n");
 });
 
-test("filesWritten is EMPTY on an unconfined run — so a write assertion is vacuous there", () => {
-  // The skill warns about this explicitly: `assertNoWrite`/`assertWroteOnly`
-  // read `filesWritten`, which is only recorded under confinement. Pinned so
-  // the warning stays true (and so a future always-on snapshot must update it).
+test("an unconfined run leaves filesWritten UNDEFINED — and a write assertion refuses rather than passing", () => {
+  // The regression this locks: the script below DOES write a file. Previously
+  // an unconfined run reported `filesWritten: []`, so `assertNoWrite` returned
+  // GREEN against a run that had just written — success with no evidence
+  // inspected. Now the absence of a recording is visible in the data, and the
+  // assertion refuses.
   const dir = mkdtempSync(join(tmpdir(), "vigiles-script-"));
   writeFileSync(join(dir, "w.sh"), "echo hi > wrote-a-file.txt\n");
   const r = runHook("bash w.sh", {}, { cwd: dir });
   assert.equal(r.exitCode, 0);
-  assert.deepEqual([...r.filesWritten], []);
+  assert.equal(r.filesWritten, undefined, "unconfined records nothing");
+  assert.throws(
+    () => {
+      assertNoWrite(r, "wrote-a-file.txt");
+    },
+    /never recorded/i,
+    "must not green-light a run whose writes were never captured",
+  );
 });

--- a/src/run-hook.ts
+++ b/src/run-hook.ts
@@ -1,13 +1,22 @@
 /**
- * vigiles — the *unit* tier for Claude Code hooks.
+ * vigiles — the *unit* tier for agent hooks.
  *
- * A hook is just a process: Claude Code pipes a JSON event to its stdin and
- * reads back an exit code (0 ok, 2 = block) and, optionally, a JSON decision on
- * stdout. `runHook` exercises exactly that contract directly — no `claude`
- * binary, no model, no sandbox — so a hook's logic can be unit-tested in
- * milliseconds:
+ * A hook is just a process with a protocol on top: the harness pipes a JSON
+ * event to its stdin and reads back an exit code (0 ok, 2 = block) and,
+ * optionally, a JSON decision on stdout. `runHook` is exactly that protocol —
+ * and nothing else.
  *
- *   const r = runHook('"$GUARD" ', {
+ * Everything underneath (spawning, shells, stdin, confinement, egress recording,
+ * write recording) lives in `./run-script.ts`, because none of it is about
+ * hooks. This module is the thin specialization:
+ *
+ *     runHook  =  runScript  +  event-to-stdin  +  exit-code-to-decision
+ *
+ * Reach for {@link runScript} instead when the thing under test is an ordinary
+ * program — a helper script has effects, not a decision, and its result type
+ * says so.
+ *
+ *   const r = runHook('"$GUARD"', {
  *     hook_event_name: "PreToolUse",
  *     tool_name: "Bash",
  *     tool_input: { command: "git commit --no-verify" },
@@ -27,45 +36,34 @@
  * `plugin:` loader + `runHarnessTest` cover. Use both: unit-test the hook's
  * logic here, then assert it fires in the assembled machine there.
  */
-import { spawnSync } from "node:child_process";
-import {
-  mkdtempSync,
-  mkdirSync,
-  rmSync,
-  writeFileSync,
-  readFileSync,
-  existsSync,
-  readdirSync,
-  statSync,
-} from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-
 import type { HookProtocol } from "./core/hook-protocol.js";
 import { claudeCodeHookProtocol } from "./adapters/claude-code/hook-protocol.js";
-import {
-  buildEgressNft,
-  buildEgressBwrapArgv,
-  resolveAllow,
-  parseResolvers,
-  parseNftCounters,
-  countersToResult,
-  egressAvailable,
-  type EgressFiles,
-} from "./egress.js";
-import {
-  decideSandbox,
-  sandboxAvailable,
-  bwrapArgs,
-  setenvArgs,
-  parseEgressLog,
-  diffTrees,
-  type SandboxMode,
-  type EgressAttempt,
-} from "./sandbox.js";
 import { propertyTest } from "./core/proofs.js";
+import {
+  runScriptWith,
+  REAL_DEPS,
+  type RunScriptOptions,
+  type ScriptRunResult,
+  type RunScriptDeps,
+} from "./run-script.js";
 
-export type { EgressAttempt };
+export type { EgressAttempt } from "./run-script.js";
+// The general runner this module specializes. Re-exported so `vigiles/unit`'s
+// hook surface and the script surface stay one import away from each other.
+export { runScript, runScriptWith, egressRoutes } from "./run-script.js";
+export type {
+  RunScriptOptions,
+  ScriptRunResult,
+  ScriptSpawnResult,
+  ScriptSpawner,
+  RunScriptDeps,
+} from "./run-script.js";
+
+/**
+ * Options for {@link runHook} — every {@link RunScriptOptions} knob except
+ * `stdin`, which the hook layer owns (it serializes the event there).
+ */
+export type RunHookOptions = Omit<RunScriptOptions, "stdin">;
 
 // ---------------------------------------------------------------------------
 // propertyHook — invariant testing for a hook's (event) → decision (Phase 5 of
@@ -155,77 +153,7 @@ export interface HookOutput {
   readonly [k: string]: unknown;
 }
 
-export interface RunHookOptions {
-  /** Working directory for the hook process. Default: a value won't be set. */
-  readonly cwd?: string;
-  /** Extra env vars (merged over process.env). `{cwd}` in values is left as-is. */
-  readonly env?: Record<string, string>;
-  /** Per-run timeout ms. Default 10000. */
-  readonly timeoutMs?: number;
-  /**
-   * Provenance of the hook command. `true` (default) means YOU authored it — the
-   * usual case at this tier, a command written inline in the test — so it runs
-   * directly. `false` marks it foreign (a vendored third-party hook script),
-   * which makes confinement the DEFAULT: with no explicit `sandbox`, an untrusted
-   * hook behaves as `sandbox: "auto"` — confined under bubblewrap, or refused if
-   * none is available — so foreign code is never run unconfined by accident. This
-   * mirrors the harness tier, where trust follows `plugin`/`pluginDir`
-   * provenance (`specTrusted` in `src/sandbox.ts`); the unit tier takes a raw
-   * command string with no provenance signal, so you declare it here.
-   *
-   * Why this is opt-in (untrusted) and not always-on: the sandbox isn't always
-   * available (Linux + working userns only — forcing it would *refuse* a hook you
-   * wrote on macOS/hardened CI), it's deliberately hostile (no egress,
-   * `--clearenv`, empty HOME, read-only fs — a false failure for trusted code that
-   * needs the network or an env var), trust follows provenance (you already
-   * vouched for inline code), and direct exec is ms vs. the confined path's
-   * setup+spawn. See `docs/sandboxing.md` ("Why confinement is opt-in"). Use
-   * `sandbox: "strict"` to force confinement even on trusted code.
-   */
-  readonly trusted?: boolean;
-  /**
-   * Confine the hook under bubblewrap (Linux). When unset, the mode follows
-   * {@link RunHookOptions.trusted}: a trusted hook runs directly (`false`), an
-   * untrusted one is confined-or-refused (`"auto"`). Set it explicitly to
-   * override: `"auto"`/`"strict"` force confinement (a no-egress namespace with a
-   * cleared environment — your `opts.env` is added back — or a **refusal** if no
-   * bwrap is available), and `false` is the opt-out that runs even untrusted code
-   * unconfined. macOS/Windows have no bwrap, so `"auto"`/`"strict"` throw there —
-   * see `src/sandbox.ts`.
-   */
-  readonly sandbox?: SandboxMode;
-  /**
-   * Record the hook's network egress. Implies confinement (the recorder lives in
-   * the sandbox netns, so this forces a sandboxed run and refuses if no sandbox is
-   * available). A recording proxy on loopback captures every `host:port` a
-   * proxy-honoring tool (npm/pip/curl/fetch) tries to reach — surfaced as
-   * {@link HookRunResult.egress} — while the netns still **blocks** it (nothing
-   * actually leaves). Use it to test what a hook/skill phones home to, or which
-   * registry an install would hit. Raw-socket egress is blocked but not recorded
-   * (it never reaches the proxy) — the block is the boundary, the record is
-   * best-effort observability over it.
-   */
-  readonly recordEgress?: boolean;
-  /**
-   * Allowlisted egress: let the hook actually reach the network, but ONLY the
-   * listed hosts, with the boundary at the **packet layer** (an `nft` allowlist
-   * inside the sandbox netns, fed by `slirp4netns`) — so a raw socket to an
-   * off-list host is dropped too, which a `recordEgress`/`HTTP_PROXY` allowlist
-   * cannot guarantee. Use it to test a hook/skill whose setup needs a real
-   * `npm install` from a registry you expect, and nothing else. Implies
-   * confinement (it needs the netns), and **refuses** if bubblewrap + slirp4netns
-   * + nft aren't available. The hosts are resolved to IPs at launch; results land
-   * in {@link HookRunResult.egress} (the allowlisted hosts that were reached, with
-   * `allowed: true`) and {@link HookRunResult.egressDropped} (how much off-list
-   * traffic was blocked). See `docs/sandboxing.md`.
-   */
-  readonly egress?: { readonly allow: readonly string[] };
-}
-
-export interface HookRunResult {
-  readonly exitCode: number;
-  readonly stdout: string;
-  readonly stderr: string;
+export interface HookRunResult extends ScriptRunResult {
   /** Parsed stdout JSON if the hook emitted a JSON decision, else null. */
   readonly json: HookOutput | null;
   /**
@@ -233,25 +161,6 @@ export interface HookRunResult {
    * `permissionDecision:"deny"` all set `blocked = true`.
    */
   readonly blocked: boolean;
-  /**
-   * Network egress the hook attempted. With {@link RunHookOptions.recordEgress}:
-   * every (blocked) attempt the proxy saw. With {@link RunHookOptions.egress}: the
-   * allowlisted hosts that were actually reached (`allowed: true`, with packet
-   * counts). Empty otherwise.
-   */
-  readonly egress: readonly EgressAttempt[];
-  /**
-   * Allowlisted-egress mode only: the aggregate off-allowlist traffic the
-   * packet-layer wall dropped. `packets === 0` means the hook stayed entirely
-   * within the allowlist. Undefined when {@link RunHookOptions.egress} was unset.
-   */
-  readonly egressDropped?: { readonly packets: number; readonly bytes: number };
-  /**
-   * Files the hook wrote to its work dir (relative paths), recorded on confined
-   * runs — what a hook touched on disk. Empty on a direct (unconfined) run.
-   * Assert over it with `assertNoWrite` / `assertWroteOnly`.
-   */
-  readonly filesWritten: readonly string[];
   /**
    * The decision the hook expressed, preferring the structured
    * `permissionDecision` ("allow"|"deny"|"ask") then legacy `decision`
@@ -293,454 +202,23 @@ export function decideHook(
   return { blocked, decision };
 }
 
-/** The raw fields of a hook spawn that the result parser needs. */
-export interface HookSpawnResult {
-  readonly status: number | null;
-  readonly signal: string | null;
-  readonly stdout: string;
-  readonly stderr: string;
-  /** Egress attempts captured by the in-sandbox recorder (recordEgress only). */
-  readonly egress?: readonly EgressAttempt[];
-  /** Off-allowlist traffic the packet-layer wall dropped (egress mode only). */
-  readonly egressDropped?: { readonly packets: number; readonly bytes: number };
-  /** Files the hook wrote to its work dir (confined runs). */
-  readonly filesWritten?: readonly string[];
-}
-
-/** Spawn a hook (command + piped event) — the injectable seam over the real spawn. */
-export type HookSpawner = (
-  command: string,
-  input: HookInput,
-  opts: RunHookOptions,
-) => HookSpawnResult;
-
-/** The spawn seams `runHookWith` needs, so its decision logic is testable. */
-export interface RunHookDeps {
-  /** Whether bubblewrap confinement is available (Linux + bwrap). */
-  readonly available: boolean;
-  /** Whether allowlisted egress is available (bwrap + slirp4netns + nft). */
-  readonly egressAvailable: boolean;
-  /** Run the command directly (unconfined). */
-  readonly direct: HookSpawner;
-  /** Run the command confined under bubblewrap. */
-  readonly sandboxed: HookSpawner;
-  /** Run the command confined with an allowlisted-egress netns. */
-  readonly egress: HookSpawner;
-}
-
 /**
- * The hook-run orchestration with injectable spawn seams: pick direct vs.
- * confined via the safe-by-default policy (`decideSandbox`), then parse the exit
- * code + stdout into a normalized decision. Exported so all three branches
- * (direct / sandbox / refuse) are unit-tested with fake spawners — no real
+ * The hook layer over {@link runScriptWith}: serialize the event to stdin, run
+ * the program, then read the exit code + stdout JSON as a normalized decision.
+ * Exported so the decision logic is unit-testable with fake spawners — no real
  * bwrap. `runHook` is this with the real seams.
  */
 export function runHookWith(
   command: string,
   input: HookInput,
   opts: RunHookOptions,
-  deps: RunHookDeps,
+  deps: RunScriptDeps,
 ): HookRunResult {
-  // Allowlisted egress is its own confined path (bwrap netns + slirp4netns + nft);
-  // it can't run unconfined, so it refuses outright when the tooling is absent
-  // rather than falling back to a direct run that would ignore the allowlist.
-  const res = opts.egress
-    ? runEgress(command, input, opts, deps)
-    : runConfinedOrDirect(command, input, opts, deps);
-  const exitCode = res.status ?? (res.signal ? 1 : 0);
-  const stdout = res.stdout ?? "";
-  const stderr = res.stderr ?? "";
-  const json = parseHookOutput(stdout);
-  const { blocked, decision: dec } = decideHook(exitCode, json);
-  return {
-    exitCode,
-    stdout,
-    stderr,
-    json,
-    blocked,
-    egress: res.egress ?? [],
-    egressDropped: res.egressDropped,
-    filesWritten: res.filesWritten ?? [],
-    decision: dec,
-  };
+  const res = runScriptWith(command, JSON.stringify(input), opts, deps);
+  const json = parseHookOutput(res.stdout);
+  const { blocked, decision } = decideHook(res.exitCode, json);
+  return { ...res, json, blocked, decision };
 }
-
-/** The allowlisted-egress branch: confine-with-netns, or refuse if unavailable. */
-function runEgress(
-  command: string,
-  input: HookInput,
-  opts: RunHookOptions,
-  deps: RunHookDeps,
-): HookSpawnResult {
-  if (!deps.egressAvailable) {
-    throw new Error(
-      "refusing to run egress: { allow } without the allowlist sandbox: it " +
-        "needs Linux + bubblewrap (bwrap) + slirp4netns + nft — install them to " +
-        "run with a packet-layer egress allowlist, or use recordEgress to record " +
-        "and block instead",
-    );
-  }
-  return deps.egress(command, input, opts);
-}
-
-/** The default branch: pick direct vs. confined via the safe-by-default policy. */
-function runConfinedOrDirect(
-  command: string,
-  input: HookInput,
-  opts: RunHookOptions,
-  deps: RunHookDeps,
-): HookSpawnResult {
-  // Confinement follows provenance: a trusted hook (the default) runs directly;
-  // marking a hook untrusted defaults it to "auto" (confine-or-refuse), so
-  // foreign code is never run unconfined by accident. An explicit `sandbox`
-  // overrides the default either way. The trust fed to decideSandbox stays
-  // `false` at this tier — a raw command has no provenance, so an explicit
-  // "auto"/"strict" here is always a request to *confine*, not "trusted→direct".
-  // recordEgress needs the netns recorder, so it forces confinement too.
-  const mode: SandboxMode =
-    opts.sandbox ??
-    (opts.trusted === false || opts.recordEgress ? "auto" : false);
-  const decision = decideSandbox({
-    trusted: false,
-    mode,
-    available: deps.available,
-  });
-  if (decision.action === "throw") throw new Error(decision.reason);
-  return decision.action === "sandbox"
-    ? deps.sandboxed(command, input, opts)
-    : deps.direct(command, input, opts);
-}
-
-/** Run the hook command directly through a shell (the default, unconfined). */
-function directSpawn(
-  command: string,
-  input: HookInput,
-  opts: RunHookOptions,
-): HookSpawnResult {
-  const res = spawnSync(command, {
-    shell: true,
-    cwd: opts.cwd,
-    env: { ...process.env, ...opts.env },
-    input: JSON.stringify(input),
-    encoding: "utf-8",
-    timeout: opts.timeoutMs ?? 10000,
-  });
-  return {
-    status: res.status,
-    signal: res.signal,
-    stdout: res.stdout ?? "",
-    stderr: res.stderr ?? "",
-  };
-}
-
-/* v8 ignore start -- spawns real bwrap; exercised by the bwrap-gated integration
-   test (skipped without bwrap). The decision logic is runHookWith (unit-tested
-   with fakes); the confinement argv is bwrapArgs/setenvArgs and the egress log
-   parse is parseEgressLog (all unit-tested). */
-
-// When recordEgress is on: co-launch the recorder on loopback, point HTTP(S)_PROXY
-// at it, run the hook, then stop it. Paths come in via env (no shell escaping).
-const EGRESS_WRAPPER = [
-  'node "$VIG_EGRESS_ENTRY" "$VIG_EGRESS_LOG" "$VIG_EGRESS_PORT" &',
-  "EPID=$!",
-  "i=0",
-  'while [ ! -s "$VIG_EGRESS_PORT" ] && [ "$i" -lt 100 ]; do sleep 0.05; i=$((i+1)); done',
-  'export HTTP_PROXY="http://127.0.0.1:$(cat "$VIG_EGRESS_PORT")"',
-  'export HTTPS_PROXY="$HTTP_PROXY" http_proxy="$HTTP_PROXY" https_proxy="$HTTP_PROXY"',
-  // Node's fetch (undici) ignores the proxy env unless this is set — without it a
-  // hook that uses fetch() (e.g. an update check) would bypass the recorder.
-  "export NODE_USE_ENV_PROXY=1",
-  'sh -c "$VIG_HOOK_CMD"',
-  "code=$?",
-  'kill "$EPID" 2>/dev/null',
-  'exit "$code"',
-].join("\n");
-
-function egressProxyEntry(): string {
-  return (
-    [
-      join(__dirname, "egress-proxy.js"),
-      join(__dirname, "..", "dist", "egress-proxy.js"),
-    ].find((p) => existsSync(p)) ?? join(__dirname, "egress-proxy.js")
-  );
-}
-
-/** Map every file under `dir` to a content signature (size:mtime), recursively. */
-function snapshotTree(dir: string): Record<string, string> {
-  const out: Record<string, string> = {};
-  const walk = (d: string, rel: string): void => {
-    for (const name of readdirSync(d)) {
-      const full = join(d, name);
-      const r = rel ? `${rel}/${name}` : name;
-      const st = statSync(full);
-      if (st.isDirectory()) walk(full, r);
-      else out[r] = `${String(st.size)}:${String(st.mtimeMs)}`;
-    }
-  };
-  try {
-    walk(dir, "");
-  } catch {
-    /* dir removed mid-walk — best effort */
-  }
-  return out;
-}
-
-function sandboxedSpawn(
-  command: string,
-  input: HookInput,
-  opts: RunHookOptions,
-): HookSpawnResult {
-  const ioDir = mkdtempSync(join(tmpdir(), "vigiles-hook-sbx-"));
-  const home = join(ioDir, "home");
-  mkdirSync(home);
-  // The hook's confined writable work dir: the caller's cwd if given, else a
-  // dedicated `work/` under the IO dir (kept separate from the egress log/home so
-  // those don't pollute the filesWritten diff).
-  const work = opts.cwd ?? join(ioDir, "work");
-  mkdirSync(work, { recursive: true });
-  try {
-    const baseArgs = [
-      ...bwrapArgs({
-        cwd: work,
-        ioDir,
-        home,
-        path: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
-      }),
-      ...setenvArgs(opts.env ?? {}),
-    ];
-    const spawnOpts = {
-      cwd: work,
-      env: process.env,
-      input: JSON.stringify(input),
-      encoding: "utf-8" as const,
-      timeout: opts.timeoutMs ?? 10000,
-    };
-    const before = snapshotTree(work);
-    let res;
-    let egress: readonly EgressAttempt[] = [];
-    if (opts.recordEgress) {
-      const egressLog = join(ioDir, "egress.ndjson");
-      const portFile = join(ioDir, "egress.port");
-      writeFileSync(egressLog, "");
-      res = spawnSync(
-        "bwrap",
-        [
-          ...baseArgs,
-          "--setenv",
-          "VIG_EGRESS_ENTRY",
-          egressProxyEntry(),
-          "--setenv",
-          "VIG_EGRESS_LOG",
-          egressLog,
-          "--setenv",
-          "VIG_EGRESS_PORT",
-          portFile,
-          "--setenv",
-          "VIG_HOOK_CMD",
-          command,
-          "sh",
-          "-c",
-          EGRESS_WRAPPER,
-        ],
-        spawnOpts,
-      );
-      egress = parseEgressLog(
-        existsSync(egressLog) ? readFileSync(egressLog, "utf-8") : "",
-      );
-    } else {
-      res = spawnSync("bwrap", [...baseArgs, "sh", "-c", command], spawnOpts);
-    }
-    return {
-      status: res.status,
-      signal: res.signal,
-      stdout: res.stdout ?? "",
-      stderr: res.stderr ?? "",
-      egress,
-      filesWritten: diffTrees(before, snapshotTree(work)),
-    };
-  } finally {
-    rmSync(ioDir, { recursive: true, force: true });
-  }
-}
-
-function egressEntry(): string {
-  return (
-    [
-      join(__dirname, "egress-entry.js"),
-      join(__dirname, "..", "dist", "egress-entry.js"),
-    ].find((p) => existsSync(p)) ?? join(__dirname, "egress-entry.js")
-  );
-}
-
-// Runs INSIDE the bwrap netns: block until the parent has attached slirp4netns
-// (the netready file), load the nft allowlist, run the hook with the event on its
-// stdin, then dump the nft counters to a bound file BEFORE exiting — the netns
-// (and its counters) die with this process, so the read-back must happen here.
-const EGRESS_ALLOW_WRAPPER = [
-  "i=0",
-  'while [ ! -s "$VIG_NETREADY" ] && [ "$i" -lt 400 ]; do sleep 0.05; i=$((i+1)); done',
-  'nft -f "$VIG_NFT" > "$VIG_IODIR/nfterr" 2>&1',
-  'sh -c "$VIG_HOOK" < "$VIG_EVENT"',
-  "code=$?",
-  'nft list chain inet vig output > "$VIG_COUNTERS" 2>/dev/null',
-  'exit "$code"',
-].join("\n");
-
-interface EgressOrchestratorResult {
-  status: number | null;
-  signal: string | null;
-  stdout: string;
-  stderr: string;
-  counters: string;
-}
-
-/** Read the orchestrator's result file, or a failed-run default if it's absent. */
-function readEgressResult(resultFile: string): EgressOrchestratorResult {
-  return existsSync(resultFile)
-    ? (JSON.parse(
-        readFileSync(resultFile, "utf-8"),
-      ) as EgressOrchestratorResult)
-    : { status: 1, signal: null, stdout: "", stderr: "", counters: "" };
-}
-
-function egressSpawn(
-  command: string,
-  input: HookInput,
-  opts: RunHookOptions,
-): HookSpawnResult {
-  const ioDir = mkdtempSync(join(tmpdir(), "vigiles-hook-egr-"));
-  const home = join(ioDir, "home");
-  mkdirSync(home);
-  const work = opts.cwd ?? join(ioDir, "work");
-  mkdirSync(work, { recursive: true });
-  try {
-    // Resolve the allowlist to IPs and the system resolvers, then generate the
-    // nft ruleset (pure helpers in src/egress.ts) — the packet-layer wall.
-    const files: EgressFiles = {
-      ioDir,
-      netready: join(ioDir, "netready"),
-      nft: join(ioDir, "rules.nft"),
-      event: join(ioDir, "event.json"),
-      counters: join(ioDir, "counters.txt"),
-    };
-    const allow = resolveAllow(opts.egress?.allow ?? []);
-    const resolvers = parseResolvers(
-      existsSync("/etc/resolv.conf")
-        ? readFileSync("/etc/resolv.conf", "utf-8")
-        : "",
-    );
-    writeFileSync(files.nft, buildEgressNft({ allow, resolvers }));
-    writeFileSync(files.event, JSON.stringify(input));
-    // The in-netns resolv.conf: only the routable resolvers (the host's may be a
-    // 127.0.0.53 stub the netns can't reach). Bound over /etc/resolv.conf below.
-    const resolvConf = join(ioDir, "resolv.conf");
-    writeFileSync(
-      resolvConf,
-      resolvers.map((r) => `nameserver ${r}`).join("\n") + "\n",
-    );
-
-    const bwrapArgv = buildEgressBwrapArgv({
-      base: bwrapArgs({
-        cwd: work,
-        ioDir,
-        home,
-        path: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
-      }),
-      setenv: setenvArgs(opts.env ?? {}),
-      files,
-      command,
-      wrapper: EGRESS_ALLOW_WRAPPER,
-      resolvConf,
-    });
-    const configFile = join(ioDir, "config.json");
-    const resultFile = join(ioDir, "result.json");
-    writeFileSync(
-      configFile,
-      JSON.stringify({
-        bwrapArgv,
-        slirpArgs: ["--configure", "--disable-host-loopback"],
-        // --config-net brings up the interface + host-derived routes in the
-        // target netns. The connector is slirp4netns by default (proven local);
-        // set VIGILES_EGRESS_CONNECTOR=pasta to use pasta (passt), which routes
-        // on hosted runners where slirp4netns's tap-attach fails.
-        pastaArgs: ["--config-net"],
-        connector:
-          process.env.VIGILES_EGRESS_CONNECTOR === "pasta"
-            ? "pasta"
-            : "slirp4netns",
-        infoFile: join(ioDir, "info.json"),
-        readyFile: join(ioDir, "ready"),
-        netreadyFile: files.netready,
-        countersFile: files.counters,
-        resultFile,
-        timeoutMs: opts.timeoutMs ?? 30000,
-      }),
-    );
-    spawnSync("node", [egressEntry(), configFile], {
-      encoding: "utf-8",
-      timeout: (opts.timeoutMs ?? 30000) + 20000,
-    });
-    const result = readEgressResult(resultFile);
-    const { egress, egressDropped } = countersToResult(
-      parseNftCounters(result.counters),
-      Date.now(),
-    );
-    return {
-      status: result.status,
-      signal: result.signal,
-      stdout: result.stdout,
-      stderr: result.stderr,
-      egress,
-      egressDropped,
-    };
-  } finally {
-    rmSync(ioDir, { recursive: true, force: true });
-  }
-}
-
-const REAL_DEPS: RunHookDeps = {
-  available: sandboxAvailable(),
-  egressAvailable: egressAvailable(sandboxAvailable()),
-  direct: directSpawn,
-  sandboxed: sandboxedSpawn,
-  egress: egressSpawn,
-};
-
-/**
- * Whether allowlisted egress can ACTUALLY route here — not just whether the tools
- * exist. On GitHub-hosted runners bwrap+slirp4netns+nft are all present, yet
- * slirp4netns fails to attach `tap0`: the netns has only `lo`, so nothing leaves
- * and the egress assertions can't be exercised. Run a trivial hook in the egress
- * sandbox and check a non-loopback interface came up; memoized (the capability is
- * fixed per run). Gates the egress e2e tests so they run for real where egress
- * works and SKIP — honestly — where it provably can't, instead of failing red.
- * (slirp4netns → pasta is the fix that makes it route in CI too; see
- * research/egress-sandbox-tooling.md.)
- */
-let egressRoutesMemo: boolean | undefined;
-export function egressRoutes(): boolean {
-  if (egressRoutesMemo !== undefined) return egressRoutesMemo;
-  if (!egressAvailable(sandboxAvailable())) return (egressRoutesMemo = false);
-  try {
-    // The only reliable signal is the egress path itself: try to reach an
-    // allowlisted host and check a packet actually got out. Filesystem probes
-    // (/proc/net/dev) and `ip` are unreliable here — bwrap may bind the host
-    // /proc (so /proc/net shows host interfaces, a false positive) and `ip` isn't
-    // on the sandbox PATH. A real reach is namespace-accurate by construction.
-    const r = egressSpawn(
-      "curl -s -m 8 -o /dev/null https://example.com/ || true",
-      { hook_event_name: "PreToolUse" },
-      { egress: { allow: ["example.com"] }, timeoutMs: 20000 },
-    );
-    egressRoutesMemo = (r.egress ?? []).some(
-      (e) => e.host === "example.com" && (e.packets ?? 0) > 0,
-    );
-  } catch {
-    egressRoutesMemo = false;
-  }
-  return egressRoutesMemo;
-}
-/* v8 ignore stop */
 
 /**
  * Run a hook command, piping `input` as JSON to its stdin, and report the exit
@@ -748,7 +226,9 @@ export function egressRoutes(): boolean {
  * `measure` too). `command` is run through a shell, so the same command string a
  * plugin ships (with args / env refs) works verbatim. Mark a hook you didn't
  * write with `trusted: false` and it is confined by default (or pass `sandbox:
- * "auto"` directly) — see {@link RunHookOptions.trusted}.
+ * "auto"` directly) — see {@link RunScriptOptions.trusted}.
+ *
+ * Testing a program that is NOT a hook? Use {@link runScript}.
  */
 export function runHook(
   command: string,

--- a/src/run-script.test.ts
+++ b/src/run-script.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for `runScript` (src/run-script.ts) — the general program runner that
+ * `runHook` specializes.
+ *
+ * Two properties matter here and nowhere else:
+ *
+ *  1. **Both streams come back.** The bug that motivated the split: a hand-rolled
+ *     `execFileSync` runner returns stdout ALONE on success, so advisory output
+ *     (which tools, including vigiles's own compiled-hook `notice()`, write to
+ *     stderr) silently disappears and a healthy react hook reports as dead.
+ *  2. **A script result has no decision.** A HOOK has a decision; a SCRIPT has
+ *     effects. Carrying an always-meaningless `decision` field would teach the
+ *     reader the field means nothing, so the type must not have one.
+ */
+import { test } from "vitest";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runScript } from "./run-script.js";
+import { runHook } from "./run-hook.js";
+import { assertNoWrite } from "./harness-assert.js";
+
+/** A temp dir holding one script file. */
+function scriptDir(name: string, body: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "vigiles-runscript-"));
+  writeFileSync(join(dir, name), body);
+  return dir;
+}
+
+test("runs a plain program and returns exit code plus BOTH streams", () => {
+  const dir = scriptDir(
+    "check.sh",
+    'echo "scanning..."\necho "0 broken links" >&2\nexit 0\n',
+  );
+  const r = runScript("bash check.sh", { cwd: dir });
+  assert.equal(r.exitCode, 0);
+  assert.equal(r.stdout, "scanning...\n");
+  // The load-bearing one: an execFileSync-shaped runner drops exactly this.
+  assert.equal(r.stderr, "0 broken links\n");
+});
+
+test("a script result carries NO decision — a script has effects, not a verdict", () => {
+  const dir = scriptDir("ok.sh", "exit 0\n");
+  const r: object = runScript("bash ok.sh", { cwd: dir });
+  // These belong to the hook layer. Their absence is the point of the split:
+  // a field that is always meaningless is worse than no field.
+  assert.equal("decision" in r, false, "no decision on a script result");
+  assert.equal("blocked" in r, false, "no blocked on a script result");
+  assert.equal("json" in r, false, "no parsed hook JSON on a script result");
+});
+
+test("a non-zero exit is a RESULT, not an exception, and keeps both streams", () => {
+  const dir = scriptDir("fail.sh", 'echo "partial"\necho "boom" >&2\nexit 3\n');
+  const r = runScript("bash fail.sh", { cwd: dir });
+  assert.equal(r.exitCode, 3);
+  assert.equal(r.stdout, "partial\n");
+  assert.equal(r.stderr, "boom\n");
+});
+
+test("stdin is optional, and delivered when given", () => {
+  const dir = scriptDir("cat.sh", "cat\n");
+  // No stdin: the program sees an empty stream and does not hang.
+  assert.equal(runScript("bash cat.sh", { cwd: dir }).stdout, "");
+  // With stdin: delivered verbatim.
+  const r = runScript("bash cat.sh", { cwd: dir, stdin: "hello payload" });
+  assert.equal(r.stdout, "hello payload");
+});
+
+test("env and cwd reach the program", () => {
+  const dir = scriptDir("env.sh", 'echo "$GREETING at $(basename "$PWD")"\n');
+  const r = runScript("bash env.sh", { cwd: dir, env: { GREETING: "hi" } });
+  assert.match(r.stdout, /^hi at vigiles-runscript-/);
+});
+
+test("an unconfined run leaves filesWritten UNDEFINED, and write assertions refuse it", () => {
+  // The script really does write. Recording writes requires confinement, so an
+  // unconfined run knows nothing — and must say so rather than report a clean
+  // bill of health.
+  const dir = scriptDir("w.sh", "echo hi > made-a-file.txt\n");
+  const r = runScript("bash w.sh", { cwd: dir });
+  assert.equal(r.exitCode, 0);
+  assert.ok(existsSync(join(dir, "made-a-file.txt")), "it really wrote");
+  assert.equal(r.filesWritten, undefined, "unconfined records nothing");
+  assert.throws(() => {
+    assertNoWrite(r, "made-a-file.txt");
+  }, /never recorded/i);
+});
+
+test("egress defaults to an empty record rather than undefined", () => {
+  const dir = scriptDir("ok.sh", "exit 0\n");
+  assert.deepEqual([...runScript("bash ok.sh", { cwd: dir }).egress], []);
+});
+
+test("runHook is runScript plus the hook protocol — same effects, plus a decision", () => {
+  // Source-compatibility: the hook layer still delivers the event as JSON on
+  // stdin and still reports a decision, while inheriting the script fields.
+  const dir = scriptDir(
+    "hook.sh",
+    // Echo back the event it was handed, and deny.
+    'cat > event.json\necho "guard ran" >&2\nexit 2\n',
+  );
+  const r = runHook(
+    "bash hook.sh",
+    { hook_event_name: "PreToolUse", tool_name: "Bash" },
+    { cwd: dir },
+  );
+  assert.equal(r.blocked, true, "exit 2 is a block");
+  assert.equal(r.stderr, "guard ran\n", "script fields are inherited");
+  const delivered: unknown = JSON.parse(
+    readFileSync(join(dir, "event.json"), "utf-8"),
+  );
+  assert.deepEqual(delivered, {
+    hook_event_name: "PreToolUse",
+    tool_name: "Bash",
+  });
+});

--- a/src/run-script.ts
+++ b/src/run-script.ts
@@ -1,0 +1,631 @@
+/**
+ * vigiles — **`runScript`**: run a program and report what it did.
+ *
+ * This is the PRIMITIVE under the hook unit tier. A program is spawned through a
+ * shell, optionally fed stdin, optionally confined under bubblewrap, and what
+ * comes back is exit code + both streams + (when confined) the files it wrote
+ * and the network it reached. Nothing here knows what a hook is.
+ *
+ * `runHook` is this plus one thing: it serializes a hook event to stdin and
+ * parses the exit code / stdout JSON into an allow-deny decision. The layering
+ * used to run the other way — the hook-shaped name owned the general machinery —
+ * which meant someone testing an ordinary helper script had no name to look for
+ * and hand-rolled an `execFileSync` runner instead. That runner returns stdout
+ * ALONE on success, so advisory output (which tools, including vigiles's own
+ * compiled-hook `notice()`, write to stderr) vanished and healthy react hooks
+ * reported as dead — three times in one repo.
+ *
+ * These are two questions, not two ways to ask one: a HOOK has a **decision**, a
+ * SCRIPT has **effects**. So the result types differ rather than a script result
+ * carrying a permanently-meaningless `decision` field, which would teach the
+ * reader that the field means nothing.
+ *
+ * See `src/run-hook.ts` for the hook layer, and `docs/sandboxing.md` for what
+ * confinement isolates versus records.
+ */
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  buildEgressNft,
+  buildEgressBwrapArgv,
+  resolveAllow,
+  parseResolvers,
+  parseNftCounters,
+  countersToResult,
+  egressAvailable,
+  type EgressFiles,
+} from "./egress.js";
+import {
+  decideSandbox,
+  sandboxAvailable,
+  bwrapArgs,
+  setenvArgs,
+  parseEgressLog,
+  diffTrees,
+  type SandboxMode,
+  type EgressAttempt,
+} from "./sandbox.js";
+
+export type { EgressAttempt };
+
+export interface RunScriptOptions {
+  /**
+   * Text piped to the program's stdin. Default: nothing. A program that ignores
+   * stdin simply ignores it. (`runHook` uses this to deliver the JSON event.)
+   */
+  readonly stdin?: string;
+  /** Working directory for the process. Default: a value won't be set. */
+  readonly cwd?: string;
+  /** Extra env vars (merged over process.env). `{cwd}` in values is left as-is. */
+  readonly env?: Record<string, string>;
+  /** Per-run timeout ms. Default 10000. */
+  readonly timeoutMs?: number;
+  /**
+   * Provenance of the hook command. `true` (default) means YOU authored it — the
+   * usual case at this tier, a command written inline in the test — so it runs
+   * directly. `false` marks it foreign (a vendored third-party hook script),
+   * which makes confinement the DEFAULT: with no explicit `sandbox`, an untrusted
+   * hook behaves as `sandbox: "auto"` — confined under bubblewrap, or refused if
+   * none is available — so foreign code is never run unconfined by accident. This
+   * mirrors the harness tier, where trust follows `plugin`/`pluginDir`
+   * provenance (`specTrusted` in `src/sandbox.ts`); the unit tier takes a raw
+   * command string with no provenance signal, so you declare it here.
+   *
+   * Why this is opt-in (untrusted) and not always-on: the sandbox isn't always
+   * available (Linux + working userns only — forcing it would *refuse* a hook you
+   * wrote on macOS/hardened CI), it's deliberately hostile (no egress,
+   * `--clearenv`, empty HOME, read-only fs — a false failure for trusted code that
+   * needs the network or an env var), trust follows provenance (you already
+   * vouched for inline code), and direct exec is ms vs. the confined path's
+   * setup+spawn. See `docs/sandboxing.md` ("Why confinement is opt-in"). Use
+   * `sandbox: "strict"` to force confinement even on trusted code.
+   */
+  readonly trusted?: boolean;
+  /**
+   * Confine the hook under bubblewrap (Linux). When unset, the mode follows
+   * {@link RunHookOptions.trusted}: a trusted hook runs directly (`false`), an
+   * untrusted one is confined-or-refused (`"auto"`). Set it explicitly to
+   * override: `"auto"`/`"strict"` force confinement (a no-egress namespace with a
+   * cleared environment — your `opts.env` is added back — or a **refusal** if no
+   * bwrap is available), and `false` is the opt-out that runs even untrusted code
+   * unconfined. macOS/Windows have no bwrap, so `"auto"`/`"strict"` throw there —
+   * see `src/sandbox.ts`.
+   */
+  readonly sandbox?: SandboxMode;
+  /**
+   * Record the hook's network egress. Implies confinement (the recorder lives in
+   * the sandbox netns, so this forces a sandboxed run and refuses if no sandbox is
+   * available). A recording proxy on loopback captures every `host:port` a
+   * proxy-honoring tool (npm/pip/curl/fetch) tries to reach — surfaced as
+   * {@link HookRunResult.egress} — while the netns still **blocks** it (nothing
+   * actually leaves). Use it to test what a hook/skill phones home to, or which
+   * registry an install would hit. Raw-socket egress is blocked but not recorded
+   * (it never reaches the proxy) — the block is the boundary, the record is
+   * best-effort observability over it.
+   */
+  readonly recordEgress?: boolean;
+  /**
+   * Allowlisted egress: let the hook actually reach the network, but ONLY the
+   * listed hosts, with the boundary at the **packet layer** (an `nft` allowlist
+   * inside the sandbox netns, fed by `slirp4netns`) — so a raw socket to an
+   * off-list host is dropped too, which a `recordEgress`/`HTTP_PROXY` allowlist
+   * cannot guarantee. Use it to test a hook/skill whose setup needs a real
+   * `npm install` from a registry you expect, and nothing else. Implies
+   * confinement (it needs the netns), and **refuses** if bubblewrap + slirp4netns
+   * + nft aren't available. The hosts are resolved to IPs at launch; results land
+   * in {@link HookRunResult.egress} (the allowlisted hosts that were reached, with
+   * `allowed: true`) and {@link HookRunResult.egressDropped} (how much off-list
+   * traffic was blocked). See `docs/sandboxing.md`.
+   */
+  readonly egress?: { readonly allow: readonly string[] };
+}
+
+/** What a program did: its exit, its output, and (when confined) its effects. */
+export interface ScriptRunResult {
+  /** Exit code. A signal-killed run reports 1. */
+  readonly exitCode: number;
+  readonly stdout: string;
+  /**
+   * Everything the program wrote to fd 2. Advisory output usually lives HERE —
+   * a runner that reads only stdout silently discards it.
+   */
+  readonly stderr: string;
+  /**
+   * Network egress the run attempted. With {@link RunScriptOptions.recordEgress}:
+   * every (blocked) attempt the proxy saw. With {@link RunScriptOptions.egress}:
+   * the allowlisted hosts actually reached, with packet counts. Empty otherwise.
+   */
+  readonly egress: readonly EgressAttempt[];
+  /**
+   * Allowlisted-egress mode only: aggregate off-allowlist traffic the packet
+   * wall dropped. Undefined when {@link RunScriptOptions.egress} was unset.
+   */
+  readonly egressDropped?: { readonly packets: number; readonly bytes: number };
+  /**
+   * Files written to the work dir (relative paths). **`undefined` when writes
+   * were never recorded** — a different fact from `[]` ("recorded, wrote
+   * nothing"). Recording diffs the work dir before and after, which only a
+   * CONFINED run does. `assertNoWrite` / `assertWroteOnly` refuse `undefined`
+   * rather than pass having inspected nothing.
+   */
+  readonly filesWritten?: readonly string[];
+}
+
+/** The raw fields of a spawn that the result assembler needs. */
+export interface ScriptSpawnResult {
+  readonly status: number | null;
+  readonly signal: string | null;
+  readonly stdout: string;
+  readonly stderr: string;
+  /** Egress attempts captured by the in-sandbox recorder (recordEgress only). */
+  readonly egress?: readonly EgressAttempt[];
+  /** Off-allowlist traffic the packet-layer wall dropped (egress mode only). */
+  readonly egressDropped?: { readonly packets: number; readonly bytes: number };
+  /** Files written to the work dir — present only on a CONFINED run. */
+  readonly filesWritten?: readonly string[];
+}
+
+/** Spawn a program (command + stdin) — the injectable seam over the real spawn. */
+export type ScriptSpawner = (
+  command: string,
+  stdin: string,
+  opts: RunScriptOptions,
+) => ScriptSpawnResult;
+
+/** The spawn seams `runScriptWith` needs, so its routing is testable. */
+export interface RunScriptDeps {
+  /** Whether bubblewrap confinement is available (Linux + bwrap). */
+  readonly available: boolean;
+  /** Whether allowlisted egress is available (bwrap + slirp4netns + nft). */
+  readonly egressAvailable: boolean;
+  /** Run the command directly (unconfined). */
+  readonly direct: ScriptSpawner;
+  /** Run the command confined under bubblewrap. */
+  readonly sandboxed: ScriptSpawner;
+  /** Run the command confined with an allowlisted-egress netns. */
+  readonly egress: ScriptSpawner;
+}
+
+/**
+ * The run orchestration with injectable spawn seams: pick direct vs. confined
+ * via the safe-by-default policy (`decideSandbox`), then assemble the result.
+ * Exported so all three branches (direct / sandbox / refuse) are unit-tested
+ * with fake spawners — no real bwrap.
+ */
+export function runScriptWith(
+  command: string,
+  stdin: string,
+  opts: RunScriptOptions,
+  deps: RunScriptDeps,
+): ScriptRunResult {
+  // Allowlisted egress is its own confined path (bwrap netns + slirp4netns +
+  // nft); it can't run unconfined, so it refuses outright when the tooling is
+  // absent rather than falling back to a direct run that ignores the allowlist.
+  const res = opts.egress
+    ? runEgress(command, stdin, opts, deps)
+    : runConfinedOrDirect(command, stdin, opts, deps);
+  return {
+    exitCode: res.status ?? (res.signal ? 1 : 0),
+    stdout: res.stdout ?? "",
+    stderr: res.stderr ?? "",
+    egress: res.egress ?? [],
+    egressDropped: res.egressDropped,
+    // NOT `?? []` — an unconfined spawn records nothing, and flattening that to
+    // an empty list would let a write assertion pass having looked at nothing.
+    filesWritten: res.filesWritten,
+  };
+}
+
+/** The allowlisted-egress branch: confine-with-netns, or refuse if unavailable. */
+function runEgress(
+  command: string,
+  stdin: string,
+  opts: RunScriptOptions,
+  deps: RunScriptDeps,
+): ScriptSpawnResult {
+  if (!deps.egressAvailable) {
+    throw new Error(
+      "refusing to run egress: { allow } without the allowlist sandbox: it " +
+        "needs Linux + bubblewrap (bwrap) + slirp4netns + nft — install them to " +
+        "run with a packet-layer egress allowlist, or use recordEgress to record " +
+        "and block instead",
+    );
+  }
+  return deps.egress(command, stdin, opts);
+}
+
+/** The default branch: pick direct vs. confined via the safe-by-default policy. */
+function runConfinedOrDirect(
+  command: string,
+  stdin: string,
+  opts: RunScriptOptions,
+  deps: RunScriptDeps,
+): ScriptSpawnResult {
+  // Confinement follows provenance: a trusted hook (the default) runs directly;
+  // marking a hook untrusted defaults it to "auto" (confine-or-refuse), so
+  // foreign code is never run unconfined by accident. An explicit `sandbox`
+  // overrides the default either way. The trust fed to decideSandbox stays
+  // `false` at this tier — a raw command has no provenance, so an explicit
+  // "auto"/"strict" here is always a request to *confine*, not "trusted→direct".
+  // recordEgress needs the netns recorder, so it forces confinement too.
+  const mode: SandboxMode =
+    opts.sandbox ??
+    (opts.trusted === false || opts.recordEgress ? "auto" : false);
+  const decision = decideSandbox({
+    trusted: false,
+    mode,
+    available: deps.available,
+  });
+  if (decision.action === "throw") throw new Error(decision.reason);
+  return decision.action === "sandbox"
+    ? deps.sandboxed(command, stdin, opts)
+    : deps.direct(command, stdin, opts);
+}
+
+/** Run the hook command directly through a shell (the default, unconfined). */
+function directSpawn(
+  command: string,
+  stdin: string,
+  opts: RunScriptOptions,
+): ScriptSpawnResult {
+  const res = spawnSync(command, {
+    shell: true,
+    cwd: opts.cwd,
+    env: { ...process.env, ...opts.env },
+    input: stdin,
+    encoding: "utf-8",
+    timeout: opts.timeoutMs ?? 10000,
+  });
+  return {
+    status: res.status,
+    signal: res.signal,
+    stdout: res.stdout ?? "",
+    stderr: res.stderr ?? "",
+  };
+}
+
+/* v8 ignore start -- spawns real bwrap; exercised by the bwrap-gated integration
+   test (skipped without bwrap). The decision logic is runScriptWith (unit-tested
+   with fakes); the confinement argv is bwrapArgs/setenvArgs and the egress log
+   parse is parseEgressLog (all unit-tested). */
+
+// When recordEgress is on: co-launch the recorder on loopback, point HTTP(S)_PROXY
+// at it, run the hook, then stop it. Paths come in via env (no shell escaping).
+const EGRESS_WRAPPER = [
+  'node "$VIG_EGRESS_ENTRY" "$VIG_EGRESS_LOG" "$VIG_EGRESS_PORT" &',
+  "EPID=$!",
+  "i=0",
+  'while [ ! -s "$VIG_EGRESS_PORT" ] && [ "$i" -lt 100 ]; do sleep 0.05; i=$((i+1)); done',
+  'export HTTP_PROXY="http://127.0.0.1:$(cat "$VIG_EGRESS_PORT")"',
+  'export HTTPS_PROXY="$HTTP_PROXY" http_proxy="$HTTP_PROXY" https_proxy="$HTTP_PROXY"',
+  // Node's fetch (undici) ignores the proxy env unless this is set — without it a
+  // hook that uses fetch() (e.g. an update check) would bypass the recorder.
+  "export NODE_USE_ENV_PROXY=1",
+  'sh -c "$VIG_HOOK_CMD"',
+  "code=$?",
+  'kill "$EPID" 2>/dev/null',
+  'exit "$code"',
+].join("\n");
+
+function egressProxyEntry(): string {
+  return (
+    [
+      join(__dirname, "egress-proxy.js"),
+      join(__dirname, "..", "dist", "egress-proxy.js"),
+    ].find((p) => existsSync(p)) ?? join(__dirname, "egress-proxy.js")
+  );
+}
+
+/** Map every file under `dir` to a content signature (size:mtime), recursively. */
+function snapshotTree(dir: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  const walk = (d: string, rel: string): void => {
+    for (const name of readdirSync(d)) {
+      const full = join(d, name);
+      const r = rel ? `${rel}/${name}` : name;
+      const st = statSync(full);
+      if (st.isDirectory()) walk(full, r);
+      else out[r] = `${String(st.size)}:${String(st.mtimeMs)}`;
+    }
+  };
+  try {
+    walk(dir, "");
+  } catch {
+    /* dir removed mid-walk — best effort */
+  }
+  return out;
+}
+
+function sandboxedSpawn(
+  command: string,
+  stdin: string,
+  opts: RunScriptOptions,
+): ScriptSpawnResult {
+  const ioDir = mkdtempSync(join(tmpdir(), "vigiles-hook-sbx-"));
+  const home = join(ioDir, "home");
+  mkdirSync(home);
+  // The hook's confined writable work dir: the caller's cwd if given, else a
+  // dedicated `work/` under the IO dir (kept separate from the egress log/home so
+  // those don't pollute the filesWritten diff).
+  const work = opts.cwd ?? join(ioDir, "work");
+  mkdirSync(work, { recursive: true });
+  try {
+    const baseArgs = [
+      ...bwrapArgs({
+        cwd: work,
+        ioDir,
+        home,
+        path: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
+      }),
+      ...setenvArgs(opts.env ?? {}),
+    ];
+    const spawnOpts = {
+      cwd: work,
+      env: process.env,
+      input: stdin,
+      encoding: "utf-8" as const,
+      timeout: opts.timeoutMs ?? 10000,
+    };
+    const before = snapshotTree(work);
+    let res;
+    let egress: readonly EgressAttempt[] = [];
+    if (opts.recordEgress) {
+      const egressLog = join(ioDir, "egress.ndjson");
+      const portFile = join(ioDir, "egress.port");
+      writeFileSync(egressLog, "");
+      res = spawnSync(
+        "bwrap",
+        [
+          ...baseArgs,
+          "--setenv",
+          "VIG_EGRESS_ENTRY",
+          egressProxyEntry(),
+          "--setenv",
+          "VIG_EGRESS_LOG",
+          egressLog,
+          "--setenv",
+          "VIG_EGRESS_PORT",
+          portFile,
+          "--setenv",
+          "VIG_HOOK_CMD",
+          command,
+          "sh",
+          "-c",
+          EGRESS_WRAPPER,
+        ],
+        spawnOpts,
+      );
+      egress = parseEgressLog(
+        existsSync(egressLog) ? readFileSync(egressLog, "utf-8") : "",
+      );
+    } else {
+      res = spawnSync("bwrap", [...baseArgs, "sh", "-c", command], spawnOpts);
+    }
+    return {
+      status: res.status,
+      signal: res.signal,
+      stdout: res.stdout ?? "",
+      stderr: res.stderr ?? "",
+      egress,
+      filesWritten: diffTrees(before, snapshotTree(work)),
+    };
+  } finally {
+    rmSync(ioDir, { recursive: true, force: true });
+  }
+}
+
+function egressEntry(): string {
+  return (
+    [
+      join(__dirname, "egress-entry.js"),
+      join(__dirname, "..", "dist", "egress-entry.js"),
+    ].find((p) => existsSync(p)) ?? join(__dirname, "egress-entry.js")
+  );
+}
+
+// Runs INSIDE the bwrap netns: block until the parent has attached slirp4netns
+// (the netready file), load the nft allowlist, run the hook with the event on its
+// stdin, then dump the nft counters to a bound file BEFORE exiting — the netns
+// (and its counters) die with this process, so the read-back must happen here.
+const EGRESS_ALLOW_WRAPPER = [
+  "i=0",
+  'while [ ! -s "$VIG_NETREADY" ] && [ "$i" -lt 400 ]; do sleep 0.05; i=$((i+1)); done',
+  'nft -f "$VIG_NFT" > "$VIG_IODIR/nfterr" 2>&1',
+  'sh -c "$VIG_HOOK" < "$VIG_EVENT"',
+  "code=$?",
+  'nft list chain inet vig output > "$VIG_COUNTERS" 2>/dev/null',
+  'exit "$code"',
+].join("\n");
+
+interface EgressOrchestratorResult {
+  status: number | null;
+  signal: string | null;
+  stdout: string;
+  stderr: string;
+  counters: string;
+}
+
+/** Read the orchestrator's result file, or a failed-run default if it's absent. */
+function readEgressResult(resultFile: string): EgressOrchestratorResult {
+  return existsSync(resultFile)
+    ? (JSON.parse(
+        readFileSync(resultFile, "utf-8"),
+      ) as EgressOrchestratorResult)
+    : { status: 1, signal: null, stdout: "", stderr: "", counters: "" };
+}
+
+function egressSpawn(
+  command: string,
+  stdin: string,
+  opts: RunScriptOptions,
+): ScriptSpawnResult {
+  const ioDir = mkdtempSync(join(tmpdir(), "vigiles-hook-egr-"));
+  const home = join(ioDir, "home");
+  mkdirSync(home);
+  const work = opts.cwd ?? join(ioDir, "work");
+  mkdirSync(work, { recursive: true });
+  try {
+    // Resolve the allowlist to IPs and the system resolvers, then generate the
+    // nft ruleset (pure helpers in src/egress.ts) — the packet-layer wall.
+    const files: EgressFiles = {
+      ioDir,
+      netready: join(ioDir, "netready"),
+      nft: join(ioDir, "rules.nft"),
+      event: join(ioDir, "event.json"),
+      counters: join(ioDir, "counters.txt"),
+    };
+    const allow = resolveAllow(opts.egress?.allow ?? []);
+    const resolvers = parseResolvers(
+      existsSync("/etc/resolv.conf")
+        ? readFileSync("/etc/resolv.conf", "utf-8")
+        : "",
+    );
+    writeFileSync(files.nft, buildEgressNft({ allow, resolvers }));
+    writeFileSync(files.event, stdin);
+    // The in-netns resolv.conf: only the routable resolvers (the host's may be a
+    // 127.0.0.53 stub the netns can't reach). Bound over /etc/resolv.conf below.
+    const resolvConf = join(ioDir, "resolv.conf");
+    writeFileSync(
+      resolvConf,
+      resolvers.map((r) => `nameserver ${r}`).join("\n") + "\n",
+    );
+
+    const bwrapArgv = buildEgressBwrapArgv({
+      base: bwrapArgs({
+        cwd: work,
+        ioDir,
+        home,
+        path: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
+      }),
+      setenv: setenvArgs(opts.env ?? {}),
+      files,
+      command,
+      wrapper: EGRESS_ALLOW_WRAPPER,
+      resolvConf,
+    });
+    const configFile = join(ioDir, "config.json");
+    const resultFile = join(ioDir, "result.json");
+    writeFileSync(
+      configFile,
+      JSON.stringify({
+        bwrapArgv,
+        slirpArgs: ["--configure", "--disable-host-loopback"],
+        // --config-net brings up the interface + host-derived routes in the
+        // target netns. The connector is slirp4netns by default (proven local);
+        // set VIGILES_EGRESS_CONNECTOR=pasta to use pasta (passt), which routes
+        // on hosted runners where slirp4netns's tap-attach fails.
+        pastaArgs: ["--config-net"],
+        connector:
+          process.env.VIGILES_EGRESS_CONNECTOR === "pasta"
+            ? "pasta"
+            : "slirp4netns",
+        infoFile: join(ioDir, "info.json"),
+        readyFile: join(ioDir, "ready"),
+        netreadyFile: files.netready,
+        countersFile: files.counters,
+        resultFile,
+        timeoutMs: opts.timeoutMs ?? 30000,
+      }),
+    );
+    spawnSync("node", [egressEntry(), configFile], {
+      encoding: "utf-8",
+      timeout: (opts.timeoutMs ?? 30000) + 20000,
+    });
+    const result = readEgressResult(resultFile);
+    const { egress, egressDropped } = countersToResult(
+      parseNftCounters(result.counters),
+      Date.now(),
+    );
+    return {
+      status: result.status,
+      signal: result.signal,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      egress,
+      egressDropped,
+    };
+  } finally {
+    rmSync(ioDir, { recursive: true, force: true });
+  }
+}
+
+export const REAL_DEPS: RunScriptDeps = {
+  available: sandboxAvailable(),
+  egressAvailable: egressAvailable(sandboxAvailable()),
+  direct: directSpawn,
+  sandboxed: sandboxedSpawn,
+  egress: egressSpawn,
+};
+
+/**
+ * Whether allowlisted egress can ACTUALLY route here — not just whether the tools
+ * exist. On GitHub-hosted runners bwrap+slirp4netns+nft are all present, yet
+ * slirp4netns fails to attach `tap0`: the netns has only `lo`, so nothing leaves
+ * and the egress assertions can't be exercised. Run a trivial hook in the egress
+ * sandbox and check a non-loopback interface came up; memoized (the capability is
+ * fixed per run). Gates the egress e2e tests so they run for real where egress
+ * works and SKIP — honestly — where it provably can't, instead of failing red.
+ * (slirp4netns → pasta is the fix that makes it route in CI too; see
+ * research/egress-sandbox-tooling.md.)
+ */
+let egressRoutesMemo: boolean | undefined;
+export function egressRoutes(): boolean {
+  if (egressRoutesMemo !== undefined) return egressRoutesMemo;
+  if (!egressAvailable(sandboxAvailable())) return (egressRoutesMemo = false);
+  try {
+    // The only reliable signal is the egress path itself: try to reach an
+    // allowlisted host and check a packet actually got out. Filesystem probes
+    // (/proc/net/dev) and `ip` are unreliable here — bwrap may bind the host
+    // /proc (so /proc/net shows host interfaces, a false positive) and `ip` isn't
+    // on the sandbox PATH. A real reach is namespace-accurate by construction.
+    const r = egressSpawn(
+      "curl -s -m 8 -o /dev/null https://example.com/ || true",
+      "",
+      { egress: { allow: ["example.com"] }, timeoutMs: 20000 },
+    );
+    egressRoutesMemo = (r.egress ?? []).some(
+      (e) => e.host === "example.com" && (e.packets ?? 0) > 0,
+    );
+  } catch {
+    egressRoutesMemo = false;
+  }
+  return egressRoutesMemo;
+}
+/* v8 ignore stop */
+
+/**
+ * Run a program and report what it did — exit code, **both** streams, and (when
+ * confined) its writes and egress. Synchronous, so it composes inside an eval's
+ * `measure`. `command` goes through a shell, so the exact string a project
+ * ships (args, env refs, pipes) works verbatim.
+ *
+ * This is the right tier for a plain helper script — a bash/node/python program
+ * that isn't a hook. It has no decision to report, so the result carries none.
+ *
+ * ```ts
+ * const r = runScript("bash scripts/check-links.sh", { cwd: repo });
+ * assert.equal(r.exitCode, 0);
+ * assert.match(r.stderr, /0 broken links/); // advisory output lives here
+ * ```
+ *
+ * Running something you didn't write? Pass `trusted: false` (or `sandbox:
+ * "auto"`) to confine it — which is also what records `filesWritten`.
+ */
+export function runScript(
+  command: string,
+  opts: RunScriptOptions = {},
+): ScriptRunResult {
+  return runScriptWith(command, opts.stdin ?? "", opts, REAL_DEPS);
+}

--- a/src/scan-cli.test.ts
+++ b/src/scan-cli.test.ts
@@ -29,6 +29,9 @@ import { join, resolve, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
 
+import { VERBS } from "./cli-commands.js";
+import { knownFlagsFor } from "./cli-flag-check.js";
+
 // __dirname is src/ when vitest resolves the .ts source → ".." is the repo root.
 const CLI = resolve(__dirname, "..", "dist", "cli.js");
 const VENDOR = resolve(__dirname, "..", "test/dogfood");
@@ -246,7 +249,11 @@ describe("scan e2e — artificial cc/codex/mixed/marketplace", () => {
     // ignored config.harness and reported claude-code. Config resolves from the
     // cwd (like `lint`), so run audit from INSIDE the fixture.
     const r = run("audit .", join(root, "cfgharness"));
-    assert.equal(r.exitCode, 0);
+    // Exit 2, not 0: scanned AS CODEX this fixture holds no AGENTS.md and no
+    // codex surface, so there is nothing to measure — which `audit` now reports
+    // as a distinct outcome instead of a silent grade F at exit 0. The harness
+    // resolution (the point of this test) is unchanged and still printed.
+    assert.equal(r.exitCode, 2);
     assert.match(r.stdout, /Detected harness: codex/);
     // A single configured harness is unambiguous → no override notice.
     assert.doesNotMatch(r.stdout, /repo matches/);
@@ -978,5 +985,164 @@ describe("audit share-link only for a whole-repo audit (Codex review)", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+});
+
+// ── Argument handling: refuse what we didn't understand ──────────────────────
+// MEASURED before the fix:
+//   $ npx vigiles audit --this-flag-does-not-exist
+//   Detected harness: claude-code … a complete audit … EXIT=0
+// audit's flags decide what LEAVES the machine (--no-html, --no-json, --out=,
+// --serve), so `--no-htlm` silently wrote the HTML report the author believed
+// they had suppressed.
+
+describe("unknown flags are refused, not swallowed", () => {
+  it("audit: an unknown flag stops the run with a non-zero exit and names it", () => {
+    const r = run("audit --this-flag-does-not-exist");
+    assert.equal(r.exitCode, 2, r.stdout + r.stderr);
+    assert.match(r.stderr, /unknown flag "--this-flag-does-not-exist"/);
+    assert.doesNotMatch(
+      r.stdout,
+      /Detected harness/,
+      "nothing may run before the argument is understood",
+    );
+  });
+
+  it("audit: a TYPO of a real flag suggests the real one", () => {
+    const r = run("audit --no-htlm");
+    assert.equal(r.exitCode, 2);
+    assert.match(r.stderr, /Did you mean `--no-html`\?/);
+  });
+
+  it("the hole is closed on every verb, not only audit", () => {
+    // Run from a THROWAWAY cwd. If this guard ever regresses, `init
+    // --definitely-not-a-flag` runs a real `vigiles init`, which writes specs, a
+    // workflow and a config into whatever directory the test happened to be in —
+    // observed once, in this repo, while proving the fix by reverting it.
+    const sandbox = mkdtempSync(join(tmpdir(), "scan-flags-"));
+    try {
+      for (const verb of ["lint", "test", "eval", "compile", "eject", "init"]) {
+        const r = run(`${verb} --definitely-not-a-flag`, sandbox);
+        assert.equal(
+          r.exitCode,
+          2,
+          `${verb} accepted an unknown flag: ${r.stdout}${r.stderr}`,
+        );
+        assert.match(r.stderr, /unknown flag "--definitely-not-a-flag"/);
+      }
+    } finally {
+      rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  it("real flags still work (the fix must not over-reject)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "scan-flagok-"));
+    try {
+      writeFileSync(join(dir, "CLAUDE.md"), "# repo\nRun `npm test`.\n");
+      const audit = run(`audit ${dir} --no-open --harness=claude-code`);
+      assert.equal(audit.exitCode, 0, audit.stdout + audit.stderr);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("`vigiles <verb> --help` prints help instead of running the verb", () => {
+  it("audit --help does not audit", () => {
+    const r = run("audit --help");
+    assert.equal(r.exitCode, 0, r.stderr);
+    assert.match(r.stdout, /vigiles audit \[dir\.\.\.\]/);
+    assert.match(r.stdout, /^Flags: /m);
+    assert.doesNotMatch(
+      r.stdout,
+      /Detected harness/,
+      "asking what a flag is called must not run the command",
+    );
+  });
+
+  it("every verb answers --help", () => {
+    // Same throwaway cwd for the same reason: a regression here means the verb
+    // RUNS, and `init` running is a side effect on whatever dir we are in.
+    const sandbox = mkdtempSync(join(tmpdir(), "scan-help-"));
+    try {
+      for (const verb of ["init", "compile", "eject", "lint", "test", "eval"]) {
+        const r = run(`${verb} --help`, sandbox);
+        assert.equal(r.exitCode, 0, `${verb} --help: ${r.stderr}`);
+        assert.match(r.stdout, new RegExp(`vigiles ${verb}`));
+      }
+    } finally {
+      rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("`nothing to audit here` is a distinct outcome, not a grade of F", () => {
+  // The measured trap: `vigiles audit --json /some/path` — `--json` takes no
+  // value, so the PATH became the positional scan dir, the audit ran over a
+  // directory with no harness, and printed `skills: 0`, grade F, EXIT 0. That is
+  // indistinguishable from a real audit of a repo that scores badly.
+  it("an empty target exits non-zero and says there was nothing to measure", () => {
+    const root = mkdtempSync(join(tmpdir(), "scan-empty-"));
+    try {
+      const r = run(`audit ${root}`);
+      assert.equal(r.exitCode, 2, r.stdout + r.stderr);
+      assert.match(r.stderr, /nothing to audit in/);
+      assert.match(r.stderr, /NOT a grade/);
+      assert.doesNotMatch(
+        r.stdout,
+        /Overall|Grade/i,
+        "no score may be printed for a target that was never measurable",
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("a real-but-bad harness still grades, and still exits 0", () => {
+    // The other side of the distinction: `audit` remains a read, so a repo that
+    // scores badly is NOT an error — only "there was nothing here" is.
+    const root = mkdtempSync(join(tmpdir(), "scan-bad-"));
+    try {
+      writeFileSync(join(root, "CLAUDE.md"), "# repo\nSee docs/nope.md\n");
+      const r = run(`audit ${root}`);
+      assert.equal(r.exitCode, 0, r.stdout + r.stderr);
+      assert.doesNotMatch(r.stderr, /nothing to audit/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("--json still emits the report for an empty target (machine contract kept)", () => {
+    const root = mkdtempSync(join(tmpdir(), "scan-empty-json-"));
+    try {
+      const r = run(`audit --json ${root}`);
+      assert.equal(r.exitCode, 2);
+      const parsed = JSON.parse(r.stdout) as { score: { empty: boolean } };
+      assert.equal(parsed.score.empty, true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("the flag registry and the help text can't drift apart", () => {
+  it("every flag the help text advertises is accepted by some verb", () => {
+    // The registry is derived from what the HANDLERS read. This is the other
+    // direction: a flag we document but forgot to register would now be
+    // rejected in a user's face, so fail here instead.
+    const help = run("--help").stdout;
+    const advertised = new Set(help.match(/--[a-z][a-z0-9-]*/g) ?? []);
+    // Top-level, handled before dispatch (not a verb flag).
+    advertised.delete("--version");
+    const accepted = new Set<string>();
+    for (const verb of VERBS)
+      for (const spec of knownFlagsFor(verb))
+        accepted.add(spec.endsWith("=") ? spec.slice(0, -1) : spec);
+    const missing = [...advertised].filter((f) => !accepted.has(f));
+    assert.deepEqual(
+      missing,
+      [],
+      `documented but unregistered: ${String(missing)}`,
+    );
   });
 });

--- a/src/scan-files.ts
+++ b/src/scan-files.ts
@@ -54,6 +54,7 @@ import { pluginDirLayoutIssues } from "./core/plugin-dir-layout.js";
 import { hookBlockIssues } from "./core/hook-block-ineffective.js";
 import { hookMatcherIssues } from "./core/hook-matcher.js";
 import { findUntestedSurfacesInFiles } from "./test-coverage-files.js";
+import { countEvidence } from "./coverage-evidence.js";
 import {
   makeClassifier,
   scanAgents,
@@ -742,6 +743,7 @@ export function scanFiles(
     untestedHarness: coverage.harness.untested.length,
     unevaluated: coverage.evals.untested.length,
     evaluable: coverage.evals.covered.length + coverage.evals.untested.length,
+    coverageEvidence: countEvidence(coverage.decisions),
     puritySummary,
   };
 }

--- a/src/scan-files.ts
+++ b/src/scan-files.ts
@@ -673,6 +673,9 @@ export function scanFiles(
   >(
     findings: readonly T[],
   ): T[] => remapFindingPaths(findings, loaded.sources, BROWSER_ROOT);
+  // ONE discovery pass, read three ways — the union, the free deterministic tier
+  // (`Tested`), and the paid real-model tier (`Evaluated`). Mirrors scanPlugin.
+  const coverage = findUntestedSurfacesInFiles(files, lay);
   return {
     dir: BROWSER_ROOT,
     instructions,
@@ -735,7 +738,10 @@ export function scanFiles(
     ),
     malformedFrontmatter: remap(malformedFrontmatterFor(loaded.files, cls)),
     warnings: loaded.warnings,
-    untested: findUntestedSurfacesInFiles(files, lay).untested.length,
+    untested: coverage.untested.length,
+    untestedHarness: coverage.harness.untested.length,
+    unevaluated: coverage.evals.untested.length,
+    evaluable: coverage.evals.covered.length + coverage.evals.untested.length,
     puritySummary,
   };
 }

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -337,7 +337,26 @@ export interface ScanReport {
   /** Skills/agents whose `---` block isn't valid YAML — informational (may still load via salvage). */
   readonly malformedFrontmatter: readonly FrontmatterParseIssue[];
   readonly warnings: readonly string[];
+  /** Surfaces covered by NEITHER tier — the union count (unchanged). */
   readonly untested: number;
+  /**
+   * Surfaces with no DETERMINISTIC harness (`*.harness.mjs` / `*.test.*`) — free,
+   * millisecond, every-push. Feeds the `Tested` ring. Optional so a hand-built
+   * report (and any producer predating the split) falls back to `untested`.
+   */
+  readonly untestedHarness?: number;
+  /**
+   * Surfaces whose FIRING was never measured — no `*.eval.mjs` covers them. Paid,
+   * scheduled, real-model. Feeds the `Evaluated` ring. A DIFFERENT gap from
+   * `untestedHarness`, at a cost three orders of magnitude apart — which is
+   * exactly why it is a different number and not a slash in one finding.
+   */
+  readonly unevaluated?: number;
+  /**
+   * Surfaces whose firing COULD be measured at all — the `Evaluated` ring's
+   * denominator. 0 → the ring is n/a (nothing to evaluate), never a false 0.
+   */
+  readonly evaluable?: number;
   /**
    * Whether the repo has its OWN test setup (a real `package.json` `test` script or
    * a conventional test dir). When true, the `untested` count — which only counts
@@ -506,6 +525,11 @@ export function scanPlugin(
   >(
     findings: readonly T[],
   ): T[] => remapFindingPaths(findings, loaded.sources, resolve(dir));
+  // ONE discovery pass, read three ways: the union (unchanged `untested`), the
+  // deterministic tier (`Tested`), and the real-model tier (`Evaluated`). The
+  // tiers differ in cost, cadence AND in the question they answer, so collapsing
+  // them here would make the difference unrecoverable downstream.
+  const coverage = findUntestedSurfaces({ basePath: dir, layout: lay });
   return {
     dir,
     instructions,
@@ -570,8 +594,10 @@ export function scanPlugin(
     ),
     malformedFrontmatter: remap(malformedFrontmatterFor(loaded.files, cls)),
     warnings: loaded.warnings,
-    untested: findUntestedSurfaces({ basePath: dir, layout: lay }).untested
-      .length,
+    untested: coverage.untested.length,
+    untestedHarness: coverage.harness.untested.length,
+    unevaluated: coverage.evals.untested.length,
+    evaluable: coverage.total,
     ownTestSignal: ownTestSignalOnDisk(dir),
     puritySummary,
   };
@@ -912,6 +938,14 @@ export function formatScanReport(r: ScanReport): string {
   if (r.commands > 0) facts.push(`Commands: ${String(r.commands)}`);
   facts.push(`MCP servers: ${r.mcp ? "yes" : "no"}`);
   facts.push(`Untested surfaces: ${String(r.untested)}`);
+  // The two tiers, named separately — a surface with a deterministic harness and
+  // no eval is NOT the same position as one with neither. Shown only when the
+  // producer supplied the split (a hand-built report may not have).
+  if (r.untestedHarness !== undefined && r.unevaluated !== undefined) {
+    facts.push(
+      `  no harness: ${String(r.untestedHarness)} · firing never measured: ${String(r.unevaluated)}`,
+    );
+  }
   // Effect surface: harness-level purity summary across all scanned agents.
   // Informational (higher pure% = more constrained, cheaper to test); shown
   // only when there are agents to summarize (no agents → no summary line).

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -55,7 +55,11 @@ import {
   hookMatcherIssues,
   type HookMatcherFinding,
 } from "./core/hook-matcher.js";
-import { findUntestedSurfaces } from "./test-coverage.js";
+import {
+  coverageEvidenceCounts,
+  findUntestedSurfaces,
+} from "./test-coverage.js";
+import { formatEvidence, type EvidenceCounts } from "./coverage-evidence.js";
 import type { PurityLevel, EffectSurface } from "./core/effects.js";
 import {
   makeClassifier,
@@ -358,6 +362,13 @@ export interface ScanReport {
    */
   readonly evaluable?: number;
   /**
+   * HOW the covered surfaces were decided to be covered — declared / colocated /
+   * name-mentioned. A coverage count with no provenance is what let a one-line
+   * COMMENT confer coverage unnoticed; carrying the derivation makes "28 covered"
+   * distinguishable from "28 names that happen to appear in some file".
+   */
+  readonly coverageEvidence?: EvidenceCounts;
+  /**
    * Whether the repo has its OWN test setup (a real `package.json` `test` script or
    * a conventional test dir). When true, the `untested` count — which only counts
    * vigiles-native `.eval.mjs`/`.harness.mjs` — is misleading: the team clearly
@@ -598,6 +609,7 @@ export function scanPlugin(
     untestedHarness: coverage.harness.untested.length,
     unevaluated: coverage.evals.untested.length,
     evaluable: coverage.total,
+    coverageEvidence: coverageEvidenceCounts(coverage),
     ownTestSignal: ownTestSignalOnDisk(dir),
     puritySummary,
   };
@@ -946,6 +958,12 @@ export function formatScanReport(r: ScanReport): string {
       `  no harness: ${String(r.untestedHarness)} · firing never measured: ${String(r.unevaluated)}`,
     );
   }
+  // …and HOW the rest passed. Without this the count is unfalsifiable from the
+  // outside: "28 covered" and "28 names that appear in some file" print the same.
+  const evidenceLine = r.coverageEvidence
+    ? formatEvidence(r.coverageEvidence)
+    : "";
+  if (evidenceLine) facts.push(`  ${evidenceLine}`);
   // Effect surface: harness-level purity summary across all scanned agents.
   // Informational (higher pure% = more constrained, cheaper to test); shown
   // only when there are agents to summarize (no agents → no summary line).

--- a/src/skill-reachability.test.ts
+++ b/src/skill-reachability.test.ts
@@ -140,21 +140,63 @@ test("a user-scope install in the GLOBAL registry counts as reachable, even when
   }
 });
 
-test("a project-level enabledPlugins entry counts as reachable", () => {
+test("a project-level enabledPlugins entry is NOT reachable on its own — Claude Code still requires an install", () => {
+  // Per the Claude Code docs (Discover plugins → "Configure team marketplaces"),
+  // as of CC v2.1.195: "A plugin that only the project's `.claude/settings.json`
+  // enables, and that comes from an external source such as a GitHub repository
+  // or npm package, doesn't load until the team member installs it."
+  // vigiles ships from a GitHub marketplace, so it is exactly that case.
+  // Treating this as reachable would silence the warning for a repo that is in
+  // fact un-wired — the precise failure the check exists to prevent.
   const s = scaffold({
     settings: JSON.stringify({ enabledPlugins: { "vigiles@vigiles": true } }),
   });
   try {
     const r = checkSkillReachability(s.dir, { home: s.home });
     assert.ok(r);
-    assert.equal(r.reachable, true);
-    assert.deepEqual([...r.sources], ["enabled-plugin"]);
+    assert.equal(r.reachable, false);
+    assert.deepEqual([...r.sources], []);
+    assert.equal(r.declaredNotInstalled, true);
   } finally {
     s.cleanup();
   }
 });
 
-test("enabledPlugins set to FALSE is not reachable — an explicit disable is not an install", () => {
+test("declared-but-not-installed says so specifically, and names the per-machine install", () => {
+  const s = scaffold({
+    settings: JSON.stringify({ enabledPlugins: { "vigiles@vigiles": true } }),
+  });
+  try {
+    const msg = formatSkillReachability(
+      checkSkillReachability(s.dir, { home: s.home }),
+    );
+    assert.ok(msg);
+    // It must NOT read as "you forgot to configure it" — the repo DID declare
+    // it. The missing step is the per-machine install.
+    assert.match(msg, /declares/i);
+    assert.match(msg, /claude plugin install vigiles@vigiles/);
+  } finally {
+    s.cleanup();
+  }
+});
+
+test("a global install PLUS a project declaration is reachable — the declaration is not harmful, just insufficient", () => {
+  const s = scaffold({
+    installedPlugins: INSTALLED,
+    settings: JSON.stringify({ enabledPlugins: { "vigiles@vigiles": true } }),
+  });
+  try {
+    const r = checkSkillReachability(s.dir, { home: s.home });
+    assert.ok(r);
+    assert.equal(r.reachable, true);
+    assert.deepEqual([...r.sources], ["global-plugin"]);
+    assert.equal(formatSkillReachability(r), null);
+  } finally {
+    s.cleanup();
+  }
+});
+
+test("enabledPlugins set to FALSE is not reachable, and is not 'declared' either", () => {
   const s = scaffold({
     settings: JSON.stringify({ enabledPlugins: { "vigiles@vigiles": false } }),
   });
@@ -162,6 +204,7 @@ test("enabledPlugins set to FALSE is not reachable — an explicit disable is no
     const r = checkSkillReachability(s.dir, { home: s.home });
     assert.ok(r);
     assert.equal(r.reachable, false);
+    assert.equal(r.declaredNotInstalled, false);
   } finally {
     s.cleanup();
   }

--- a/src/skill-reachability.test.ts
+++ b/src/skill-reachability.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Tests for the shipped-skill reachability alarm (`src/skill-reachability.ts`).
+ *
+ * The defect it exists for, observed in a real consumer repo: `npm install
+ * vigiles` puts six user-facing skills on disk at `node_modules/vigiles/skills/`,
+ * which Claude Code never scans. The skills are wired by the GLOBAL plugin
+ * install (`vigiles init` → `claude plugin install vigiles@vigiles`), and until
+ * that has run the skills are silently unreachable — a user can spend a day doing
+ * exactly what `test-harness` teaches with the skill three directories away.
+ *
+ * The subtle part these tests pin down: the authoritative record of a user-scope
+ * plugin install is `~/.claude/plugins/installed_plugins.json`, NOT the repo's
+ * `.claude/settings.json`. Reading only `settings.json` (which carries
+ * PROJECT-level `enabledPlugins`) reports a correctly-installed plugin as
+ * missing — the exact misread that made this look like an npm packaging bug.
+ */
+import { test } from "vitest";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  checkSkillReachability,
+  formatSkillReachability,
+} from "./skill-reachability.js";
+import { SHIPPED_SKILLS } from "./setup-plan.js";
+import { makeTmpDir, cleanupTmpDir } from "./core/test-utils.js";
+
+/** A repo that depends on vigiles, plus a fake $HOME to point the check at. */
+function scaffold(opts: {
+  readonly dependsOnVigiles?: boolean;
+  /** Raw `~/.claude/plugins/installed_plugins.json`, or omitted for none. */
+  readonly installedPlugins?: string;
+  /** Raw repo `.claude/settings.json`, or omitted for none. */
+  readonly settings?: string;
+  /** Skill dir names to vendor into the repo's `.claude/skills/`. */
+  readonly repoSkills?: readonly string[];
+  /** Vendor the shipped skills into `node_modules/vigiles/skills/`. */
+  readonly nodeModulesSkills?: boolean;
+  /** Make the audited dir vigiles itself. */
+  readonly self?: boolean;
+}): { dir: string; home: string; cleanup: () => void } {
+  const dir = makeTmpDir("reach-repo");
+  const home = makeTmpDir("reach-home");
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify({
+      name: opts.self ? "vigiles" : "consumer",
+      devDependencies: opts.dependsOnVigiles === false ? {} : { vigiles: "^4" },
+    }),
+  );
+  if (opts.self) {
+    writeFileSync(
+      join(dir, "plugin.json"),
+      JSON.stringify({ name: "vigiles" }),
+    );
+  }
+  if (opts.installedPlugins !== undefined) {
+    const p = join(home, ".claude", "plugins");
+    mkdirSync(p, { recursive: true });
+    writeFileSync(join(p, "installed_plugins.json"), opts.installedPlugins);
+  }
+  if (opts.settings !== undefined) {
+    mkdirSync(join(dir, ".claude"), { recursive: true });
+    writeFileSync(join(dir, ".claude", "settings.json"), opts.settings);
+  }
+  for (const s of opts.repoSkills ?? []) {
+    const d = join(dir, ".claude", "skills", s);
+    mkdirSync(d, { recursive: true });
+    writeFileSync(join(d, "SKILL.md"), `---\nname: ${s}\n---\n`);
+  }
+  if (opts.nodeModulesSkills) {
+    for (const s of SHIPPED_SKILLS) {
+      const d = join(dir, "node_modules", "vigiles", "skills", s);
+      mkdirSync(d, { recursive: true });
+      writeFileSync(join(d, "SKILL.md"), `---\nname: ${s}\n---\n`);
+    }
+  }
+  return {
+    dir,
+    home,
+    cleanup: () => {
+      cleanupTmpDir(dir);
+      cleanupTmpDir(home);
+    },
+  };
+}
+
+const INSTALLED = JSON.stringify({
+  version: 2,
+  plugins: {
+    "vigiles@vigiles": [
+      { scope: "user", installPath: "/root/.claude/plugins/cache/vigiles" },
+    ],
+  },
+});
+
+/** settings.json that enables SOME OTHER plugin — the observed real-world state. */
+const OTHER_PLUGIN_ONLY = JSON.stringify({
+  enabledPlugins: { "superpowers@superpowers": true },
+});
+
+test("says nothing about a repo that does not depend on vigiles", () => {
+  const s = scaffold({ dependsOnVigiles: false });
+  try {
+    assert.equal(checkSkillReachability(s.dir, { home: s.home }), null);
+  } finally {
+    s.cleanup();
+  }
+});
+
+test("says nothing when the audited dir IS the vigiles plugin itself", () => {
+  const s = scaffold({ self: true });
+  try {
+    assert.equal(checkSkillReachability(s.dir, { home: s.home }), null);
+  } finally {
+    s.cleanup();
+  }
+});
+
+test("a user-scope install in the GLOBAL registry counts as reachable, even when settings.json enables only an unrelated plugin", () => {
+  // The misread that started this: `.claude/settings.json` lists
+  // `superpowers@superpowers` and no vigiles, which LOOKS un-wired — but
+  // `claude plugin install` records a user-scope install in the global
+  // registry, and that is what actually decides.
+  const s = scaffold({
+    installedPlugins: INSTALLED,
+    settings: OTHER_PLUGIN_ONLY,
+    nodeModulesSkills: true,
+  });
+  try {
+    const r = checkSkillReachability(s.dir, { home: s.home });
+    assert.ok(r);
+    assert.equal(r.reachable, true);
+    assert.deepEqual([...r.sources], ["global-plugin"]);
+    // Reachable → the audit says nothing at all.
+    assert.equal(formatSkillReachability(r), null);
+  } finally {
+    s.cleanup();
+  }
+});
+
+test("a project-level enabledPlugins entry counts as reachable", () => {
+  const s = scaffold({
+    settings: JSON.stringify({ enabledPlugins: { "vigiles@vigiles": true } }),
+  });
+  try {
+    const r = checkSkillReachability(s.dir, { home: s.home });
+    assert.ok(r);
+    assert.equal(r.reachable, true);
+    assert.deepEqual([...r.sources], ["enabled-plugin"]);
+  } finally {
+    s.cleanup();
+  }
+});
+
+test("enabledPlugins set to FALSE is not reachable — an explicit disable is not an install", () => {
+  const s = scaffold({
+    settings: JSON.stringify({ enabledPlugins: { "vigiles@vigiles": false } }),
+  });
+  try {
+    const r = checkSkillReachability(s.dir, { home: s.home });
+    assert.ok(r);
+    assert.equal(r.reachable, false);
+  } finally {
+    s.cleanup();
+  }
+});
+
+test("skills vendored into the repo's .claude/skills count as reachable", () => {
+  const s = scaffold({ repoSkills: ["test-harness"] });
+  try {
+    const r = checkSkillReachability(s.dir, { home: s.home });
+    assert.ok(r);
+    assert.equal(r.reachable, true);
+    assert.deepEqual([...r.sources], ["repo-skills"]);
+  } finally {
+    s.cleanup();
+  }
+});
+
+test("unrelated repo skills do NOT count — 38 skills, none of them vigiles', is still un-wired", () => {
+  const s = scaffold({
+    repoSkills: ["argument-arc", "handoff", "session-retro"],
+    settings: OTHER_PLUGIN_ONLY,
+  });
+  try {
+    const r = checkSkillReachability(s.dir, { home: s.home });
+    assert.ok(r);
+    assert.equal(r.reachable, false);
+    assert.deepEqual([...r.sources], []);
+  } finally {
+    s.cleanup();
+  }
+});
+
+test("un-wired + skills stranded in node_modules is LOUD, names the stranded skills, and gives the fix", () => {
+  const s = scaffold({
+    settings: OTHER_PLUGIN_ONLY,
+    nodeModulesSkills: true,
+  });
+  try {
+    const r = checkSkillReachability(s.dir, { home: s.home });
+    assert.ok(r);
+    assert.equal(r.reachable, false);
+    assert.deepEqual([...r.strandedSkills], [...SHIPPED_SKILLS]);
+
+    const msg = formatSkillReachability(r);
+    assert.ok(msg, "an un-wired repo must produce a warning");
+    // It must name the skill the user could not find, say WHERE it is
+    // stranded, and give a command that fixes it.
+    assert.match(msg, /test-harness/);
+    assert.match(msg, /node_modules/);
+    assert.match(msg, /claude plugin install vigiles@vigiles/);
+  } finally {
+    s.cleanup();
+  }
+});
+
+test("un-wired with NOTHING in node_modules still warns, without claiming stranded skills", () => {
+  const s = scaffold({ settings: OTHER_PLUGIN_ONLY });
+  try {
+    const r = checkSkillReachability(s.dir, { home: s.home });
+    assert.ok(r);
+    assert.equal(r.reachable, false);
+    assert.deepEqual([...r.strandedSkills], []);
+    const msg = formatSkillReachability(r);
+    assert.ok(msg);
+    assert.doesNotMatch(msg, /node_modules/);
+  } finally {
+    s.cleanup();
+  }
+});
+
+test("malformed JSON anywhere degrades to un-wired instead of throwing", () => {
+  const s = scaffold({
+    installedPlugins: "{ not json",
+    settings: "also not json",
+    nodeModulesSkills: true,
+  });
+  try {
+    const r = checkSkillReachability(s.dir, { home: s.home });
+    assert.ok(r);
+    assert.equal(r.reachable, false);
+  } finally {
+    s.cleanup();
+  }
+});
+
+test("an unreadable package.json means we cannot tell — say nothing rather than guess", () => {
+  const dir = makeTmpDir("reach-nopkg");
+  const home = makeTmpDir("reach-home");
+  try {
+    assert.equal(checkSkillReachability(dir, { home }), null);
+  } finally {
+    cleanupTmpDir(dir);
+    cleanupTmpDir(home);
+  }
+});
+
+test("a plain `dependencies` entry counts, not just devDependencies", () => {
+  const dir = makeTmpDir("reach-dep");
+  const home = makeTmpDir("reach-home");
+  try {
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ name: "c", dependencies: { vigiles: "^4" } }),
+    );
+    const r = checkSkillReachability(dir, { home });
+    assert.ok(r);
+    assert.equal(r.reachable, false);
+  } finally {
+    cleanupTmpDir(dir);
+    cleanupTmpDir(home);
+  }
+});
+
+test("an empty install record for vigiles is not an install", () => {
+  const s = scaffold({
+    installedPlugins: JSON.stringify({
+      version: 2,
+      plugins: { "vigiles@vigiles": [] },
+    }),
+  });
+  try {
+    const r = checkSkillReachability(s.dir, { home: s.home });
+    assert.ok(r);
+    assert.equal(r.reachable, false);
+  } finally {
+    s.cleanup();
+  }
+});
+
+test("formatSkillReachability(null) is null — nothing to say", () => {
+  assert.equal(formatSkillReachability(null), null);
+});

--- a/src/skill-reachability.ts
+++ b/src/skill-reachability.ts
@@ -1,0 +1,215 @@
+/**
+ * Are vigiles's SHIPPED SKILLS actually reachable by the agent in this repo?
+ *
+ * vigiles publishes six user-facing skills (`SHIPPED_SKILLS`) — the teaching
+ * surface. `test-harness` alone answers "which testing tier do I want?", the
+ * question this project's docs are otherwise organized around. They reach the
+ * agent through the GLOBAL plugin install (`vigiles init`, or
+ * `claude plugin marketplace add zernie/vigiles` + `claude plugin install
+ * vigiles@vigiles`), which lands in `~/.claude/plugins/` — deliberately never
+ * vendored into the repo (`docs/agent-setup.md`).
+ *
+ * The failure this module makes loud: `npm install vigiles` ALSO puts those
+ * skills on disk, at `node_modules/vigiles/skills/` (they are in package.json's
+ * `files`, because the npm tarball doubles as the plugin payload). Claude Code
+ * never scans `node_modules`. So a repo that took the dependency but never ran
+ * the plugin install has all six skills present, unreachable, and **silent** —
+ * observed in a real consumer repo, where a full day went into re-deriving what
+ * `test-harness` teaches while it sat three directories away.
+ *
+ * ⚠️ The part that is easy to get wrong, and did get wrong: the authoritative
+ * record of a `claude plugin install` is the GLOBAL
+ * `~/.claude/plugins/installed_plugins.json`. A repo's `.claude/settings.json`
+ * carries PROJECT-level `enabledPlugins`, which a correctly-installed user-scope
+ * plugin does not appear in. Judging "is it wired?" from `settings.json` alone
+ * reports a working install as broken — that misread is what made this look like
+ * an npm packaging bug. Both are checked here, and either one counts.
+ *
+ * Shape follows `src/dialect-drift.ts`: pure parsers + a best-effort local read
+ * that NEVER throws + a formatter that returns null when there is nothing to
+ * say, so `vigiles audit` can print it without a new verb, flag, or failure mode.
+ * It is ADVISORY — it never touches the audit score, because reachability is a
+ * property of the machine (is the plugin installed?), not of the repo, and a
+ * score that moved between a laptop and CI for identical source would be a lie.
+ */
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { SHIPPED_SKILLS } from "./setup-plan.js";
+
+/** The plugin id `claude plugin install` records — `<plugin>@<marketplace>`. */
+export const VIGILES_PLUGIN_ID = "vigiles@vigiles";
+
+/** Where a reachable install was found. */
+export type ReachabilitySource =
+  /** `~/.claude/plugins/installed_plugins.json` — what `claude plugin install` writes. */
+  | "global-plugin"
+  /** The repo's `.claude/settings.json` `enabledPlugins`. */
+  | "enabled-plugin"
+  /** The skills vendored into the repo's own `.claude/skills/`. */
+  | "repo-skills";
+
+/** The advisory: can the agent see vigiles's skills from this repo? */
+export interface SkillReachability {
+  /** True when at least one {@link ReachabilitySource} was found. */
+  readonly reachable: boolean;
+  /** Every source that resolved, in check order. Empty when un-wired. */
+  readonly sources: readonly ReachabilitySource[];
+  /**
+   * Shipped skills found under `node_modules/vigiles/skills/` while UNREACHABLE
+   * — present on disk, invisible to the agent. Empty when reachable (there is
+   * nothing stranded if they are wired) or when the package isn't installed yet.
+   */
+  readonly strandedSkills: readonly string[];
+}
+
+/**
+ * Is `vigiles` a declared dependency of this package.json text? Pure. Any of the
+ * four dependency fields counts — the question is "did this repo take vigiles
+ * on", not how.
+ */
+export function declaresVigilesDependency(pkgJson: string): boolean {
+  let pkg: Record<string, unknown>;
+  try {
+    pkg = JSON.parse(pkgJson) as Record<string, unknown>;
+  } catch {
+    return false;
+  }
+  // The vigiles repo itself is not a consumer — it IS the plugin.
+  if (pkg.name === "vigiles") return false;
+  const fields = [
+    "dependencies",
+    "devDependencies",
+    "peerDependencies",
+    "optionalDependencies",
+  ];
+  return fields.some((f) => {
+    const deps = pkg[f];
+    return typeof deps === "object" && deps !== null && "vigiles" in deps;
+  });
+}
+
+/**
+ * Does the global registry record a live install of the vigiles plugin? Pure over
+ * the raw `installed_plugins.json` text. An entry with an EMPTY array is a
+ * leftover record, not an install, so it does not count.
+ */
+export function hasGlobalPluginInstall(installedPluginsJson: string): boolean {
+  try {
+    const parsed = JSON.parse(installedPluginsJson) as {
+      plugins?: Record<string, unknown>;
+    };
+    const entry = parsed.plugins?.[VIGILES_PLUGIN_ID];
+    return Array.isArray(entry) && entry.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Does the repo's `.claude/settings.json` explicitly enable the vigiles plugin?
+ * Pure. An explicit `false` is a deliberate disable and does NOT count.
+ */
+export function hasEnabledPlugin(settingsJson: string): boolean {
+  try {
+    const parsed = JSON.parse(settingsJson) as {
+      enabledPlugins?: Record<string, unknown>;
+    };
+    return parsed.enabledPlugins?.[VIGILES_PLUGIN_ID] === true;
+  } catch {
+    return false;
+  }
+}
+
+/** Directory names directly under `dir`, or [] when it isn't readable. */
+function dirNames(dir: string): string[] {
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+  } catch {
+    return [];
+  }
+}
+
+/** Read a file, or null when it isn't there / isn't readable. Never throws. */
+function readOrNull(path: string): string | null {
+  try {
+    return existsSync(path) ? readFileSync(path, "utf-8") : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Best-effort, read-local reachability check for `vigiles audit`. Returns null
+ * when the question does not apply — the repo has no package.json, or does not
+ * depend on vigiles, or IS vigiles — so a non-consumer is never nagged. NEVER
+ * throws: every read degrades to "not found".
+ *
+ * `opts.home` overrides `$HOME` (tests, and any caller with a relocated config).
+ */
+export function checkSkillReachability(
+  dir: string,
+  opts: { readonly home?: string } = {},
+): SkillReachability | null {
+  const pkgJson = readOrNull(join(dir, "package.json"));
+  if (pkgJson === null || !declaresVigilesDependency(pkgJson)) return null;
+
+  const home = opts.home ?? homedir();
+  const sources: ReachabilitySource[] = [];
+
+  const installed = readOrNull(
+    join(home, ".claude", "plugins", "installed_plugins.json"),
+  );
+  if (installed !== null && hasGlobalPluginInstall(installed))
+    sources.push("global-plugin");
+
+  const settings = readOrNull(join(dir, ".claude", "settings.json"));
+  if (settings !== null && hasEnabledPlugin(settings))
+    sources.push("enabled-plugin");
+
+  // Vendored copies: only vigiles's OWN skill names count. A repo with 38
+  // unrelated skills in `.claude/skills/` is still un-wired.
+  const repoSkills = new Set(dirNames(join(dir, ".claude", "skills")));
+  if (SHIPPED_SKILLS.some((s) => repoSkills.has(s)))
+    sources.push("repo-skills");
+
+  const reachable = sources.length > 0;
+  const vendored = new Set(
+    dirNames(join(dir, "node_modules", "vigiles", "skills")),
+  );
+  return {
+    reachable,
+    sources,
+    strandedSkills: reachable
+      ? []
+      : SHIPPED_SKILLS.filter((s) => vendored.has(s)),
+  };
+}
+
+/**
+ * The warning for an un-wired repo, or null when there is nothing to say
+ * (reachable, or the check did not apply). Names the skill the user most likely
+ * went looking for, says where the copies are stranded when they exist, and ends
+ * on a command that fixes it.
+ */
+export function formatSkillReachability(
+  r: SkillReachability | null,
+): string | null {
+  if (!r || r.reachable) return null;
+  const stranded =
+    r.strandedSkills.length > 0
+      ? ` ${String(r.strandedSkills.length)} of them are sitting in ` +
+        `node_modules/vigiles/skills/, which the agent never scans.`
+      : "";
+  return (
+    `⚠ vigiles's skills are NOT reachable by your agent here. This repo depends on ` +
+    `vigiles, but its plugin isn't installed, so the shipped skills ` +
+    `(${SHIPPED_SKILLS.join(", ")}) can't be selected — including test-harness, ` +
+    `which picks the testing tier for you.${stranded}\n` +
+    `  Fix: claude plugin marketplace add zernie/vigiles && claude plugin install ${VIGILES_PLUGIN_ID}\n` +
+    `  (or run \`vigiles init\`, which does both)`
+  );
+}

--- a/src/skill-reachability.ts
+++ b/src/skill-reachability.ts
@@ -17,13 +17,31 @@
  * observed in a real consumer repo, where a full day went into re-deriving what
  * `test-harness` teaches while it sat three directories away.
  *
- * ⚠️ The part that is easy to get wrong, and did get wrong: the authoritative
- * record of a `claude plugin install` is the GLOBAL
- * `~/.claude/plugins/installed_plugins.json`. A repo's `.claude/settings.json`
- * carries PROJECT-level `enabledPlugins`, which a correctly-installed user-scope
- * plugin does not appear in. Judging "is it wired?" from `settings.json` alone
- * reports a working install as broken — that misread is what made this look like
- * an npm packaging bug. Both are checked here, and either one counts.
+ * ⚠️ The part that is easy to get wrong, and did get wrong TWICE, in opposite
+ * directions:
+ *
+ * 1. The authoritative record of a `claude plugin install` is the GLOBAL
+ *    `~/.claude/plugins/installed_plugins.json`. A repo's `.claude/settings.json`
+ *    carries PROJECT-level `enabledPlugins`, which a correctly-installed
+ *    user-scope plugin does not appear in. Judging "is it wired?" from
+ *    `settings.json` alone reports a working install as broken — the misread
+ *    that made this look like an npm packaging bug.
+ * 2. The converse is ALSO false: a project `enabledPlugins` entry does not make
+ *    the plugin load. Per the Claude Code docs (Discover plugins → "Configure
+ *    team marketplaces"), as of CC v2.1.195 — "A plugin that only the project's
+ *    `.claude/settings.json` enables, and that comes from an external source
+ *    such as a GitHub repository or npm package, doesn't load until the team
+ *    member installs it." vigiles ships from a GitHub marketplace, so that is
+ *    exactly our case. Committing `extraKnownMarketplaces` + `enabledPlugins`
+ *    makes Claude Code PROMPT each collaborator to install; it does not install.
+ *    Confirmed empirically: in a repo whose committed settings.json declares an
+ *    external plugin project-level, the global registry had no marketplace
+ *    entry, no cache dir, and no install record for it, while a plugin installed
+ *    the normal way on the same machine had all three.
+ *
+ * So a project declaration is a THIRD state — declared, not installed — that
+ * still warrants a warning, with a different fix line: the collaborator runs the
+ * install, the repo cannot run it for them.
  *
  * Shape follows `src/dialect-drift.ts`: pure parsers + a best-effort local read
  * that NEVER throws + a formatter that returns null when there is nothing to
@@ -41,13 +59,15 @@ import { SHIPPED_SKILLS } from "./setup-plan.js";
 /** The plugin id `claude plugin install` records — `<plugin>@<marketplace>`. */
 export const VIGILES_PLUGIN_ID = "vigiles@vigiles";
 
-/** Where a reachable install was found. */
+/**
+ * Where a reachable install was found. Deliberately does NOT include a project
+ * `enabledPlugins` entry: that declares the plugin, it does not install it (see
+ * the header). It is reported as {@link SkillReachability.declaredNotInstalled}.
+ */
 export type ReachabilitySource =
   /** `~/.claude/plugins/installed_plugins.json` — what `claude plugin install` writes. */
   | "global-plugin"
-  /** The repo's `.claude/settings.json` `enabledPlugins`. */
-  | "enabled-plugin"
-  /** The skills vendored into the repo's own `.claude/skills/`. */
+  /** The skills vendored into the repo's own `.claude/skills/` (standalone config, always loaded). */
   | "repo-skills";
 
 /** The advisory: can the agent see vigiles's skills from this repo? */
@@ -56,6 +76,13 @@ export interface SkillReachability {
   readonly reachable: boolean;
   /** Every source that resolved, in check order. Empty when un-wired. */
   readonly sources: readonly ReachabilitySource[];
+  /**
+   * The repo's `.claude/settings.json` enables the plugin, but no install was
+   * found. Claude Code will prompt this collaborator to install it; until they
+   * do, it does not load. A distinct state from "nothing configured at all",
+   * because the fix belongs to the person, not the repo.
+   */
+  readonly declaredNotInstalled: boolean;
   /**
    * Shipped skills found under `node_modules/vigiles/skills/` while UNREACHABLE
    * — present on disk, invisible to the agent. Empty when reachable (there is
@@ -166,10 +193,6 @@ export function checkSkillReachability(
   if (installed !== null && hasGlobalPluginInstall(installed))
     sources.push("global-plugin");
 
-  const settings = readOrNull(join(dir, ".claude", "settings.json"));
-  if (settings !== null && hasEnabledPlugin(settings))
-    sources.push("enabled-plugin");
-
   // Vendored copies: only vigiles's OWN skill names count. A repo with 38
   // unrelated skills in `.claude/skills/` is still un-wired.
   const repoSkills = new Set(dirNames(join(dir, ".claude", "skills")));
@@ -177,12 +200,20 @@ export function checkSkillReachability(
     sources.push("repo-skills");
 
   const reachable = sources.length > 0;
+
+  // A project declaration is NOT a source — it makes Claude Code prompt for an
+  // install, it does not perform one. Only meaningful while unreachable.
+  const settings = readOrNull(join(dir, ".claude", "settings.json"));
+  const declaredNotInstalled =
+    !reachable && settings !== null && hasEnabledPlugin(settings);
+
   const vendored = new Set(
     dirNames(join(dir, "node_modules", "vigiles", "skills")),
   );
   return {
     reachable,
     sources,
+    declaredNotInstalled,
     strandedSkills: reachable
       ? []
       : SHIPPED_SKILLS.filter((s) => vendored.has(s)),
@@ -204,12 +235,18 @@ export function formatSkillReachability(
       ? ` ${String(r.strandedSkills.length)} of them are sitting in ` +
         `node_modules/vigiles/skills/, which the agent never scans.`
       : "";
+  const why = r.declaredNotInstalled
+    ? `This repo DECLARES the vigiles plugin in .claude/settings.json, but a ` +
+      `project declaration doesn't install it — Claude Code loads an ` +
+      `external-source plugin only once each collaborator installs it on their ` +
+      `own machine.`
+    : `This repo depends on vigiles, but its plugin isn't installed.`;
   return (
-    `⚠ vigiles's skills are NOT reachable by your agent here. This repo depends on ` +
-    `vigiles, but its plugin isn't installed, so the shipped skills ` +
-    `(${SHIPPED_SKILLS.join(", ")}) can't be selected — including test-harness, ` +
-    `which picks the testing tier for you.${stranded}\n` +
-    `  Fix: claude plugin marketplace add zernie/vigiles && claude plugin install ${VIGILES_PLUGIN_ID}\n` +
+    `⚠ vigiles's skills are NOT reachable by your agent here. ${why} So the ` +
+    `shipped skills (${SHIPPED_SKILLS.join(", ")}) can't be selected — ` +
+    `including test-harness, which picks the testing tier for you.${stranded}\n` +
+    `  Fix (per machine): claude plugin marketplace add zernie/vigiles && ` +
+    `claude plugin install ${VIGILES_PLUGIN_ID}\n` +
     `  (or run \`vigiles init\`, which does both)`
   );
 }

--- a/src/test-coverage-files.ts
+++ b/src/test-coverage-files.ts
@@ -15,12 +15,15 @@
 import { basename, dirname } from "./posix-path.js";
 
 import type { PluginLayout } from "./core/layout.js";
-import type { Surface, SurfaceKind } from "./test-coverage.js";
+import type { CoverageTier, Surface, SurfaceKind } from "./test-coverage.js";
 
-// Mirrors src/test-coverage.ts constants.
+// Mirrors src/test-coverage.ts constants. VALUES are re-declared, never imported
+// — test-coverage.ts pulls in node:fs/glob, and this twin must stay browser-safe.
+const EVAL_SUFFIX = ".eval.mjs";
+
 const DEFAULT_TEST_SUFFIXES = [
   ".harness.mjs",
-  ".eval.mjs",
+  EVAL_SUFFIX,
   ".test.ts",
   ".test.mts",
   ".test.cts",
@@ -214,15 +217,28 @@ function isCovered(surface: Surface, tests: readonly TestFile[]): boolean {
   return false;
 }
 
+/** Mirror of test-coverage.ts `tierOf` — one tier's covered/untested split. */
+function tierOf(
+  considered: readonly Surface[],
+  tests: readonly TestFile[],
+): CoverageTier {
+  const covered: Surface[] = [];
+  const untested: Surface[] = [];
+  for (const s of considered)
+    (isCovered(s, tests) ? covered : untested).push(s);
+  return { covered, untested };
+}
+
 /**
  * The untested harness surfaces (skills / agents / hooks) in a file map — the
- * browser-safe twin of `findUntestedSurfaces`, returning only the `untested` list
- * (`scanFiles` needs the count). Same coverage rules as the disk detector.
+ * browser-safe twin of `findUntestedSurfaces`, returning the union `untested` list
+ * plus the same per-tier split (`scanFiles` needs the counts). Same coverage rules
+ * as the disk detector; the tier split is by suffix, exactly as on disk.
  */
 export function findUntestedSurfacesInFiles(
   files: Record<string, string>,
   layout: PluginLayout,
-): { untested: Surface[] } {
+): { untested: Surface[]; harness: CoverageTier; evals: CoverageTier } {
   const surfaces: Surface[] = [
     ...discoverSkills(files, layout),
     ...discoverAgents(files, layout),
@@ -231,5 +247,15 @@ export function findUntestedSurfacesInFiles(
   const considered = surfaces.filter((s) => !s.ignored);
   const tests = discoverTests(files);
   const untested = considered.filter((s) => !isCovered(s, tests));
-  return { untested };
+  return {
+    untested,
+    harness: tierOf(
+      considered,
+      tests.filter((t) => !t.path.endsWith(EVAL_SUFFIX)),
+    ),
+    evals: tierOf(
+      considered,
+      tests.filter((t) => t.path.endsWith(EVAL_SUFFIX)),
+    ),
+  };
 }

--- a/src/test-coverage-files.ts
+++ b/src/test-coverage-files.ts
@@ -9,13 +9,28 @@
  * and the materialize-root form), the hook-script discovery from the
  * manifest/settings/`.local` settings, the test-file globs (harness/eval/test
  * suffixes) with the same ignore set, the `vigiles:ignore-test` exemption, and the
- * colocation + content-reference coverage rules. See the parity test in
- * src/scan-files.test.ts.
+ * declaration + colocation + content-reference coverage rules. See the parity
+ * test in src/scan-files.test.ts.
+ *
+ * The part that DECIDES coverage is not mirrored — it is imported from
+ * `coverage-evidence.ts` (pure, browser-safe), so the twins cannot drift on the
+ * one thing whose divergence would change a grade.
  */
 import { basename, dirname } from "./posix-path.js";
 
 import type { PluginLayout } from "./core/layout.js";
-import type { CoverageTier, Surface, SurfaceKind } from "./test-coverage.js";
+import type {
+  CoverageDecision,
+  CoverageTier,
+  Surface,
+  SurfaceKind,
+} from "./test-coverage.js";
+import {
+  evidenceFor,
+  isStronger,
+  prepareTest,
+  type PreparedTest,
+} from "./coverage-evidence.js";
 
 // Mirrors src/test-coverage.ts constants. VALUES are re-declared, never imported
 // — test-coverage.ts pulls in node:fs/glob, and this twin must stay browser-safe.
@@ -178,17 +193,12 @@ function discoverHooks(
   }));
 }
 
-interface TestFile {
-  readonly path: string;
-  readonly content: string;
-}
-
-function discoverTests(files: Record<string, string>): TestFile[] {
-  const out: TestFile[] = [];
+function discoverTests(files: Record<string, string>): PreparedTest[] {
+  const out: PreparedTest[] = [];
   for (const [path, content] of Object.entries(files)) {
     if (isIgnored(path)) continue;
     if (DEFAULT_TEST_SUFFIXES.some((s) => path.endsWith(s))) {
-      out.push({ path, content });
+      out.push(prepareTest(path, content));
     }
   }
   return out;
@@ -208,25 +218,40 @@ function isColocated(surface: Surface, testPath: string): boolean {
   );
 }
 
-function isCovered(surface: Surface, tests: readonly TestFile[]): boolean {
+/** Mirror of test-coverage.ts `coverageOf` — strongest evidence across tests. */
+function coverageOf(
+  surface: Surface,
+  tests: readonly PreparedTest[],
+): CoverageDecision | null {
+  let best: CoverageDecision | null = null;
   for (const t of tests) {
     if (t.path === surface.path) continue;
-    if (isColocated(surface, t.path)) return true;
-    if (surface.tokens.some((tok) => t.content.includes(tok))) return true;
+    const ev = evidenceFor(surface, t, isColocated(surface, t.path));
+    if (!ev) continue;
+    if (!best || isStronger(ev, best.evidence))
+      best = { surface, evidence: ev, by: t.path };
   }
-  return false;
+  return best;
 }
 
 /** Mirror of test-coverage.ts `tierOf` — one tier's covered/untested split. */
 function tierOf(
   considered: readonly Surface[],
-  tests: readonly TestFile[],
+  tests: readonly PreparedTest[],
 ): CoverageTier {
   const covered: Surface[] = [];
   const untested: Surface[] = [];
-  for (const s of considered)
-    (isCovered(s, tests) ? covered : untested).push(s);
-  return { covered, untested };
+  const decisions: CoverageDecision[] = [];
+  for (const s of considered) {
+    const decision = coverageOf(s, tests);
+    if (decision) {
+      covered.push(s);
+      decisions.push(decision);
+    } else {
+      untested.push(s);
+    }
+  }
+  return { covered, untested, decisions };
 }
 
 /**
@@ -238,7 +263,12 @@ function tierOf(
 export function findUntestedSurfacesInFiles(
   files: Record<string, string>,
   layout: PluginLayout,
-): { untested: Surface[]; harness: CoverageTier; evals: CoverageTier } {
+): {
+  untested: Surface[];
+  decisions: readonly CoverageDecision[];
+  harness: CoverageTier;
+  evals: CoverageTier;
+} {
   const surfaces: Surface[] = [
     ...discoverSkills(files, layout),
     ...discoverAgents(files, layout),
@@ -246,9 +276,10 @@ export function findUntestedSurfacesInFiles(
   ];
   const considered = surfaces.filter((s) => !s.ignored);
   const tests = discoverTests(files);
-  const untested = considered.filter((s) => !isCovered(s, tests));
+  const union = tierOf(considered, tests);
   return {
-    untested,
+    untested: [...union.untested],
+    decisions: union.decisions,
     harness: tierOf(
       considered,
       tests.filter((t) => !t.path.endsWith(EVAL_SUFFIX)),

--- a/src/test-coverage.test.ts
+++ b/src/test-coverage.test.ts
@@ -287,3 +287,68 @@ test("a root SKILL.md is COVERED by a colocated eval (single-skill-dir target)",
   );
   cleanupTmpDir(dir);
 });
+
+// ── Two tiers, split at DISCOVERY ────────────────────────────────────────────
+// A harness (`*.harness.mjs`, `*.test.*`) is free and runs on every push; an eval
+// (`*.eval.mjs`) spends real model calls on a schedule and is the ONLY thing that
+// answers "does this skill fire?". Erasing that at discovery makes it
+// unrecoverable downstream — hence a per-tier split, not a display tweak.
+
+test("tiers split at discovery: a harness-only skill is NOT evaluated, and vice versa", () => {
+  const dir = makeTmpDir("cov-tiers");
+  write(dir, "skills/harnessed/SKILL.md", skill("harnessed"));
+  write(dir, "skills/harnessed/harnessed.harness.mjs", "// deterministic\n");
+  write(dir, "skills/evaled/SKILL.md", skill("evaled"));
+  write(dir, "skills/evaled/evaled.eval.mjs", "// real model\n");
+  write(dir, "skills/bare/SKILL.md", skill("bare"));
+
+  const r = findUntestedSurfaces({ basePath: dir });
+  const names = (ss: readonly { name: string }[]) =>
+    ss.map((s) => s.name).sort();
+
+  // The UNION is unchanged: a test anywhere counts.
+  assert.deepEqual(names(r.untested), ["bare"]);
+  assert.deepEqual(names(r.covered), ["evaled", "harnessed"]);
+
+  // The tiers disagree, which is the whole point — "has deterministic coverage,
+  // no evals" is a different position from "has neither".
+  assert.deepEqual(names(r.harness.covered), ["harnessed"]);
+  assert.deepEqual(names(r.harness.untested), ["bare", "evaled"]);
+  assert.deepEqual(names(r.evals.covered), ["evaled"]);
+  assert.deepEqual(names(r.evals.untested), ["bare", "harnessed"]);
+  cleanupTmpDir(dir);
+});
+
+test("a `*.test.ts` is a HARNESS, never an eval (it spends no model calls)", () => {
+  const dir = makeTmpDir("cov-tier-ts");
+  write(dir, "skills/foo/SKILL.md", skill("foo"));
+  write(dir, "suite/foo.test.ts", 'import "../skills/foo/SKILL.md";\n');
+  const r = findUntestedSurfaces({ basePath: dir });
+  assert.equal(r.untested.length, 0, "content-reference covers the union");
+  assert.equal(r.harness.untested.length, 0, "…and the deterministic tier");
+  assert.deepEqual(
+    r.evals.untested.map((s) => s.name),
+    ["foo"],
+    "but firing is still unmeasured — a .test.ts cannot answer that",
+  );
+  cleanupTmpDir(dir);
+});
+
+test("formatUntestedReport names the two gaps SEPARATELY (no test/eval slash)", () => {
+  const dir = makeTmpDir("cov-tier-fmt");
+  write(dir, "skills/a/SKILL.md", skill("a"));
+  write(dir, "skills/a/a.harness.mjs", "// deterministic only\n");
+  write(dir, "skills/b/SKILL.md", skill("b"));
+  const text = formatUntestedReport(findUntestedSurfaces({ basePath: dir }));
+  // Only `b` is in the union list…
+  assert.ok(text.includes("1 surface(s) with no test"));
+  // …but the breakdown says 1 needs a harness and 2 need firing measured, with
+  // the cost of each named. One number could not have said that.
+  assert.ok(
+    text.includes(
+      "Two gaps, two costs: 1 with no deterministic harness (free, every push) · 2 whose firing was never measured",
+    ),
+    text,
+  );
+  cleanupTmpDir(dir);
+});

--- a/src/test-coverage.test.ts
+++ b/src/test-coverage.test.ts
@@ -12,6 +12,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import {
+  coverageEvidenceCounts,
   findUntestedSurfaces,
   formatUntestedReport,
   suggestedTestPath,
@@ -372,5 +373,145 @@ test("formatUntestedReport names the two gaps SEPARATELY (no test/eval slash)", 
     ),
     text,
   );
+  cleanupTmpDir(dir);
+});
+
+// ── Evidence: a STRING is not a test ─────────────────────────────────────────
+// The detector used to count any occurrence of a surface's path/namespace ANYWHERE
+// in a discovered test file. Measured on a real repo (37 skills, 14 hooks),
+// appending one COMMENT line — `// probe: skills/argument-arc` — moved the
+// untested count 33 → 32. Meanwhile a harness that genuinely asserts over 21
+// skills but builds its paths at runtime contained no literal `skills/<name>` and
+// covered nothing: generality was penalised, gaming was free.
+
+test("a surface named ONLY in a comment is NOT covered (the one-line probe)", () => {
+  const dir = makeTmpDir("cov-comment-probe");
+  write(dir, "skills/argument-arc/SKILL.md", skill("argument-arc"));
+  // Verbatim shape of the reproduction: a real harness file, plus a comment that
+  // happens to spell the surface's path. Nothing asserts anything about it.
+  write(
+    dir,
+    "test/pipeline.harness.mjs",
+    [
+      "import { readFileSync } from 'node:fs';",
+      "// probe: skills/argument-arc",
+      "export default () => readFileSync('unrelated.txt');",
+      "",
+    ].join("\n"),
+  );
+  const r = findUntestedSurfaces({ basePath: dir });
+  assert.deepEqual(
+    r.untested.map((s) => s.name),
+    ["argument-arc"],
+    "a comment is prose about a test, not a test",
+  );
+  cleanupTmpDir(dir);
+});
+
+test("a mention in CODE still counts — the zero-config path is kept, and labelled", () => {
+  // The bare substring detector is deliberately RETAINED for code: it is what
+  // makes an ordinary `foo.test.ts` naming `skills/foo` count without anyone
+  // learning a marker. What it no longer reads is comments.
+  const dir = makeTmpDir("cov-code-mention");
+  write(dir, "skills/foo/SKILL.md", skill("foo"));
+  write(dir, "test/foo.test.ts", 'loadSkill("skills/foo/SKILL.md");\n');
+  const r = findUntestedSurfaces({ basePath: dir });
+  assert.equal(r.untested.length, 0);
+  assert.deepEqual(coverageEvidenceCounts(r), {
+    declared: 0,
+    colocated: 0,
+    mention: 1,
+  });
+  cleanupTmpDir(dir);
+});
+
+test("a URL in a string literal survives comment-stripping", () => {
+  // The stripper must not treat `//` inside a string as a comment opener, or a
+  // fixture URL would swallow the rest of the line and drop real coverage.
+  const dir = makeTmpDir("cov-url");
+  write(dir, "skills/foo/SKILL.md", skill("foo"));
+  write(
+    dir,
+    "test/foo.test.ts",
+    'const u = "https://example.com"; loadSkill("skills/foo");\n',
+  );
+  assert.equal(findUntestedSurfaces({ basePath: dir }).untested.length, 0);
+  cleanupTmpDir(dir);
+});
+
+test("a runtime-path harness that DECLARES its surfaces is counted", () => {
+  // The false NEGATIVE half: this harness really does assert over both skills,
+  // but assembles the paths at runtime, so it contains ZERO literal `skills/<name>`
+  // strings. Substring matching can never see it; a declaration can.
+  const dir = makeTmpDir("cov-declared");
+  write(dir, "skills/alpha/SKILL.md", skill("alpha"));
+  write(dir, "skills/beta/SKILL.md", skill("beta"));
+  const runtimeHarness = [
+    "import { join } from 'node:path';",
+    "// vigiles:covers skills/alpha, skills/beta",
+    "for (const name of ['alpha', 'beta']) {",
+    "  assertFrontmatter(join(root, 'skills', name, 'SKILL.md'));",
+    "}",
+    "",
+  ].join("\n");
+  write(dir, "test/pipeline.harness.mjs", runtimeHarness);
+  // The literal path exists ONLY on the declaration line: strike that line and
+  // no substring detector could ever have found either skill.
+  const codeOnly = runtimeHarness
+    .split("\n")
+    .filter((l) => !l.includes("vigiles:covers"))
+    .join("\n");
+  assert.ok(!codeOnly.includes("skills/alpha"), codeOnly);
+  assert.ok(!codeOnly.includes("skills/beta"), codeOnly);
+
+  const r = findUntestedSurfaces({ basePath: dir });
+  assert.equal(r.untested.length, 0, "both surfaces are covered");
+  assert.deepEqual(coverageEvidenceCounts(r), {
+    declared: 2,
+    colocated: 0,
+    mention: 0,
+  });
+  cleanupTmpDir(dir);
+});
+
+test("evidence provenance is REPORTED, and names the weakest case explicitly", () => {
+  const dir = makeTmpDir("cov-provenance");
+  write(dir, "skills/mentioned/SKILL.md", skill("mentioned"));
+  write(dir, "test/a.test.ts", 'loadSkill("skills/mentioned");\n');
+  const mentionOnly = formatUntestedReport(
+    findUntestedSurfaces({ basePath: dir }),
+  );
+  assert.ok(mentionOnly.includes("How coverage was decided"), mentionOnly);
+  assert.ok(
+    mentionOnly.includes("ALL of it is a name appearing in a test file"),
+    mentionOnly,
+  );
+
+  // Add a colocated test and the "all of it" escalation must drop away.
+  write(dir, "skills/colo/SKILL.md", skill("colo"));
+  write(dir, "skills/colo/colo.harness.mjs", "export default () => {};\n");
+  const mixed = formatUntestedReport(findUntestedSurfaces({ basePath: dir }));
+  assert.ok(mixed.includes("1 colocated"), mixed);
+  assert.ok(!mixed.includes("ALL of it"), mixed);
+  cleanupTmpDir(dir);
+});
+
+test("a declaration OUTRANKS a mention for the same surface", () => {
+  // Provenance must not depend on glob order: the strongest evidence wins.
+  const dir = makeTmpDir("cov-rank");
+  write(dir, "skills/foo/SKILL.md", skill("foo"));
+  write(dir, "test/a-mention.test.ts", 'loadSkill("skills/foo");\n');
+  write(
+    dir,
+    "test/z-declared.harness.mjs",
+    "// vigiles:covers skills/foo\nexport default () => {};\n",
+  );
+  const r = findUntestedSurfaces({ basePath: dir });
+  assert.deepEqual(coverageEvidenceCounts(r), {
+    declared: 1,
+    colocated: 0,
+    mention: 0,
+  });
+  assert.equal(r.decisions[0].by, "test/z-declared.harness.mjs");
   cleanupTmpDir(dir);
 });

--- a/src/test-coverage.test.ts
+++ b/src/test-coverage.test.ts
@@ -334,6 +334,28 @@ test("a `*.test.ts` is a HARNESS, never an eval (it spends no model calls)", () 
   cleanupTmpDir(dir);
 });
 
+test("a clean UNION still says when nothing has measured firing", () => {
+  // Every surface has a deterministic harness, so the gate passes — but no
+  // `*.eval.mjs` exists, so nothing has measured that the skill fires. A bare ✓
+  // there would read as "firing verified" when the question was never asked.
+  const dir = makeTmpDir("cov-clean-noeval");
+  write(dir, "skills/a/SKILL.md", skill("a"));
+  write(dir, "skills/a/a.harness.mjs", "// deterministic only\n");
+  const harnessOnly = formatUntestedReport(
+    findUntestedSurfaces({ basePath: dir }),
+  );
+  assert.ok(harnessOnly.startsWith("✓"), harnessOnly);
+  assert.ok(harnessOnly.includes("no `*.eval.mjs`"), harnessOnly);
+  assert.ok(harnessOnly.includes("actually fire"), harnessOnly);
+
+  // Add the eval and the caveat disappears — a plain ✓, nothing left unasked.
+  write(dir, "skills/a/a.eval.mjs", "// real model\n");
+  const both = formatUntestedReport(findUntestedSurfaces({ basePath: dir }));
+  assert.ok(both.startsWith("✓"), both);
+  assert.ok(!both.includes("eval.mjs`"), both);
+  cleanupTmpDir(dir);
+});
+
 test("formatUntestedReport names the two gaps SEPARATELY (no test/eval slash)", () => {
   const dir = makeTmpDir("cov-tier-fmt");
   write(dir, "skills/a/SKILL.md", skill("a"));

--- a/src/test-coverage.ts
+++ b/src/test-coverage.ts
@@ -424,7 +424,16 @@ export function suggestedTestPath(surface: Surface): string {
 export function formatUntestedReport(report: UntestedReport): string {
   if (report.untested.length === 0) {
     const tail = report.exempt > 0 ? ` (${String(report.exempt)} exempt)` : "";
-    return `✓ all ${String(report.total)} surface(s) have a test or eval${tail}`;
+    const ok = `✓ all ${String(report.total)} surface(s) have a test or eval${tail}`;
+    // A clean UNION can still hide a whole unanswered question: every surface may
+    // have a deterministic harness and NOTHING may ever have measured that a
+    // skill fires. The gate is unchanged (still the union), but the ✓ must not
+    // read as "firing verified" when nothing asked.
+    const unevaluated = report.evals.untested.length;
+    return unevaluated === 0
+      ? ok
+      : `${ok}\n  …but ${String(unevaluated)} of them have no \`*.eval.mjs\`, so ` +
+          `nothing has measured whether they actually fire (a harness can't tell you that).`;
   }
   const lines = [
     `⚠ ${String(report.untested.length)} surface(s) with no test or eval:`,

--- a/src/test-coverage.ts
+++ b/src/test-coverage.ts
@@ -20,6 +20,20 @@
  * skill still DOES something when invoked, and that behaviour is worth a test).
  * The only opt-out is explicit: a `vigiles:ignore-test` marker in the surface
  * file, which is reported as `exempt` so the skip is visible, never silent.
+ *
+ * TWO TIERS, discovered SEPARATELY — a harness and an eval are not the same thing
+ * and collapsing them at discovery makes the difference unrecoverable downstream:
+ *
+ *   | | harness (`*.harness.mjs`, `*.test.*`) | eval (`*.eval.mjs`) |
+ *   |---|---|---|
+ *   | cost    | free                          | paid model calls    |
+ *   | cadence | every push                    | scheduled           |
+ *   | answers | "does this gate still catch what it claims?" | "does this skill FIRE at all?" |
+ *
+ * So a repo with complete deterministic coverage and no evals is a DIFFERENT
+ * position from a repo with neither, and "add a test/eval" spans three orders of
+ * magnitude in cost without saying which. {@link UntestedReport} therefore carries
+ * a per-tier {@link CoverageTier} alongside the (unchanged) union fields.
  */
 
 import { existsSync, readFileSync } from "node:fs";
@@ -63,13 +77,31 @@ export interface Surface {
   readonly ignored: boolean;
 }
 
+/** One tier's split of the considered surfaces — covered by THAT tier, or not. */
+export interface CoverageTier {
+  readonly covered: readonly Surface[];
+  readonly untested: readonly Surface[];
+}
+
 export interface UntestedReport {
   /** Total surfaces considered (after exemptions). */
   readonly total: number;
+  /** Covered by EITHER tier — the union, unchanged (a test anywhere counts). */
   readonly covered: readonly Surface[];
+  /** Covered by NEITHER tier — the union, unchanged. */
   readonly untested: readonly Surface[];
   /** Surfaces explicitly opted out via `vigiles:ignore-test`. */
   readonly exempt: number;
+  /**
+   * DETERMINISTIC coverage only — `*.harness.mjs` and `*.test.*`. Free,
+   * millisecond, every-push. Answers "does this gate still catch what it claims?"
+   */
+  readonly harness: CoverageTier;
+  /**
+   * REAL-MODEL coverage only — `*.eval.mjs`. Paid, minutes, scheduled. Answers
+   * the one question the deterministic tier cannot: "does this skill FIRE at all?"
+   */
+  readonly evals: CoverageTier;
 }
 
 export interface TestCoverageOptions {
@@ -97,9 +129,12 @@ export interface TestCoverageOptions {
 // Internals
 // ---------------------------------------------------------------------------
 
+/** The REAL-MODEL tier's suffix — the one file kind that costs money to run. */
+const EVAL_SUFFIX = ".eval.mjs";
+
 const DEFAULT_TEST_GLOBS = [
   "**/*.harness.mjs",
-  "**/*.eval.mjs",
+  `**/*${EVAL_SUFFIX}`,
   "**/*.test.ts",
   "**/*.test.mts",
   "**/*.test.cts",
@@ -292,6 +327,36 @@ function isCovered(surface: Surface, tests: readonly TestFile[]): boolean {
   return false;
 }
 
+/**
+ * Split the discovered tests into the two tiers by SUFFIX — `*.eval.mjs` is the
+ * paid real-model tier, everything else (`*.harness.mjs`, `*.test.*`, and any
+ * user-supplied `testGlobs`) is the free deterministic tier. Suffix, not glob set,
+ * so a custom `testGlobs` (a promptfoo suite, a home-grown loop) still lands in a
+ * tier instead of silently disappearing from the split.
+ */
+function partitionTests(tests: readonly TestFile[]): {
+  harness: TestFile[];
+  evals: TestFile[];
+} {
+  const harness: TestFile[] = [];
+  const evals: TestFile[] = [];
+  for (const t of tests)
+    (t.path.endsWith(EVAL_SUFFIX) ? evals : harness).push(t);
+  return { harness, evals };
+}
+
+/** Split the considered surfaces by whether ONE tier's tests cover them. */
+function tierOf(
+  considered: readonly Surface[],
+  tests: readonly TestFile[],
+): CoverageTier {
+  const covered: Surface[] = [];
+  const untested: Surface[] = [];
+  for (const s of considered)
+    (isCovered(s, tests) ? covered : untested).push(s);
+  return { covered, untested };
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -302,6 +367,11 @@ function isCovered(surface: Surface, tests: readonly TestFile[]): boolean {
  * test that references its path/namespace. EVERY skill, agent, and hook is held
  * to this — the only exemption is an explicit `vigiles:ignore-test` marker in the
  * surface file (counted as `exempt`).
+ *
+ * The `covered`/`untested` union fields are UNCHANGED (a test anywhere counts).
+ * `harness` and `evals` carry the per-tier split so a caller can tell "has
+ * deterministic coverage, no evals" from "has neither" — two positions the single
+ * count made indistinguishable.
  */
 export function findUntestedSurfaces(
   options: TestCoverageOptions = {},
@@ -325,13 +395,17 @@ export function findUntestedSurfaces(
   const exempt = surfaces.length - considered.length;
 
   const tests = discoverTests(basePath, globs, ignore);
-  const covered: Surface[] = [];
-  const untested: Surface[] = [];
-  for (const s of considered) {
-    (isCovered(s, tests) ? covered : untested).push(s);
-  }
+  const split = partitionTests(tests);
+  const union = tierOf(considered, tests);
 
-  return { total: considered.length, covered, untested, exempt };
+  return {
+    total: considered.length,
+    covered: union.covered,
+    untested: union.untested,
+    exempt,
+    harness: tierOf(considered, split.harness),
+    evals: tierOf(considered, split.evals),
+  };
 }
 
 /** Suggested colocated test path for an untested surface (shown in the warning). */
@@ -358,6 +432,16 @@ export function formatUntestedReport(report: UntestedReport): string {
   for (const s of report.untested) {
     lines.push(`    ${s.kind} ${s.path} — add e.g. ${suggestedTestPath(s)}`);
   }
+  // Name the two gaps SEPARATELY — they lead to different work at wildly
+  // different cost. "add a test/eval" is one sentence for two prescriptions three
+  // orders of magnitude apart; a reader can't tell whether it's ten minutes or a
+  // model budget.
+  lines.push(
+    `  Two gaps, two costs: ${String(report.harness.untested.length)} with no ` +
+      `deterministic harness (free, every push) · ` +
+      `${String(report.evals.untested.length)} whose firing was never measured ` +
+      `(needs a real model, run on a schedule).`,
+  );
   // Already testing these another way (a promptfoo suite, a home-grown evals
   // file)? Point `testGlobs` at it so it counts toward coverage (issue #113).
   lines.push(

--- a/src/test-coverage.ts
+++ b/src/test-coverage.ts
@@ -7,13 +7,20 @@
  * with no test is a probabilistic-compliance gap hiding in the deterministic
  * layer: nothing measures whether it still does what it claims.
  *
- * Two detectors decide "tested", OR'd, so a test placed ANYWHERE counts:
- *   1. colocation — a `*.{harness,eval}.mjs` next to the surface (the zero-config
+ * THREE detectors decide "tested", OR'd, so a test placed ANYWHERE counts — and
+ * every decision now carries WHICH one decided it (see `coverage-evidence.ts`
+ * for why that provenance is load-bearing, not decoration):
+ *   1. declaration — a `vigiles:covers <surface>` marker in the test file. The
+ *      only detector a RUNTIME-PATH harness can reach, and the only one that
+ *      cannot happen by accident.
+ *   2. colocation — a `*.{harness,eval}.mjs` next to the surface (the zero-config
  *      convention the warning suggests): `skills/foo/*.eval.mjs`,
  *      `agents/bar.harness.mjs`, `hooks/pre-edit.harness.mjs`.
- *   2. content-reference — any discovered test (incl. `*.test.ts`) that names the
- *      surface by PATH (`skills/foo`, `hooks/pre-edit.sh`) or NAMESPACE
- *      (`vigiles:foo`). Not bare-name — too fuzzy.
+ *   3. content-reference — any discovered test (incl. `*.test.ts`) whose CODE
+ *      names the surface by PATH (`skills/foo`, `hooks/pre-edit.sh`) or NAMESPACE
+ *      (`vigiles:foo`). Not bare-name — too fuzzy. And no longer COMMENTS: a name
+ *      in a comment is prose about a test, not a test. Counting it made the
+ *      metric gameable by one line (measured: untested 33 → 32, from a comment).
  *
  * Warning-by-default (a nudge, not a gate). EVERY skill, agent, and hook is held
  * to the requirement — invocation mode does NOT exempt anything (a command-only
@@ -41,6 +48,17 @@ import { basename, dirname, join } from "node:path";
 import { globSync } from "glob";
 import type { PluginLayout } from "./core/layout.js";
 import { claudeCodeLayout } from "./adapters/claude-code/layout.js";
+import {
+  COVERS_MARKER,
+  countEvidence,
+  evidenceFor,
+  formatEvidence,
+  isStronger,
+  prepareTest,
+  type CoverageEvidence,
+  type EvidenceCounts,
+  type PreparedTest,
+} from "./coverage-evidence.js";
 
 /**
  * The two on-disk locations a surface dir can occupy: the plugin-root form
@@ -77,10 +95,24 @@ export interface Surface {
   readonly ignored: boolean;
 }
 
+/**
+ * WHY one surface counts as covered — the provenance of a single decision.
+ * Reported so a repo can see what its coverage number actually rests on; a count
+ * whose derivation is invisible is exactly the failure this detector had.
+ */
+export interface CoverageDecision {
+  readonly surface: Surface;
+  readonly evidence: CoverageEvidence;
+  /** The test file the (strongest) evidence came from. */
+  readonly by: string;
+}
+
 /** One tier's split of the considered surfaces — covered by THAT tier, or not. */
 export interface CoverageTier {
   readonly covered: readonly Surface[];
   readonly untested: readonly Surface[];
+  /** One entry per `covered` surface, in the same order — how it was decided. */
+  readonly decisions: readonly CoverageDecision[];
 }
 
 export interface UntestedReport {
@@ -92,6 +124,12 @@ export interface UntestedReport {
   readonly untested: readonly Surface[];
   /** Surfaces explicitly opted out via `vigiles:ignore-test`. */
   readonly exempt: number;
+  /**
+   * How each covered surface was decided — the union tier's provenance, one
+   * entry per `covered` element. A coverage count whose derivation is invisible
+   * is what let a COMMENT confer coverage unnoticed; this is the visibility.
+   */
+  readonly decisions: readonly CoverageDecision[];
   /**
    * DETERMINISTIC coverage only — `*.harness.mjs` and `*.test.*`. Free,
    * millisecond, every-push. Answers "does this gate still catch what it claims?"
@@ -280,16 +318,11 @@ function discoverHooks(basePath: string, layout: PluginLayout): Surface[] {
   }));
 }
 
-interface TestFile {
-  readonly path: string;
-  readonly content: string;
-}
-
 function discoverTests(
   basePath: string,
   globs: readonly string[],
   ignore: string[],
-): TestFile[] {
+): PreparedTest[] {
   // `dot: true` so a colocated test under a DOT directory is found — most
   // loose skills live in `.claude/skills/<name>/`, so the eval the warning
   // suggests (`.claude/skills/<name>/<name>.eval.mjs`) is itself dot-pathed.
@@ -298,7 +331,9 @@ function discoverTests(
   // still discovered — so the surface looks untested even after the user adds
   // exactly the suggested file. DEFAULT_IGNORE still drops .git/node_modules/etc.
   const found = globSync([...globs], { cwd: basePath, ignore, dot: true });
-  return found.map((path) => ({ path, content: read(join(basePath, path)) }));
+  // Prepared ONCE per file (comment-strip + declaration parse), not once per
+  // (surface × file) pair — the matching below is quadratic by nature.
+  return found.map((path) => prepareTest(path, read(join(basePath, path))));
 }
 
 /** Colocated: a test inside a skill dir, or a name-prefixed sibling of an agent/hook. */
@@ -318,13 +353,25 @@ function isColocated(surface: Surface, testPath: string): boolean {
   );
 }
 
-function isCovered(surface: Surface, tests: readonly TestFile[]): boolean {
+/**
+ * The STRONGEST evidence any discovered test provides for this surface, or null.
+ * Strongest — not first-found — so a surface that is both name-mentioned and
+ * explicitly declared is reported as declared; otherwise the provenance summary
+ * would depend on glob order.
+ */
+function coverageOf(
+  surface: Surface,
+  tests: readonly PreparedTest[],
+): CoverageDecision | null {
+  let best: CoverageDecision | null = null;
   for (const t of tests) {
     if (t.path === surface.path) continue;
-    if (isColocated(surface, t.path)) return true;
-    if (surface.tokens.some((tok) => t.content.includes(tok))) return true;
+    const ev = evidenceFor(surface, t, isColocated(surface, t.path));
+    if (!ev) continue;
+    if (!best || isStronger(ev, best.evidence))
+      best = { surface, evidence: ev, by: t.path };
   }
-  return false;
+  return best;
 }
 
 /**
@@ -334,12 +381,12 @@ function isCovered(surface: Surface, tests: readonly TestFile[]): boolean {
  * so a custom `testGlobs` (a promptfoo suite, a home-grown loop) still lands in a
  * tier instead of silently disappearing from the split.
  */
-function partitionTests(tests: readonly TestFile[]): {
-  harness: TestFile[];
-  evals: TestFile[];
+function partitionTests(tests: readonly PreparedTest[]): {
+  harness: PreparedTest[];
+  evals: PreparedTest[];
 } {
-  const harness: TestFile[] = [];
-  const evals: TestFile[] = [];
+  const harness: PreparedTest[] = [];
+  const evals: PreparedTest[] = [];
   for (const t of tests)
     (t.path.endsWith(EVAL_SUFFIX) ? evals : harness).push(t);
   return { harness, evals };
@@ -348,13 +395,21 @@ function partitionTests(tests: readonly TestFile[]): {
 /** Split the considered surfaces by whether ONE tier's tests cover them. */
 function tierOf(
   considered: readonly Surface[],
-  tests: readonly TestFile[],
+  tests: readonly PreparedTest[],
 ): CoverageTier {
   const covered: Surface[] = [];
   const untested: Surface[] = [];
-  for (const s of considered)
-    (isCovered(s, tests) ? covered : untested).push(s);
-  return { covered, untested };
+  const decisions: CoverageDecision[] = [];
+  for (const s of considered) {
+    const decision = coverageOf(s, tests);
+    if (decision) {
+      covered.push(s);
+      decisions.push(decision);
+    } else {
+      untested.push(s);
+    }
+  }
+  return { covered, untested, decisions };
 }
 
 // ---------------------------------------------------------------------------
@@ -403,6 +458,7 @@ export function findUntestedSurfaces(
     covered: union.covered,
     untested: union.untested,
     exempt,
+    decisions: union.decisions,
     harness: tierOf(considered, split.harness),
     evals: tierOf(considered, split.evals),
   };
@@ -420,11 +476,22 @@ export function suggestedTestPath(surface: Surface): string {
   return `${prefix}${surface.name}.harness.mjs`;
 }
 
+/** Tally the union tier's coverage decisions by how each was established. */
+export function coverageEvidenceCounts(report: UntestedReport): EvidenceCounts {
+  return countEvidence(report.decisions);
+}
+
 /** Format an untested-surface report as human-readable text. */
 export function formatUntestedReport(report: UntestedReport): string {
+  // Every coverage number is printed WITH its provenance. "28 covered" and
+  // "28 covered, all of it a name appearing in a file" are different facts, and
+  // the detector used to be able to say only the first.
+  const provenance = formatEvidence(coverageEvidenceCounts(report));
   if (report.untested.length === 0) {
     const tail = report.exempt > 0 ? ` (${String(report.exempt)} exempt)` : "";
-    const ok = `✓ all ${String(report.total)} surface(s) have a test or eval${tail}`;
+    const ok =
+      `✓ all ${String(report.total)} surface(s) have a test or eval${tail}` +
+      (provenance ? `\n  ${provenance}` : "");
     // A clean UNION can still hide a whole unanswered question: every surface may
     // have a deterministic harness and NOTHING may ever have measured that a
     // skill fires. The gate is unchanged (still the union), but the ✓ must not
@@ -451,12 +518,15 @@ export function formatUntestedReport(report: UntestedReport): string {
       `${String(report.evals.untested.length)} whose firing was never measured ` +
       `(needs a real model, run on a schedule).`,
   );
+  // What the surfaces that DID pass are resting on. A repo whose coverage is
+  // entirely name-mentions should be able to see that about itself.
+  if (provenance) lines.push(`  ${provenance}`);
   // Already testing these another way (a promptfoo suite, a home-grown evals
   // file)? Point `testGlobs` at it so it counts toward coverage (issue #113).
   lines.push(
     `  Testing these another way (promptfoo / a home-grown eval loop)? Add its ` +
-      `files to \`testGlobs\` in .vigilesrc.json — a discovered test that names a ` +
-      `surface's path counts. See docs/rules/untested-skill.md.`,
+      `files to \`testGlobs\` in .vigilesrc.json, and mark what it covers with ` +
+      `\`${COVERS_MARKER} <surface>\`. See docs/rules/untested-skill.md.`,
   );
   return lines.join("\n");
 }

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -15,7 +15,13 @@
 // helpers — stay out of the public surface, the api reports, and the docs site.
 // (vigiles's own tests import those from the source modules directly.)
 
-// --- unit tier: runHook ---
+// --- unit tier: runScript (the primitive) + runHook (it, plus a decision) ---
+// `runScript` runs any program and reports what it DID (exit, both streams,
+// writes, egress). `runHook` is that plus the hook protocol: event to stdin,
+// exit code to allow/deny. Testing a plain helper script? Reach for runScript —
+// its result carries no `decision`, because a script does not have one.
+export { runScript } from "./run-script.js";
+export type { RunScriptOptions, ScriptRunResult } from "./run-script.js";
 export { runHook, propertyHook } from "./run-hook.js";
 export type {
   HookRunResult,

--- a/src/unit.ts
+++ b/src/unit.ts
@@ -29,6 +29,10 @@ export type {
   RunHookOptions,
   HookPropertyResult,
 } from "./run-hook.js";
+// The PRIMITIVE beneath runHook: run any program, get what it did. A hook has a
+// DECISION, a script has EFFECTS — two questions, so two result types.
+export { runScript } from "./run-script.js";
+export type { RunScriptOptions, ScriptRunResult } from "./run-script.js";
 // The check vocabulary is part of the base surface (pure, no capability). Its
 // `hookFired` check supersedes the legacy boolean predicate of the same name.
 export * from "./check.js";

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -72,6 +72,7 @@ export default defineConfig({
         "src/eval-lock.ts",
         "src/stats.ts",
         "src/run-hook.ts",
+        "src/run-script.ts",
         "src/mock-model.ts",
         "src/plugin-loader.ts",
         "src/judge.ts",


### PR DESCRIPTION
## The defect

`Tested` collapsed two different things into one number, and its finding text said so out loud:

```
✗ Tested   67  ██████████████░░░░░░░░  · advisory (not graded)
     └ 11 surfaces with no vigiles test/eval
```

A harness and an eval differ on three axes at once, and none of them is cosmetic:

| | harness (`*.harness.mjs`, `*.test.*`) | eval (`*.eval.mjs`) |
|---|---|---|
| **cost** | free | paid model calls |
| **cadence** | every push | scheduled |
| **question answered** | does this gate still catch what it claims? | **does this skill fire at all?** |

So a repo with complete deterministic coverage and no evals scored *identically* to a repo with neither — two very different positions. And the prescription, "add a test/eval", spans three orders of magnitude in cost without saying which one you need.

## The sharp part

The same report already **states the distinction in prose**, one line below the ring it discards it in:

> ℹ Do your 37 skills actually fire? The deterministic read can't tell — run `audit` interactively to measure, or test with `measureTriggerRate` (vigiles/testing).

The tool names the difference in a sentence and folds it into one score anyway. That is the pattern this product exists to find in other people's repositories, sitting in ours. (Same failure mode as #126 and #128 from the same dogfooding session: a rule written in prose, not built into a mechanism.)

## What this does

**1. Splits at discovery, not at display.** `findUntestedSurfaces` ran one `DEFAULT_TEST_GLOBS` pass and marked each surface covered/untested — the distinction was destroyed at discovery, so nothing downstream could recover it. It now partitions the discovered tests by suffix and returns a per-tier `CoverageTier` alongside the *unchanged* union `covered`/`untested`. The browser-safe twin (`test-coverage-files.ts`) mirrors it, values re-declared rather than imported so it stays node-free.

**2. Two rings.**
- `Tested` — deterministic harness coverage. Same advisory stance, same per-item weight, no change to grading.
- `Evaluated` — real-model eval coverage. Advisory.

**3. `Evaluated` has THREE states, not two.** This is the core of the change:

| state | meaning |
|---|---|
| a number | measured — evals exist here, this is their coverage |
| `0` | the firing tier **ran** this session and nothing covers these surfaces — an earned zero |
| `not measured` | **nobody asked.** No eval on disk *and* the executing checks were skipped (headless / `--json` / a remembered no) |

Collapsing the third into the first reports *the absence of a check* as *the result of a check*. The signal already existed — the audit prints `Executing checks (safety battery · live MCP · skill firing) skipped` — and is now threaded into the ring instead of being thrown away. In that state the ring **nudges with the command**, rather than leaving it to a line of prose at the tail of a long report:

```
? Evaluated  not measured                         · advisory (not graded)
     └ 18 surfaces whose firing was never measured; not measured — run
       `npx vigiles audit` interactively to measure, or add a `*.eval.mjs`
       (`measureTriggerRate`, vigiles/testing)
```

`not measured` also gets its own glyph (`?`), distinct from n/a (`○`) and from a measured failure (`✗`): an unasked question is neither.

**4. Findings name what is missing, separately.** `"N surfaces with no vigiles harness (deterministic, free)"` and `"M surfaces whose firing was never measured"` are different sentences leading to different work. The slash is gone; a test asserts no finding contains `test/eval`.

**5. Report, HTML and JSON carry both.** Six rings render (grid widened to 6), `CategoryScore.notMeasured` is mirrored into `packages/report-view/src/schema.ts` with a shared `categoryScoreLabel`, and `inventory` gains additive `untestedHarness` / `unevaluated`. Schema version unchanged — every new field is optional.

## What I did NOT change

**Grade weighting.** Both rings are advisory; neither enters `reportDeductions`, and `computeIntegrityScore` is untouched. Verified two ways:

- A test loops all three `Evaluated` states × both `firingMeasured` values and asserts `overall` and `grade` are identical to the clean baseline.
- Empirically, `vigiles audit` on this repo, built from `main` and from this branch:

| | main | this branch |
|---|---|---|
| grade | **A (100/100)** | **A (100/100)** |
| Tested | 67 — "11 surfaces with no vigiles test/eval" | 58 — "14 surfaces with no vigiles harness (deterministic, free)" |
| Evaluated | — | 22 — "18 surfaces whose firing was never measured" |

The diagnostic rings move (and are more honest: three surfaces were "covered" only by an eval, which is not a harness). The letter grade does not.

Also unchanged: the lint path (`untested-skill` / `-subagent` / `-hook`) still gates on the union, so no CI result flips; the `W_UNTESTED` weight; the read-vs-run consent flow (`resolveExecution` now takes the decision `decideExecute` already produced instead of recomputing it).

## Tests — and proof they aren't vacuous

Every branch, both directions, colocated vitest in the existing style. The load-bearing assertion is that `not measured` stays distinguishable from `0` **in the report object and in the rendered output**:

- `audit-score.test.ts` — the same `ScanReport` scored with and without `firingMeasured`: `null` + `notMeasured` vs a literal `0`; labels differ; terminal render keeps `not measured` / `n/a` / `0` apart, each with its own glyph; the nudge names the command.
- `audit-report.test.ts` — the JSON distinguishes them and the two serialize differently; wire-shape pin extended to the new optional keys.
- `audit-html.test.ts` — the distinction survives injection into the HTML template.
- `test-coverage.test.ts` — tiers disagree at discovery; a `*.test.ts` is a harness and never an eval; the formatter names both gaps with their costs.

**Non-vacuity, by planting the defect back** (baseline for the four suites: 65 passed / 0 failed):

| planted defect | result |
|---|---|
| collapse `not measured` into a scored `0` | **5 failed** / 60 passed |
| erase the tier split at discovery (both tiers = union) | **3 failed** / 62 passed |
| `Tested` reads the union again + restore the `test/eval` slash | **2 failed** / 63 passed |

Restored: 65 passed / 0 failed.

## Checks

- `npx tsc --noEmit` — clean.
- `npm run lint` — 0 errors (196 pre-existing warnings, none in touched files).
- `npx vitest run` (all projects) — **2408 passed, 2 failed**. Both failures are `core/spec.test.ts` pylint cases, reproduced identically on unmodified `main` in this environment (no `pylint` installed) — pre-existing, unrelated.
- `npx prettier --write` run on every touched file; `npm run fmt:check` clean apart from `site/checks/*/index.html`, which are gitignored build artifacts that already fail on `main`.

Docs updated: `docs/cli.md` (the ring list, sample output, and a section on the two tiers + the three states), `README.md`, `docs/non-js-harnesses.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012omt6sirxNMyZN2x5RhK2u

---
_Generated by [Claude Code](https://claude.ai/code/session_012omt6sirxNMyZN2x5RhK2u)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Features**
- split Tested into Tested + Evaluated, with a `not measured` state
- say so when a repo's vigiles skills are unreachable
- split runScript out as the primitive under runHook
- declare the plugin in the repo, turning silent absence into a prompt

**Fixes**
- a clean union must not read as 'firing verified'
- `Tested` measured a STRING, not a test
- key the browser-test prebundle to dist, so a stale cache can't lie
- make the parity-fixture generator emit prettier-clean JSON
- refuse unknown flags; `<verb> --help`; nothing-to-audit ≠ grade F
- mirror the split inventory fields, and let CI see the project
- a project plugin declaration is not an install

**Docs**
- the audit grades six categories, not five

**Tests**
- regenerate the browser-parity fixture for the Evaluated ring
<!-- vigiles:pr-summary:end -->





