### PR TITLE
fix(audit,testing): three dogfood defects — a heading, a salvage, and a check count

### DIFF
--- a/api-surface/vigiles-testing.api.md
+++ b/api-surface/vigiles-testing.api.md
@@ -715,6 +715,9 @@ export function readBaseline(path: string): BaselineFile | null;
 export function received(matcher: string | RegExp): Check<Trace>;
 
 // @public
+export function recordCheck(n?: number): void;
+
+// @public
 export function reliable(report: EvalReport, arm: string, metric: string): boolean;
 
 // @public

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -62,11 +62,22 @@ deliberately distinct from a harness that was audited and scored badly (exit
 pointed at the wrong directory".
 
 `vigiles test` / `vigiles eval` run scripts in JS **or** TS and report each as
-**pass / skip / fail** — a tier that can't run (e.g. deterministic with no
-`claude`) reports a loud `⊘ SKIPPED`, tallied separately, never a fake green.
+**pass / skip / 0 checks / fail** — a tier that can't run (e.g. deterministic with
+no `claude`) reports a loud `⊘ SKIPPED`, tallied separately, never a fake green.
 Unit-tier `runHook` tests need no `claude` and always run. A skip passes by
 default; in a CI job that **asserts** the capability is present, add `--no-skip`
 so a skipped tier **fails** (a green-with-skips is untested surface).
+
+**A file that verified nothing says so: `∅ … 0 CHECKS`.** Exit codes answer "did
+it fail?", never "did it do anything?", so a script that ran NOTHING used to print
+the same `✓` as one that ran and passed — the classic shape being a file that
+_defines_ tests (`export default { … }`) and never calls them. Each tier now
+records its own runs, and the runner reports a clean exit with **zero** recorded
+checks as its own state. It is **not** a failure (the exit code is unchanged), and
+a script that never imports `vigiles/testing` cannot report at all, so it stays a
+plain pass — silence is the legacy branch, never a verdict. If your harness
+asserts some other way (`node:assert`, a runner's `expect`), call `recordCheck()`
+from `vigiles/testing` so those count.
 
 **`vigiles eval` asks before fanning out.** A bare `vigiles eval` with no target
 discovers every `*.eval.*` in the tree, and each one runs the **real model on your

--- a/docs/harness-testing.md
+++ b/docs/harness-testing.md
@@ -394,6 +394,21 @@ vigiles eval --trials=6 # *.eval.mjs — real model, on a keyed job only
 A skip is **loud** (`⊘ SKIPPED`, tallied separately), never a silent green; pass
 `--no-skip` in a job that asserts the capability is present.
 
+So is a file that **verified nothing**: a script that exits clean having recorded
+**zero** checks reports `∅ … 0 CHECKS`, tallied separately from `passed`. The
+shape this catches is a harness that _defines_ tests and never calls them —
+
+```js
+export default { "never runs": () => assert.equal(1, 2) }; // exits 0, asserts nothing
+```
+
+— which an exit code alone cannot tell from a real pass. The tiers (`runHook`,
+`runHarnessTest`, `runEval`, the in-process compiled-hook assertions) count
+themselves, so an ordinary harness needs no extra call; if yours asserts some
+other way, `recordCheck()` from `vigiles/testing` reports those. It is **not** a
+failure — it never turns a build red — and a script that doesn't import
+`vigiles/testing` cannot report at all, so it stays a plain pass.
+
 **The composite action** encapsulates the per-tier setup (bubblewrap, the egress
 connector) so you don't re-derive it:
 

--- a/docs/rules/frontmatter-valid.md
+++ b/docs/rules/frontmatter-valid.md
@@ -39,6 +39,15 @@ description: a value with: a colon    # ⚠ invalid plain scalar (may still load
 The file's other fields are still **salvaged** by the reader, so the rest of
 `scan`/`lint` keeps working on a malformed file.
 
+**Except the tool contract, which is not salvaged for SCORING.** A salvaged
+`allowed-tools:` / `tools:` is a regex guess at a block a strict loader rejects, so
+`vigiles audit` treats a malformed unit's contract as **inherits-all** rather than
+grading the guess — see
+[lethal-trifecta](lethal-trifecta.md#a-contract-that-doesnt-parse-is-not-a-contract).
+The live PreToolUse rail still uses the salvage (something to enforce beats
+nothing); only the score refuses it. So a broken block can cost a grade even when
+the fields "look fine", and fixing the YAML restores both.
+
 ## Configuration
 
 ```json

--- a/docs/rules/lethal-trifecta.md
+++ b/docs/rules/lethal-trifecta.md
@@ -48,6 +48,28 @@ The two severities describe **how the unit got there**, not how much it costs: a
 inherits-all unit is graded exactly like an explicit one (see below), because it
 is strictly the worse of the two.
 
+### A contract that doesn't parse is not a contract
+
+If a unit's frontmatter **exists but isn't valid YAML**
+([frontmatter-valid](frontmatter-valid.md)), its declared tool list is read as
+**inherits-all** — the advisory case — and the finding says so:
+
+```
+⚠ skill broken: Frontmatter is not valid YAML, so the declared tool list could not
+  be read — a strict loader rejects the block, and a regex salvage of it is a guess,
+  not a contract. Scored as INHERITS-ALL (every capability) …
+```
+
+vigiles's shared frontmatter reader is deliberately lenient: on a block js-yaml
+rejects it falls back to a regex salvage, so the live PreToolUse rail still has
+something to enforce and the file's other fields keep working. That is right for a
+rail and wrong for a **score** — a unit whose contract a strict loader rejects was
+being graded as though it had declared exactly the narrow list its author meant, so
+the Safety ring read **better than the truth**. Same conservative direction as
+grading inherits-all like an explicit all-three: presence of a declaration is not
+enforcement of it. **Fix the YAML and the declared list counts again** — the finding
+disappears the moment the block parses.
+
 ## In `vigiles audit`: graded, but a **ding — not a fail**
 
 A trifecta finding is a **capability PATTERN with no exploit code**, not a

--- a/docs/rules/skill-resource-resolves.md
+++ b/docs/rules/skill-resource-resolves.md
@@ -51,6 +51,23 @@ shape than a bare backtick span, but an example link — "For example, see
 `[a report](assets/example.pdf)`" — is still a prose illustration, not a real dead
 ref, so the same prose gate applies to both.
 
+**A heading counts as a directive.** The verb gate reads prose, and a heading is
+not prose — it is the section's label — so the most common way a skill points at
+its own script went unchecked:
+
+```md
+## 🏗 START WITH THE MECHANICAL LEG — `scripts/structure.mjs`
+```
+
+Measured on a real skill whose `structure.mjs` sits at the skill **root**, not
+under `scripts/`: that line yielded nothing, while rewriting it to "Run the
+mechanical leg" — same file, same missing target — reported it correctly. The
+tool's answer depended on the author's choice of verb. An ATX heading naming a
+bundle path is now treated like an explicit "run …". The illustrative-cue veto
+still applies (`## Examples: …` stays skipped), and the wider net stops there: a
+mid-paragraph mention with no directive is still not checked, because flagging
+every backticked bundle path is what cries wolf on teaching skills.
+
 The detector prefers **missing a real ref over a false positive** — a noisy
 resource check would teach users to ignore it. A skill whose body is inherently
 full of illustrative bundle-path examples (a skill-authoring tutorial) can opt out

--- a/docs/testing-matrix.md
+++ b/docs/testing-matrix.md
@@ -172,6 +172,13 @@ repo runs the egress tier under `e2e`, not `harness`), but in a CI job that
 skipped tier **fails**: a green-with-skips is itself untested surface. A standalone
 script emits a skip with `skip(reason)` from `vigiles/testing`.
 
+**And so is a file that verified nothing.** A script that exits clean having
+recorded **zero** checks reports `∅ … 0 CHECKS`, tallied apart from `passed` — the
+shape being a harness that _defines_ tests (`export default { … }`) and never calls
+them, which no exit code can distinguish from a pass. Non-fatal by design: it never
+turns a build red, and a script that doesn't import `vigiles/testing` cannot report,
+so it stays a plain pass. `recordCheck()` reports assertions made another way.
+
 ## See also
 
 - [`docs/harness-testing.md`](harness-testing.md) — the full guide (four layers:

--- a/examples/harness/oh-my-claudecode-egress.harness.mjs
+++ b/examples/harness/oh-my-claudecode-egress.harness.mjs
@@ -23,13 +23,18 @@ import { fileURLToPath } from "node:url";
 
 import { runHook } from "../../dist/run-hook.js";
 import { sandboxAvailable } from "../../dist/sandbox.js";
-import { assertNoEgress, assertEgressOnly } from "../../dist/harness-assert.js";
+import {
+  assertNoEgress,
+  assertEgressOnly,
+  skip,
+} from "../../dist/harness-assert.js";
 
+// `skip()`, not `exit(0)`: this file used to report itself SKIPPED in prose and
+// then exit clean, which the runner could only read as a pass — the same
+// "verified nothing, looked green" shape the ∅ state exists to surface. It was
+// caught by that state on the repo's own examples the day it landed.
 if (!sandboxAvailable()) {
-  console.log(
-    "skip: no working bubblewrap sandbox (can't confine → can't record egress)",
-  );
-  process.exit(0);
+  skip("no working bubblewrap sandbox (can't confine → can't record egress)");
 }
 
 const ROOT = fileURLToPath(

--- a/src/adapters/claude-code/run-scripts.test.ts
+++ b/src/adapters/claude-code/run-scripts.test.ts
@@ -6,7 +6,8 @@
 import { test } from "vitest";
 import assert from "node:assert/strict";
 import { writeFileSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 
 import {
   discoverScripts,
@@ -18,6 +19,8 @@ import {
   scriptGlob,
   SCRIPT_EXTS,
   decideRunScripts,
+  statusFor,
+  SKIP_EXIT_CODE,
 } from "./run-scripts.js";
 import { makeTmpDir, cleanupTmpDir } from "../../core/test-utils.js";
 
@@ -168,6 +171,110 @@ test("runScripts surfaces an error code for an unrunnable TS script", () => {
   } finally {
     cleanupTmpDir(dir);
   }
+});
+
+// --- the fourth state: ran, verified nothing (dogfood 2026-08-08) -------------
+//
+// 🔴 The defect. `statusForCode` knew exit codes and nothing else, so a file that
+// ran NOTHING printed the same `✓ 1 passed` as one that ran and passed. Measured
+// on `export default { "never runs": () => assert.equal(1, 2) }` — a false
+// assertion, never called, reported green. A consumer repo hit it and now
+// hand-copies a warning into every new harness header, eight of them, because the
+// runner could not enforce it.
+
+test("statusFor: 0 reported checks is its own state, and silence is NOT zero", () => {
+  assert.equal(statusFor(0, 3), "pass");
+  assert.equal(statusFor(0, 0), "vacuous", "ran clean, verified nothing");
+  assert.equal(
+    statusFor(0, undefined),
+    "pass",
+    "no report at all is the legacy branch — 'nobody counted' is not 'counted zero'",
+  );
+  // The other two states are unchanged, count or no count.
+  assert.equal(statusFor(SKIP_EXIT_CODE, undefined), "skip");
+  assert.equal(statusFor(SKIP_EXIT_CODE, 0), "skip");
+  assert.equal(statusFor(1, 5), "fail");
+  assert.equal(statusFor(1, 0), "fail");
+});
+
+/** The built `check-count.js`, as a URL a spawned fixture script can import. */
+function countModuleUrl(): string {
+  return pathToFileURL(resolve(process.cwd(), "dist/check-count.js")).href;
+}
+
+test("runScripts reports 0 checks for a script that loads the API and runs nothing", () => {
+  const dir = makeTmpDir("run-scripts-vacuous");
+  try {
+    const mod = JSON.stringify(countModuleUrl());
+    // The incident, reproduced: tests DEFINED, nothing called. Exits 0.
+    writeFileSync(
+      join(dir, "vacuous.harness.mjs"),
+      `import { recordCheck } from ${mod};\n` +
+        `export default { "never runs": () => { recordCheck(); } };\n`,
+    );
+    // The control: same import, actually calls it.
+    writeFileSync(
+      join(dir, "real.harness.mjs"),
+      `import { recordCheck } from ${mod};\nrecordCheck();\nrecordCheck();\n`,
+    );
+    // The legacy shape: never touches vigiles, so it cannot report. Unchanged.
+    writeFileSync(join(dir, "legacy.harness.mjs"), "process.exit(0);\n");
+
+    const r = runScripts(
+      ["vacuous.harness.mjs", "real.harness.mjs", "legacy.harness.mjs"],
+      dir,
+    );
+    assert.deepEqual(
+      r.map((x) => [x.status, x.checks]),
+      [
+        ["vacuous", 0],
+        ["pass", 2],
+        ["pass", undefined],
+      ],
+    );
+    // …and it must not turn CI red: harnesses in the wild predate the counter.
+    assert.equal(anyFailed(r), false);
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});
+
+test("a script's spawned CHILD does not inherit the report path", () => {
+  // A harness spawns processes for a living. A child that inherited the count
+  // path would write ITS count — usually zero — over the parent's, reporting a
+  // sub-process's activity as the file's. The variable is read once and dropped,
+  // so the child cannot see it at all. Asserted from INSIDE the child, because
+  // spawnSync makes the parent write last, which would mask the bug end-to-end.
+  const dir = makeTmpDir("run-scripts-nested");
+  try {
+    const mod = JSON.stringify(countModuleUrl());
+    writeFileSync(
+      join(dir, "parent.harness.mjs"),
+      `import { recordCheck } from ${mod};\n` +
+        `import { spawnSync } from "node:child_process";\n` +
+        `recordCheck(4);\n` +
+        `const probe = "process.exit(process.env.VIGILES_CHECK_COUNT_FILE ? 3 : 0)";\n` +
+        `const r = spawnSync(process.execPath, ["-e", probe]);\n` +
+        `if (r.status !== 0) process.exit(9); // the child could see the path\n`,
+    );
+    const [r] = runScripts(["parent.harness.mjs"], dir);
+    assert.equal(r?.code, 0, "the spawned child must not see the report path");
+    assert.equal(r?.checks, 4, "the parent's own count is what gets reported");
+    assert.equal(r?.status, "pass");
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});
+
+test("formatScriptSummary shows a 0-check run as its own state, with the remedy", () => {
+  const out = formatScriptSummary([
+    { file: "a.mjs", code: 0, status: "pass", checks: 2 },
+    { file: "b.mjs", code: 0, status: "vacuous", checks: 0 },
+  ]);
+  assert.match(out, /∅ b\.mjs — 0 CHECKS/);
+  assert.doesNotMatch(out, /2 passed/); // NOT folded into the pass tally
+  assert.match(out, /1 passed, 1 with 0 checks\./);
+  assert.match(out, /recordCheck\(\)/); // the fix is named where it is read
 });
 
 test("formatScriptSummary tallies pass/skip/fail; skips are loud, not a pass", () => {

--- a/src/adapters/claude-code/run-scripts.ts
+++ b/src/adapters/claude-code/run-scripts.ts
@@ -11,16 +11,31 @@
  * also run standalone — the CLI just discovers, runs, and aggregates exit codes.
  */
 import { spawnSync } from "node:child_process";
-import { resolve } from "node:path";
-import { existsSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { globSync } from "glob";
+import { CHECK_COUNT_ENV } from "../../check-count.js";
 
-export type ScriptStatus = "pass" | "skip" | "fail";
+/**
+ * The outcome of running one script.
+ *
+ * `"vacuous"` — the script exited 0 and reported that it made ZERO checks. It
+ * neither passed nor failed: nothing was verified. See {@link statusFor}.
+ */
+export type ScriptStatus = "pass" | "skip" | "fail" | "vacuous";
 
 export interface ScriptRunResult {
   readonly file: string;
   readonly code: number;
   readonly status: ScriptStatus;
+  /**
+   * How many checks the script reported making, or `undefined` when it reported
+   * nothing at all — a script that never imports `vigiles/testing` has no way to
+   * report, and that silence is NOT a claim about it. `0` is a claim: the script
+   * loaded the library and used none of it.
+   */
+  readonly checks?: number;
 }
 
 /**
@@ -31,10 +46,38 @@ export interface ScriptRunResult {
  */
 export const SKIP_EXIT_CODE = 77;
 
-function statusForCode(code: number): ScriptStatus {
-  if (code === 0) return "pass";
+/**
+ * Classify one script's run from its exit code and its reported check count.
+ *
+ * 🔴 THE FOURTH STATE, AND WHY. Exit codes answer "did it fail?", never "did it
+ * do anything?". Measured 2026-08-08: a file whose whole body is
+ * `export default { "never runs": () => assert.equal(1, 2) }` imports fine,
+ * exits 0, and printed `✓ … 1 passed` — a false assertion, never called,
+ * reported as a pass. A consumer repo hit exactly that and now hand-copies a
+ * warning into every new harness header, because the runner could not enforce
+ * it: eight harnesses resting on a comment.
+ *
+ * So a run that ends clean having recorded ZERO checks is `"vacuous"` — its own
+ * visible state, not folded into `passed`, the same way a skip is not.
+ *
+ * NOT A FAILURE, deliberately. Harnesses in the wild predate the counter, and a
+ * tool that turned CI red on the release that taught it a new word would be
+ * punishing people for upgrading. It is loud and it is not fatal.
+ *
+ * AND SILENCE IS NOT ZERO. `checks === undefined` means the script never
+ * reported — it may not import `vigiles/testing` at all — so it stays a plain
+ * `pass`, exactly as before. Only a script that loaded the library and used
+ * none of it says zero. This is the `undefined`-vs-`[]` distinction
+ * `assertNoWrite` already draws: "nobody looked" must not read as "nothing
+ * happened".
+ */
+export function statusFor(
+  code: number,
+  checks: number | undefined,
+): ScriptStatus {
   if (code === SKIP_EXIT_CODE) return "skip";
-  return "fail";
+  if (code !== 0) return "fail";
+  return checks === 0 ? "vacuous" : "pass";
 }
 
 /** Filename extensions accepted for harness/eval scripts (JS and TS). */
@@ -123,9 +166,33 @@ export function discoverScripts(
 }
 
 /**
+ * The count a script left behind, or `undefined` if it left none (it never
+ * imported `vigiles/testing`, or died before its exit handler). Anything that
+ * isn't a non-negative integer is treated as no report — a corrupt scratch file
+ * must not invent a verdict.
+ */
+function readCheckCount(path: string): number | undefined {
+  if (!existsSync(path)) return undefined;
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8").trim();
+  } catch {
+    return undefined;
+  }
+  if (!/^\d+$/.test(raw)) return undefined;
+  return Number(raw);
+}
+
+/**
  * Run each script as `node <file>`, inheriting stdio so the script's own report
  * streams to the console. `env` is merged over `process.env` for every child
- * (e.g. `VIGILES_TRIALS`). Returns the per-file exit codes.
+ * (e.g. `VIGILES_TRIALS`). Returns the per-file exit codes + check counts.
+ *
+ * Each child is handed its OWN scratch path in `VIGILES_CHECK_COUNT_ENV`, which
+ * `vigiles/testing` writes its check count to on exit — the channel that makes
+ * "ran nothing" distinguishable from "ran and passed" (see check-count.ts). It
+ * has to be a file: stdio is inherited so the script's report streams live,
+ * which leaves no stream to parse.
  */
 export function runScripts(
   files: readonly string[],
@@ -134,27 +201,38 @@ export function runScripts(
 ): ScriptRunResult[] {
   const caps = detectNodeCaps(cwd);
   const results: ScriptRunResult[] = [];
-  for (const file of files) {
-    let argv: string[];
-    try {
-      argv = interpreterArgs(file, caps);
-    } catch (e) {
-      console.error(`✗ ${file}: ${(e as Error).message}`);
-      results.push({ file, code: 1, status: "fail" });
-      continue;
-    }
-    const res = spawnSync("node", argv, {
-      cwd,
-      stdio: "inherit",
-      env: { ...process.env, ...env },
+  const countDir = mkdtempSync(join(tmpdir(), "vigiles-checks-"));
+  try {
+    files.forEach((file, i) => {
+      let argv: string[];
+      try {
+        argv = interpreterArgs(file, caps);
+      } catch (e) {
+        console.error(`✗ ${file}: ${(e as Error).message}`);
+        results.push({ file, code: 1, status: "fail" });
+        return;
+      }
+      const countFile = join(countDir, `${String(i)}.count`);
+      const res = spawnSync("node", argv, {
+        cwd,
+        stdio: "inherit",
+        env: { ...process.env, ...env, [CHECK_COUNT_ENV]: countFile },
+      });
+      const code = res.status ?? 1;
+      const checks = readCheckCount(countFile);
+      results.push({ file, code, status: statusFor(code, checks), checks });
     });
-    const code = res.status ?? 1;
-    results.push({ file, code, status: statusForCode(code) });
+  } finally {
+    rmSync(countDir, { recursive: true, force: true });
   }
   return results;
 }
 
-/** Whether any script FAILED (a skip is not a failure). */
+/**
+ * Whether any script FAILED. Neither a skip nor a vacuous run counts: the first
+ * declined to run, the second ran and verified nothing, and neither is evidence
+ * that anything is broken. Both are visible in the summary instead.
+ */
 export function anyFailed(results: readonly ScriptRunResult[]): boolean {
   return results.some((r) => r.status === "fail");
 }
@@ -211,23 +289,39 @@ const MARK: Record<ScriptStatus, string> = {
   pass: "✓",
   skip: "⊘",
   fail: "✗",
+  vacuous: "∅",
 };
 
-/** One line per file + an explicit pass/skip/fail tally. Skips are SHOWN, never
- * folded into "passed" — a `⊘ SKIPPED` is loud, not a silent green. */
+/** One line per file + an explicit pass/skip/vacuous/fail tally. Skips and
+ * vacuous runs are SHOWN, never folded into "passed" — a `⊘ SKIPPED` is loud,
+ * not a silent green, and so is a file that verified nothing. */
 export function formatScriptSummary(
   results: readonly ScriptRunResult[],
 ): string {
   const lines = results.map((r) => {
     if (r.status === "skip") return `  ⊘ ${r.file} — SKIPPED`;
     if (r.status === "fail") return `  ✗ ${r.file} (exit ${String(r.code)})`;
+    if (r.status === "vacuous") {
+      return `  ${MARK.vacuous} ${r.file} — 0 CHECKS (it ran clean and verified nothing)`;
+    }
     return `  ${MARK.pass} ${r.file}`;
   });
   const n = (s: ScriptStatus): number =>
     results.filter((r) => r.status === s).length;
   const parts = [`${String(n("pass"))} passed`];
   if (n("skip") > 0) parts.push(`${String(n("skip"))} skipped`);
+  if (n("vacuous") > 0) parts.push(`${String(n("vacuous"))} with 0 checks`);
   if (n("fail") > 0) parts.push(`${String(n("fail"))} failed`);
   lines.push(`\n${parts.join(", ")}.`);
+  // Name the remedy where it's read, once — the usual cause is a file that
+  // DEFINES tests and never calls them, and the usual second cause is a harness
+  // asserting some other way, which the runner cannot see.
+  if (n("vacuous") > 0) {
+    lines.push(
+      `  ∅ = the file loaded vigiles/testing and used none of it. Either nothing ran ` +
+        `(an exported test object nobody calls), or it asserts another way — in which ` +
+        `case call recordCheck() from vigiles/testing so those count.`,
+    );
+  }
   return lines.join("\n");
 }

--- a/src/check-count.test.ts
+++ b/src/check-count.test.ts
@@ -1,0 +1,129 @@
+/**
+ * The check counter — the channel a harness script reports through, so
+ * `vigiles test` can tell "ran nothing" from "ran and passed". Pure: the
+ * process bits (env, exit hook, file write) are injected.
+ */
+import { test, beforeEach } from "vitest";
+import assert from "node:assert/strict";
+
+import {
+  CHECK_COUNT_ENV,
+  recordCheck,
+  checksRecorded,
+  resetCheckCount,
+  armCheckReport,
+} from "./check-count.js";
+import { runHook } from "./run-hook.js";
+import { assertHookAllows } from "./harness-assert.js";
+import { defineHook, allow, tool } from "./hook.js";
+
+/** Capture what an armed report would write, without touching the disk. */
+function fakes(env: NodeJS.ProcessEnv): {
+  deps: Parameters<typeof armCheckReport>[0];
+  exit: () => void;
+  written: { path: string; contents: string }[];
+} {
+  const written: { path: string; contents: string }[] = [];
+  let onExit = (): void => {
+    throw new Error("never armed");
+  };
+  return {
+    deps: {
+      env,
+      onExit: (fn) => {
+        onExit = fn;
+      },
+      write: (path, contents) => written.push({ path, contents }),
+    },
+    exit: () => {
+      onExit();
+    },
+    written,
+  };
+}
+
+beforeEach(() => {
+  resetCheckCount();
+});
+
+test("counts, and reports the count at exit", () => {
+  const env: NodeJS.ProcessEnv = { [CHECK_COUNT_ENV]: "/tmp/x.count" };
+  const f = fakes(env);
+  assert.equal(armCheckReport(f.deps), true);
+  recordCheck();
+  recordCheck(2);
+  assert.equal(checksRecorded(), 3);
+  f.exit();
+  assert.deepEqual(f.written, [{ path: "/tmp/x.count", contents: "3" }]);
+});
+
+test("reports ZERO — the whole point, and the one thing silence must not mean", () => {
+  // A script that loaded the API and used none of it says so explicitly. The
+  // runner turns this into `∅ 0 CHECKS`; an absent file it leaves as a pass.
+  const f = fakes({ [CHECK_COUNT_ENV]: "/tmp/zero.count" });
+  armCheckReport(f.deps);
+  f.exit();
+  assert.deepEqual(f.written, [{ path: "/tmp/zero.count", contents: "0" }]);
+});
+
+test("does not arm when the runner asked for no count (a standalone `node x.mjs`)", () => {
+  const f = fakes({});
+  assert.equal(armCheckReport(f.deps), false);
+  assert.throws(() => {
+    f.exit();
+  }, /never armed/); // no exit hook was installed
+  assert.deepEqual(f.written, []);
+});
+
+test("drops the env var, so a spawned CHILD cannot report over its parent", () => {
+  // A harness spawns processes for a living. An inherited count path would let a
+  // child's exit overwrite the parent's count with its own — usually zero.
+  const env: NodeJS.ProcessEnv = { [CHECK_COUNT_ENV]: "/tmp/x.count" };
+  armCheckReport(fakes(env).deps);
+  assert.equal(env[CHECK_COUNT_ENV], undefined);
+});
+
+test("arms once — a second copy of vigiles in the process does not double-report", () => {
+  const env: NodeJS.ProcessEnv = { [CHECK_COUNT_ENV]: "/tmp/x.count" };
+  const first = fakes(env);
+  assert.equal(armCheckReport(first.deps), true);
+  const second = fakes({ [CHECK_COUNT_ENV]: "/tmp/other.count" });
+  assert.equal(armCheckReport(second.deps), false);
+});
+
+test("an unwritable report path never crashes a passing harness on the way out", () => {
+  const f = fakes({ [CHECK_COUNT_ENV]: "/nope/x.count" });
+  armCheckReport({
+    ...f.deps,
+    write: () => {
+      throw new Error("EACCES");
+    },
+  });
+  assert.doesNotThrow(() => {
+    f.exit();
+  });
+});
+
+// --- the tiers count themselves ---------------------------------------------
+//
+// A harness author should never have to call `recordCheck` for ordinary work; if
+// they did, the counter would measure diligence instead of activity, and the
+// first person to forget would be told their file verified nothing. Each tier
+// reports its own runs, so the count tracks what the script DID.
+
+test("runHook counts as a check", () => {
+  runHook("exit 0", { hook_event_name: "PreToolUse" });
+  assert.equal(checksRecorded(), 1);
+});
+
+test("an in-process compiled-hook assertion counts as a check", () => {
+  // The tier with no subprocess at all — without this, a harness that only tests
+  // compiled hooks would look like it did nothing.
+  const gate = defineHook({
+    on: "PreToolUse",
+    match: tool("Bash"),
+    decide: () => allow(),
+  });
+  assertHookAllows(gate, { tool_name: "Bash", tool_input: { command: "ls" } });
+  assert.equal(checksRecorded(), 1);
+});

--- a/src/check-count.ts
+++ b/src/check-count.ts
@@ -1,0 +1,145 @@
+/**
+ * vigiles — the CHECK COUNTER: the channel a `*.harness.*` / `*.eval.*` script
+ * uses to tell `vigiles test` / `vigiles eval` how much it actually did.
+ *
+ * 🔴 WHY THIS EXISTS. The runner knew exit codes and nothing else, so a script
+ * that ran NOTHING was indistinguishable from one that ran and passed. Measured
+ * 2026-08-08 — a file whose entire content is
+ *
+ *     export default { "never runs": () => assert.equal(1, 2) };
+ *
+ * imports cleanly, exits 0, and the runner printed `✓ … 1 passed`. The assertion
+ * inside it is false; it is never called, because nothing calls an exported
+ * object. Not hypothetical: a consumer repo hit it, and now hand-copies a warning
+ * into the header of every new harness file — "An earlier version exported a
+ * `tests` object; nothing ran and the runner printed ✓" — because the runner
+ * could not enforce it. Eight harnesses resting on a comment.
+ *
+ * This is the same distinction `assertNoWrite` already draws between `undefined`
+ * and `[]`: "nobody looked" and "nothing happened" must not print the same.
+ *
+ * HOW IT REPORTS. `vigiles test` puts a scratch path in `VIGILES_CHECK_COUNT_FILE`
+ * before spawning each script; on exit, a script that loaded this module writes
+ * its count there. A FILE, not stdout, because the runner inherits stdio so the
+ * script's own report streams live — there is no stream left to parse. Not an
+ * exit code either: those already carry pass/skip/fail, and overloading one would
+ * make a real failure ambiguous.
+ *
+ * WHAT COUNTS AS A CHECK: an observation vigiles can see the script make — a run
+ * through one of the tiers (`runHook`, `runHarnessTest`, `runEval`, …), an
+ * in-process compiled-hook decision asserted, or an explicit {@link recordCheck}
+ * from a harness that asserts some other way (`node:assert`, a runner's
+ * `expect`). Deliberately generous: the question this answers is "did this file
+ * exercise the harness at all", and a false "0 checks" against a script that
+ * genuinely tested something would be exactly the crying wolf the rest of the
+ * tool avoids.
+ *
+ * WHAT A MISSING COUNT MEANS: nothing at all. A script that never imports
+ * `vigiles/testing` cannot report, so the runner sees no file and treats it
+ * exactly as before — a plain pass. Silence is the legacy branch, never a
+ * verdict; only a count of literally zero is a finding. (The alternative —
+ * force-loading this module into every child with `node --import` so silence
+ * became impossible — was rejected: it would report `0` for a hand-rolled
+ * harness that spawns and asserts entirely on its own, which is a real and
+ * blameless way to write one.)
+ */
+import { writeFileSync } from "node:fs";
+
+/**
+ * Env var naming the file a script writes its check count to. Set per-script by
+ * the runner (`runScripts`), read once here at import.
+ */
+export const CHECK_COUNT_ENV = "VIGILES_CHECK_COUNT_FILE";
+
+/**
+ * The counter lives on the global registry, not in module scope, so two copies
+ * of vigiles loaded in one child (a global CLI plus a local dependency, say)
+ * share ONE count instead of one copy counting while the other reports zero.
+ * The cheap version of that bug is a false "this file verified nothing".
+ */
+const STATE = Symbol.for("vigiles.check-count");
+
+interface CountState {
+  count: number;
+  armed: boolean;
+}
+
+function state(): CountState {
+  const g = globalThis as unknown as Record<symbol, CountState | undefined>;
+  return (g[STATE] ??= { count: 0, armed: false });
+}
+
+/**
+ * Record `n` checks against this script's run.
+ *
+ * The tiers call it themselves, so an ordinary harness never needs to. Call it
+ * directly when you assert some OTHER way — `node:assert`, vitest's `expect`, a
+ * hand-rolled comparison — and want those visible to `vigiles test` instead of
+ * leaving it to conclude the file did nothing.
+ */
+export function recordCheck(n = 1): void {
+  state().count += n;
+}
+
+/** How many checks this process has recorded so far. */
+export function checksRecorded(): number {
+  return state().count;
+}
+
+/**
+ * Reset the counter AND the armed flag. For vigiles's own tests, which drive
+ * {@link armCheckReport} with fakes several times in one process; a harness
+ * script has no use for it.
+ */
+export function resetCheckCount(): void {
+  const s = state();
+  s.count = 0;
+  s.armed = false;
+}
+
+/** Injection seam for {@link armCheckReport} — the process bits it needs. */
+export interface CheckReportEnv {
+  readonly env: NodeJS.ProcessEnv;
+  readonly onExit: (fn: () => void) => void;
+  readonly write: (path: string, contents: string) => void;
+}
+
+/**
+ * Arm the exit-time report, returning whether it armed (i.e. whether the runner
+ * asked for a count). Pure except for the two effects it is handed.
+ *
+ * It DELETES the env var after reading it. A harness spawns child processes —
+ * that is its whole job — and a child inheriting the path would write ITS count
+ * over the parent's on exit, reporting a sub-process's activity as the file's.
+ * Reading the variable once and dropping it makes that unrepresentable rather
+ * than merely unlikely.
+ */
+export function armCheckReport(deps: CheckReportEnv): boolean {
+  const s = state();
+  if (s.armed) return false;
+  const file = deps.env[CHECK_COUNT_ENV];
+  if (file === undefined || file === "") return false;
+  // `Reflect.deleteProperty`, not `delete env[KEY]`: the key is a const, which
+  // the lint rules count as a dynamic delete.
+  Reflect.deleteProperty(deps.env, CHECK_COUNT_ENV);
+  s.armed = true;
+  deps.onExit(() => {
+    try {
+      deps.write(file, String(s.count));
+    } catch {
+      // An unwritable scratch path must never turn a passing harness into a
+      // crash on the way out. No count reported = the legacy branch = a pass.
+    }
+  });
+  return true;
+}
+
+armCheckReport({
+  env: process.env,
+  onExit: (fn) => {
+    process.on("exit", fn);
+  },
+  write: (path, contents) => {
+    writeFileSync(path, contents);
+  },
+});

--- a/src/core/lethal-trifecta.test.ts
+++ b/src/core/lethal-trifecta.test.ts
@@ -68,6 +68,49 @@ test("inherits-all (wildcard '*') → an advisory finding", () => {
   const finding = lethalTrifectaIssues(["*"], claudeCodeDialect);
   assert.notEqual(finding, null);
   assert.equal(finding?.severity, "advisory");
+  assert.match(finding?.message ?? "", /no explicit tools/);
+});
+
+test("an unreadable contract whose SALVAGE names all three legs still convicts", () => {
+  // One-directional: a salvage may make the verdict worse, never better. A real
+  // vendored plugin (madappgang's tester.md) is exactly this shape — malformed
+  // block, explicit all-three tool list — and demoting it to advisory would lose
+  // a genuine exfil path.
+  const finding = lethalTrifectaIssues(
+    ["Read", "WebSearch", "WebFetch"],
+    claudeCodeDialect,
+    { contractUnreadable: true },
+  );
+  assert.equal(finding?.severity, "hard");
+  assert.match(finding?.message ?? "", /Lethal trifecta/);
+  assert.match(finding?.message ?? "", /SALVAGED/);
+});
+
+test("an unreadable contract that reads NARROW falls back to inherits-all", () => {
+  // The defect itself: Read + Bash is private + exfil with no untrusted leg, so
+  // the salvage scored CLEAN. What a strict loader yields from that block is no
+  // contract at all — every leg.
+  const finding = lethalTrifectaIssues(["Read", "Bash"], claudeCodeDialect, {
+    contractUnreadable: true,
+  });
+  assert.equal(finding?.severity, "advisory");
+  assert.match(finding?.message ?? "", /not valid YAML/);
+  // …and the same list in a block that PARSES is still clean (Rule of Two).
+  assert.equal(lethalTrifectaIssues(["Read", "Bash"], claudeCodeDialect), null);
+});
+
+test("an UNREADABLE contract says so, instead of 'no explicit tools'", () => {
+  // The caller (scan-core) passes the wildcard when the frontmatter block exists
+  // but js-yaml rejects it. Same severity, different sentence: telling an author
+  // who plainly declared `allowed-tools:` that they declared no tools sends them
+  // hunting the wrong bug. Name the YAML, and name what it was scored as instead.
+  const finding = lethalTrifectaIssues(["*"], claudeCodeDialect, {
+    contractUnreadable: true,
+  });
+  assert.equal(finding?.severity, "advisory");
+  assert.match(finding?.message ?? "", /not valid YAML/);
+  assert.match(finding?.message ?? "", /INHERITS-ALL/);
+  assert.doesNotMatch(finding?.message ?? "", /no explicit tools/);
 });
 
 test("mcp__* servers classify per leg (github get_file=A, fetch=B, github PR=C)", () => {

--- a/src/core/lethal-trifecta.ts
+++ b/src/core/lethal-trifecta.ts
@@ -347,20 +347,51 @@ export function classifyTrifectaLegs(
   return { private: [...priv], untrusted: [...untrusted], exfil: [...exfil] };
 }
 
+/** Extra facts about HOW the contract was obtained, which change the verdict. */
+export interface TrifectaContext {
+  /**
+   * The unit's frontmatter block EXISTS but is not valid YAML.
+   *
+   * 🔴 WHY THE DETECTOR NEEDS TO KNOW. vigiles's frontmatter reader is
+   * deliberately lenient: on a block js-yaml rejects it regex-SALVAGES the
+   * fields, so the live PreToolUse rail still has something to enforce. Right
+   * for a rail, wrong for a score. Measured 2026-08-08:
+   * `readFrontmatter(bad).malformed` is `true` — the tool KNOWS the block is
+   * broken — while `frontmatterList(…, "allowed-tools")` on it still returns
+   * `["Read","Bash"]`, the narrow contract its author MEANT. A unit whose
+   * contract a strict loader rejects was therefore graded as though it had
+   * declared exactly that list, and scored CLEAN. Presence of a declaration is
+   * not enforcement of it — the product's own thesis, turned on the product.
+   *
+   * With this set, `tools` is read as a SALVAGE, not a contract: it can only make
+   * the verdict worse, never better. A salvaged list that names all three legs
+   * still fires `"hard"` (both readings of the file agree the unit holds them);
+   * anything less falls back to what a strict loader actually yields — no
+   * contract at all, i.e. inherits-all, which is the `"advisory"` finding.
+   */
+  readonly contractUnreadable?: boolean;
+}
+
 /**
  * Returns a {@link TrifectaFinding} ONLY when a unit holds all three legs, else
  * `null` (≤ 2 legs = safe by the Rule of Two).
  *
- * Two paths:
+ * Three paths:
  * - INHERITS-ALL (a wildcard `""`/`"*"`, or an EMPTY contract): inherits every
  *   tool → trivially all three legs → an `"advisory"` finding (the inherits-all
  *   stance: a footgun worth surfacing, not a declared exfil path).
  * - EXPLICIT: classify the named tools; emit a `"hard"` finding iff each of the
  *   three legs is non-empty.
+ * - UNREADABLE ({@link TrifectaContext.contractUnreadable}): the names came from
+ *   a salvage of a block a strict loader rejects. They can only make the verdict
+ *   WORSE — a salvaged all-three still fires `"hard"` — and anything short of
+ *   that falls back to what a strict loader really yields: no contract, i.e.
+ *   inherits-all, the `"advisory"` finding. Never the other way round.
  */
 export function lethalTrifectaIssues(
   tools: readonly string[],
   dialect: HarnessDialect,
+  ctx: TrifectaContext = {},
 ): TrifectaFinding | null {
   const hasWildcard = tools.some((t) => isWildcard(baseTool(t)));
   // Inherits-all is signalled by a WILDCARD (the caller passes `["*"]` for an
@@ -376,11 +407,17 @@ export function lethalTrifectaIssues(
     return {
       severity: "advisory",
       legs,
-      message:
-        "Inherits-all contract (no explicit tools / wildcard) grants every capability — " +
-        "it holds all three lethal-trifecta legs (read private data, ingest untrusted content, " +
-        "exfiltrate) and is a maximal prompt-injection blast radius. Declare an explicit tools " +
-        "list dropping at least one leg (Meta's Rule of Two).",
+      message: ctx.contractUnreadable
+        ? "Frontmatter is not valid YAML, so the declared tool list could not be read — a " +
+          "strict loader rejects the block, and a regex salvage of it is a guess, not a " +
+          "contract. Scored as INHERITS-ALL (every capability), which is what a strict " +
+          "loader yields: it therefore holds all three lethal-trifecta legs (read private " +
+          "data, ingest untrusted content, exfiltrate). Fix the YAML and the declared list " +
+          "counts again — a declaration that does not parse is not an enforcement."
+        : "Inherits-all contract (no explicit tools / wildcard) grants every capability — " +
+          "it holds all three lethal-trifecta legs (read private data, ingest untrusted content, " +
+          "exfiltrate) and is a maximal prompt-injection blast radius. Declare an explicit tools " +
+          "list dropping at least one leg (Meta's Rule of Two).",
     };
   }
 
@@ -398,8 +435,21 @@ export function lethalTrifectaIssues(
         `(${legs.private.join(", ")}), ingest untrusted content ` +
         `(${legs.untrusted.join(", ")}), AND exfiltrate ` +
         `(${legs.exfil.join(", ")}) — a prompt-injection exfil path with no exploit code. ` +
-        "Drop at least one leg (Meta's Rule of Two: allow at most two).",
+        "Drop at least one leg (Meta's Rule of Two: allow at most two)." +
+        (ctx.contractUnreadable
+          ? " (Those tool names were SALVAGED: the frontmatter is not valid YAML, so a strict" +
+            " loader reads no contract here at all and the real grant may be wider still." +
+            " Fix the YAML — this finding stands either way.)"
+          : ""),
     };
+  }
+  // Fewer than three legs — but the names were salvaged from a block a strict
+  // loader rejects, so "fewer" is a guess. What that loader actually yields is
+  // NOTHING: no contract, which is inherits-all, which holds every leg. This is
+  // the branch the defect lived in — a malformed unit scored clean because the
+  // salvage happened to read narrow.
+  if (ctx.contractUnreadable) {
+    return lethalTrifectaIssues(["*"], dialect, ctx);
   }
   return null;
 }

--- a/src/core/skill-resources.test.ts
+++ b/src/core/skill-resources.test.ts
@@ -197,6 +197,51 @@ describe("skillResourceIssues", () => {
     expect(run(body, existsOnly())).toHaveLength(1);
   });
 
+  // --- headings name the script the section is about (dogfood 2026-08-08) ----
+
+  it("flags a bundled script named in a SECTION HEADING (no use verb)", () => {
+    // 🔴 The regression this exists for. A skill's own `structure.mjs` sits at the
+    // skill ROOT; the SKILL.md pointed at `scripts/structure.mjs` from the heading
+    // of the section about running it. The verb gate reads prose, a heading has no
+    // prose, and the broken ref went unreported for three days. Measured: this line
+    // yielded [], while "Run the mechanical leg — `scripts/structure.mjs`" — same
+    // file, same missing target — correctly yielded the finding.
+    const body =
+      "## 🏗 START WITH THE MECHANICAL LEG — `scripts/structure.mjs` (added 2026-08-05)";
+    const found = run(body, existsOnly());
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({
+      ref: "scripts/structure.mjs",
+      resolved: "scripts/structure.mjs",
+      kind: "path",
+      line: 1,
+    });
+  });
+
+  it("does not flag a heading naming a bundled script that EXISTS", () => {
+    const body = "### `scripts/structure.mjs`";
+    expect(run(body, existsOnly("scripts/structure.mjs"))).toEqual([]);
+  });
+
+  it("still skips an ILLUSTRATIVE heading (the cue vetoes a heading too)", () => {
+    // A skill that teaches skill-authoring headlines its examples. Widening to
+    // headings must not reopen that false positive.
+    const body = [
+      "## Examples of bundled scripts: `scripts/rotate_pdf.py`",
+      "## A template layout — `references/patterns.md`",
+    ].join("\n");
+    expect(run(body, existsOnly())).toEqual([]);
+  });
+
+  it("keeps the verb gate on ORDINARY prose (the wide net was NOT taken)", () => {
+    // The narrow fix promotes HEADINGS only. A mid-paragraph mention with no
+    // directive stays unchecked — flagging every backticked bundle path was
+    // measured FP-heavy on teaching skills, which is why the gate exists at all.
+    const body =
+      "A skill ships `scripts/rotate.py` alongside its SKILL.md, one dir deep.";
+    expect(run(body, existsOnly())).toEqual([]);
+  });
+
   it("skips a bare word inline mention (no extension, no bundle prefix)", () => {
     const body = "Use the `runHook` helper and the `scripts` directory.";
     expect(run(body, existsOnly())).toEqual([]);

--- a/src/core/skill-resources.ts
+++ b/src/core/skill-resources.ts
@@ -30,8 +30,9 @@
  * `references/finance.md`", or a markdown-link example demonstrating how to
  * write a path — e.g. one with a space in the filename). A reference (link OR
  * inline path) is treated as real ONLY when the line DIRECTS the agent to use
- * the file (read/run/see/…) and carries no illustrative cue (example / e.g. /
- * such as / would be / template / →). See `inlinePathIsUsed`.
+ * the file (read/run/see/…, or the line is a HEADING naming it — see
+ * `MD_HEADING`) and carries no illustrative cue (example / e.g. / such as /
+ * would be / template / →). See `inlinePathIsUsed`.
  *
  * ESCAPE HATCH: a SKILL.md carrying `<!-- vigiles-disable skill-resource-resolves -->`
  * anywhere in its body opts OUT of this check entirely (mirrors `orphans.ts`'s
@@ -225,17 +226,48 @@ const ILLUSTRATIVE_CUE =
   /\b(example|examples|e\.g\.?|i\.e\.?|such as|for instance|would be|helpful|useful|template|boilerplate)\b|→|->/i;
 
 /**
+ * An ATX markdown heading (`## …`, up to three leading spaces per CommonMark).
+ *
+ * 🔴 WHY A HEADING COUNTS AS A USE-DIRECTIVE. The verb gate below reads PROSE,
+ * and a heading is not prose — it is the section's label. So the single most
+ * common way a skill points at its own bundled script, naming it in the heading
+ * of the section about running it, carried no verb and went unchecked:
+ *
+ *     ## 🏗 START WITH THE MECHANICAL LEG — `scripts/structure.mjs`
+ *
+ * Measured 2026-08-08 on a real skill whose `structure.mjs` sits at the skill
+ * ROOT, not under `scripts/`: that line yielded NOTHING. Rewriting the same
+ * heading to "Run the mechanical leg" — same file, same ref, same missing
+ * target — correctly yielded the finding. The tool's answer depended on the
+ * author's choice of verb, and it stayed silent for three days.
+ *
+ * The narrow fix, and deliberately not the wide one. The alternative — treat
+ * ANY bundle-dir path with an extension as a reference, verb or not — reopens
+ * exactly the false positives the gate exists for (a skill TEACHING how to
+ * build skills mentions `scripts/rotate.py` constantly as prose). A heading
+ * naming a bundle path is a structural claim about what this section is about,
+ * not a sentence illustrating what a skill *could* ship, so it earns the same
+ * standing as an explicit "run …". The illustrative-cue veto still applies —
+ * `## Examples: \`references/finance.md\`` stays skipped — and the check is
+ * `warn` severity with a `vigiles-disable` escape hatch, so a slightly wider
+ * net is affordable where a blanket one is not.
+ */
+const MD_HEADING = /^\s{0,3}#{1,6}\s/;
+
+/**
  * Whether a bundle-path reference on this line reads as a REAL reference (the
  * agent is told to use the file) rather than an illustrative mention. Requires
- * a positive use-directive and the absence of an illustrative cue — both
- * evaluated over the whole line for simplicity (a tight, precise rule over a
- * clever one). BOTH candidate shapes consult this (issue #110) — a markdown
- * link's `[text](target)` syntax is a stronger signal than a bare inline span,
- * but "For example, see [the schema](...)" is still an illustrative mention,
- * not a real dead ref.
+ * a positive directive — a use verb, or the line being a heading (see
+ * {@link MD_HEADING}) — and the absence of an illustrative cue, both evaluated
+ * over the whole line for simplicity (a tight, precise rule over a clever one).
+ * BOTH candidate shapes consult this (issue #110) — a markdown link's
+ * `[text](target)` syntax is a stronger signal than a bare inline span, but
+ * "For example, see [the schema](...)" is still an illustrative mention, not a
+ * real dead ref.
  */
 function inlinePathIsUsed(line: string): boolean {
-  return USE_DIRECTIVE.test(line) && !ILLUSTRATIVE_CUE.test(line);
+  if (ILLUSTRATIVE_CUE.test(line)) return false;
+  return USE_DIRECTIVE.test(line) || MD_HEADING.test(line);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -78,6 +78,7 @@ import {
 } from "./eval-lock.js";
 import type { Check, CheckJSON } from "./check.js";
 import { welchTTest, type Comparison } from "./stats.js";
+import { recordCheck } from "./check-count.js";
 import {
   type ToolIntercept,
   buildInterceptSettings,
@@ -1792,6 +1793,9 @@ export async function runEvalWith<M extends Metrics>(
   spec: EvalSpec<M>,
   runner: AgentRunner,
 ): Promise<EvalReport> {
+  // Tell the CLI runner this script exercised the harness, so a file that runs
+  // NOTHING can be told apart from one that ran and passed. See check-count.ts.
+  recordCheck();
   const trials = spec.trials ?? 5;
   const spacing = (spec.spacingSec ?? 4) * 1000;
   const concurrency = spec.concurrency ?? 1;
@@ -2611,6 +2615,8 @@ export async function measureTriggerRateWith(
   runError?: (out: RunOut) => string | null,
   harness = "claude-code",
 ): Promise<TriggerRateReport> {
+  // Tell the CLI runner this script exercised the harness (see check-count.ts).
+  recordCheck();
   // Deterministic gate FIRST — before spending a token (or packaging a skillsDir).
   assertTriggerDiversity(spec);
 

--- a/src/harness-assert.ts
+++ b/src/harness-assert.ts
@@ -29,6 +29,7 @@ import type {
   HookProgramOutcome,
 } from "./core/hook-program.js";
 import { evalChecks, type Check } from "./check.js";
+import { recordCheck } from "./check-count.js";
 import type { OutputContract } from "./core/spec.js";
 import {
   parseAgentResult,
@@ -138,6 +139,19 @@ export function assertHookAllowed(r: HookRunResult): void {
   }
 }
 
+/**
+ * `runHookProgram`, counted. An in-process hook decision is an observation the
+ * CLI runner can see — without it, a `*.harness.*` file that only tests compiled
+ * hooks would look like it did nothing at all. See check-count.ts.
+ */
+function runCountedHookProgram(
+  hook: AnyHook,
+  event: RawHookEvent,
+): HookProgramOutcome {
+  recordCheck();
+  return runHookProgram(hook, event);
+}
+
 /** Render a {@link HookProgramOutcome} for an assertion message. */
 function describeOutcome(o: HookProgramOutcome): string {
   if (o.kind === "decision") return `${o.decision.kind} (a gate decision)`;
@@ -152,7 +166,7 @@ function describeOutcome(o: HookProgramOutcome): string {
  * check, use {@link assertHookBlocked} over `runHook`.)
  */
 export function assertHookDenies(hook: AnyHook, event: RawHookEvent): void {
-  const o = runHookProgram(hook, event);
+  const o = runCountedHookProgram(hook, event);
   if (o.kind !== "decision" || o.decision.kind !== "deny") {
     fail(`expected the hook to deny, got ${describeOutcome(o)}`);
   }
@@ -160,7 +174,7 @@ export function assertHookDenies(hook: AnyHook, event: RawHookEvent): void {
 
 /** Assert a COMPILED hook allows an event (in-process). The twin of {@link assertHookDenies}. */
 export function assertHookAllows(hook: AnyHook, event: RawHookEvent): void {
-  const o = runHookProgram(hook, event);
+  const o = runCountedHookProgram(hook, event);
   if (o.kind !== "decision" || o.decision.kind !== "allow") {
     fail(`expected the hook to allow, got ${describeOutcome(o)}`);
   }
@@ -182,7 +196,7 @@ export function assertHookNotices(
   event: RawHookEvent,
   matcher?: string | RegExp,
 ): void {
-  const o = runHookProgram(hook, event);
+  const o = runCountedHookProgram(hook, event);
   if (o.kind !== "reaction" || o.reaction.kind !== "notice") {
     fail(`expected the hook to notice, got ${describeOutcome(o)}`);
   }
@@ -208,7 +222,7 @@ export function assertHookNotices(
  * A `run(…)` reaction is not silent for this purpose: the hook still reacted.
  */
 export function assertHookSilent(hook: AnyHook, event: RawHookEvent): void {
-  const o = runHookProgram(hook, event);
+  const o = runCountedHookProgram(hook, event);
   if (o.kind !== "reaction") {
     fail(`expected a react hook, got ${describeOutcome(o)}`);
   }

--- a/src/harness-test.ts
+++ b/src/harness-test.ts
@@ -52,6 +52,7 @@ import type {
   ModelRequest,
 } from "./core/harness-driver.js";
 import { assertHarnessTestable } from "./adapter-conformance.js";
+import { recordCheck } from "./check-count.js";
 
 import { claudeCodeRuntime } from "./adapters/claude-code/runtime.js";
 
@@ -630,6 +631,9 @@ export async function runHarnessTest(
   spec: HarnessTestSpec,
   opts: RunHarnessTestOptions = {},
 ): Promise<HarnessTestResult> {
+  // Tell the CLI runner this script exercised the harness, so a file that runs
+  // NOTHING can be told apart from one that ran and passed. See check-count.ts.
+  recordCheck();
   const adapter = opts.adapter;
   // Default (no adapter): the unchanged Claude Code driver — keeps the
   // sandbox/confined path and behaviour byte-for-byte identical.

--- a/src/run-script.ts
+++ b/src/run-script.ts
@@ -57,6 +57,7 @@ import {
   type SandboxMode,
   type EgressAttempt,
 } from "./sandbox.js";
+import { recordCheck } from "./check-count.js";
 
 export type { EgressAttempt };
 
@@ -210,6 +211,11 @@ export function runScriptWith(
   opts: RunScriptOptions,
   deps: RunScriptDeps,
 ): ScriptRunResult {
+  // Tell the CLI runner this script exercised the harness, so a `*.harness.*`
+  // file that runs NOTHING can be told apart from one that ran and passed. Here,
+  // at the primitive, so `runHook` and a bare `runScript` both count. See
+  // check-count.ts.
+  recordCheck();
   // Allowlisted egress is its own confined path (bwrap netns + slirp4netns +
   // nft); it can't run unconfined, so it refuses outright when the tooling is
   // absent rather than falling back to a direct run that ignores the allowlist.

--- a/src/scan-core.ts
+++ b/src/scan-core.ts
@@ -98,6 +98,45 @@ function frontmatter(md: string): {
 }
 
 /**
+ * Whether this unit's declared TOOL CONTRACT is unreadable — the frontmatter
+ * block exists but is not valid YAML.
+ *
+ * 🔴 WHY SCORING MUST NOT USE THE SALVAGE. The shared reader is deliberately
+ * lenient: on a block js-yaml rejects it falls back to a regex salvage, so the
+ * live PreToolUse rail still has *something* to enforce and the other fields
+ * keep working. That is right for a rail and wrong for a SCORE. Measured
+ * 2026-08-08: `readFrontmatter(bad)` returns `{data: null, malformed: true}` —
+ * the tool KNOWS the block is broken — while `frontmatterList(…, "allowed-tools")`
+ * on the same block returns `["Read","Bash"]`, the narrow contract the author
+ * MEANT. Strict js-yaml on it throws `bad indentation of a mapping entry`. So a
+ * unit whose contract a strict loader rejects was graded as though it had
+ * declared exactly that narrow contract: the Safety ring read BETTER than the
+ * truth, on the optimistic branch, in the tool whose own thesis is that the
+ * presence of a declaration is not the enforcement of it.
+ *
+ * The trifecta detector is therefore told the list is a SALVAGE, and reads it as
+ * one: it can only make the verdict worse (a salvaged all-three still convicts),
+ * and anything short of that falls back to what a strict loader really yields —
+ * no contract, i.e. inherits-all. The finding says which happened, so the author
+ * can tell a dropped grade from a real capability. Strictly one-directional, the
+ * same shape as the inherits-all monotonicity fix (#119). `frontmatter-valid`
+ * reports the broken block itself; this is the half that stops the SCORE
+ * disagreeing with it.
+ *
+ * DELIBERATELY NOT WIDER. The typo / never-available / MCP-server /
+ * disallowed-tools cross-references keep using the salvage: they are diagnostics,
+ * and suppressing them on a malformed file DELETES findings, which moves the
+ * grade the optimistic way — the direction this whole fix exists to close. A real
+ * vendored plugin in `test/dogfood` proves the point: `madappgang-frontend`'s
+ * `tester.md` has both a malformed description and an explicit all-three-legs
+ * tool list, and its `AskUserQuestion` never-available finding is true whether or
+ * not the block parses.
+ */
+function contractIsUnreadable(md: string): boolean {
+  return readFrontmatter(md).malformed;
+}
+
+/**
  * Per-kind surface classifiers, built from the harness `PluginLayout`'s
  * `skillDir`/`agentDir`/`commandDir` — so adding a harness whose subagents live
  * somewhere other than `agents/` (OpenCode's `.opencode/agent`) needs no change
@@ -360,11 +399,17 @@ export function scanSkills(
     // invocable skill can be hijacked by attacker content, so a user-invoked one is
     // excluded. A skill with no `allowed-tools` line inherits all → advisory.
     const skillTools = parseAgentToolList(md, "allowed-tools");
+    // Whether that list came out of a block a strict loader REJECTS — in which
+    // case it is a salvage, and the trifecta detector must read it as one. See
+    // `contractIsUnreadable`.
+    const contractUnreadable = contractIsUnreadable(md);
     // No `allowed-tools:` line (null) → inherits all → wildcard sentinel; an
     // EXPLICIT empty `[]` means zero tools → no trifecta (don't collapse them).
     const trifecta = userInvoked
       ? null
-      : lethalTrifectaIssues(skillTools ?? ["*"], dialect);
+      : lethalTrifectaIssues(skillTools ?? ["*"], dialect, {
+          contractUnreadable,
+        });
     out.push({
       name: fm.name ?? skillName(path),
       // Report the real on-disk path, not the synthetic materialize key (E1).
@@ -440,6 +485,14 @@ export function scanAgents(
   for (const [path, md] of Object.entries(files)) {
     if (!cls.isAgent(path)) continue;
     const tools = parseAgentTools(md);
+    // Whether that list came out of a block a strict loader REJECTS — see
+    // `contractIsUnreadable`. Scoped to the trifecta (the Safety ring) on
+    // purpose: the typo / MCP / disallowed-tools cross-references below are
+    // DIAGNOSTICS, and dropping them on a malformed file would delete real
+    // findings — moving the grade in the optimistic direction this fix exists to
+    // stop. A salvage is too weak to earn a unit a clean bill of health; it is
+    // plenty strong enough to convict.
+    const contractUnreadable = contractIsUnreadable(md);
     // An inherits-all agent (no `tools:` line) grants access to every tool
     // including every side-effecting one — pass the wildcard sentinel so
     // effectSurface correctly classifies it as `"unrestricted"`.
@@ -479,7 +532,9 @@ export function scanAgents(
       // inherits-all agent (no `tools:` line → tools === null) is the advisory
       // case — pass the wildcard sentinel so it's distinguished from an EXPLICIT
       // empty `tools: []` (zero tools → no trifecta). One detector, no drift.
-      trifecta: lethalTrifectaIssues(tools ?? ["*"], dialect),
+      trifecta: lethalTrifectaIssues(tools ?? ["*"], dialect, {
+        contractUnreadable,
+      }),
     });
   }
   return out.sort((a, b) => a.name.localeCompare(b.name));

--- a/src/scan.test.ts
+++ b/src/scan.test.ts
@@ -1460,6 +1460,118 @@ test("trifecta detector is dialect-injected — works under a non-CC layout", ()
 });
 
 // ---------------------------------------------------------------------------
+// A contract that does not parse is not a contract (dogfood 2026-08-08)
+//
+// 🔴 The defect these exist for. The shared frontmatter reader is deliberately
+// lenient — on a block js-yaml rejects it regex-salvages the fields, so the live
+// PreToolUse rail still has something to enforce. The SCORING path was reading
+// that salvage. Measured: `readFrontmatter(bad).malformed` is `true` while
+// `frontmatterList(bad, "allowed-tools")` returns the narrow list the author
+// MEANT, so a unit whose contract a strict loader rejects was graded as though it
+// had declared exactly that list — the Safety ring reading BETTER than the truth,
+// in the tool whose thesis is that a declaration present is not a rule enforced.
+// ---------------------------------------------------------------------------
+
+// `allowed-tools: [Read, Bash` — an unclosed flow array, the unambiguous
+// malformed case the frontmatter-valid docs cite. The salvage yields exactly
+// ["Read","Bash"]: private + exfil, no untrusted leg, so it scores CLEAN. A
+// strict loader yields nothing at all, which is inherits-all: all three legs.
+const UNCLOSED_TOOLS = "[Read, Bash";
+
+test("a skill whose allowed-tools is MALFORMED scores as inherits-all, not as the salvage", () => {
+  const dir = makeTmpDir("scan-malformed-contract-skill");
+  write(
+    dir,
+    "skills/broken/SKILL.md",
+    `---\nname: broken\ndescription: A model-invocable skill whose frontmatter does not parse\nallowed-tools: ${UNCLOSED_TOOLS}\n---\n# broken\n`,
+  );
+  const r = scanPlugin(dir);
+  const skill = r.skills.find((s) => s.name === "broken");
+  assert.equal(
+    skill?.trifecta?.severity,
+    "advisory",
+    "an unreadable contract is scored as inherits-all, which holds every leg",
+  );
+  // …and the finding SAYS why the grade moved, so the author doesn't read
+  // "no explicit tools" on a file that plainly declares them.
+  assert.match(skill.trifecta?.message ?? "", /not valid YAML/);
+  assert.match(skill.trifecta?.message ?? "", /INHERITS-ALL/);
+  // The two paths now agree: the same file is reported by frontmatter-valid.
+  assert.ok(
+    r.malformedFrontmatter.some((i) => i.path.includes("skills/broken")),
+    "frontmatter-valid reports the same block the scorer refused to trust",
+  );
+  cleanupTmpDir(dir);
+});
+
+test("a subagent whose tools list is MALFORMED gets the same treatment", () => {
+  const dir = makeTmpDir("scan-malformed-contract-agent");
+  write(
+    dir,
+    "agents/broken.md",
+    `---\nname: broken\ndescription: A subagent whose frontmatter does not parse\ntools: ${UNCLOSED_TOOLS}\n---\nbody\n`,
+  );
+  const r = scanPlugin(dir);
+  const agent = r.agents.find((a) => a.name === "broken");
+  assert.equal(agent?.trifecta?.severity, "advisory");
+  assert.match(agent?.trifecta?.message ?? "", /not valid YAML/);
+  cleanupTmpDir(dir);
+});
+
+test("a SALVAGED all-three contract still convicts — the refusal is one-directional", () => {
+  // 🔴 The over-reach this pins, caught by the vendored corpus: madappgang's real
+  // `tester.md` carries BOTH a malformed description and an explicit
+  // all-three-legs tools list. Refusing the salvage outright demoted a genuine
+  // hard exfil path to an advisory and deleted its never-available finding. A
+  // salvage is too weak to earn a clean bill of health and plenty strong enough
+  // to convict, so it may only ever make the verdict worse.
+  const dir = makeTmpDir("scan-malformed-contract-hard");
+  write(
+    dir,
+    "agents/leaky.md",
+    "---\nname: leaky\ndescription: Broken YAML, and every leg declared: a colon\n  bad: indent\n" +
+      "tools: Read, WebSearch, WebFetch, NotARealTool\n---\nbody\n",
+  );
+  const r = scanPlugin(dir);
+  const agent = r.agents.find((a) => a.name === "leaky");
+  assert.ok(r.malformedFrontmatter.some((i) => i.path.includes("leaky.md")));
+  assert.equal(agent?.trifecta?.severity, "hard", "not demoted to advisory");
+  assert.match(agent?.trifecta?.message ?? "", /SALVAGED/);
+  // …and the diagnostics built on the same salvage are NOT suppressed: dropping
+  // them would delete findings, moving the grade the optimistic way.
+  assert.ok(
+    agent?.tools?.includes("Read"),
+    "the salvaged list is still reported",
+  );
+  cleanupTmpDir(dir);
+});
+
+test("a VALID narrow contract is unaffected — the refusal is scoped to unparseable blocks", () => {
+  // Control. The same two tools, in a block that parses, must still score clean:
+  // Read + Bash is private + exfil with no untrusted leg (Rule of Two).
+  const dir = makeTmpDir("scan-valid-contract-control");
+  write(
+    dir,
+    "skills/fine/SKILL.md",
+    "---\nname: fine\ndescription: A model-invocable skill whose frontmatter parses cleanly\nallowed-tools: [Read, Bash]\n---\n# fine\n",
+  );
+  write(
+    dir,
+    "agents/fine.md",
+    "---\nname: fine\ndescription: A subagent whose frontmatter parses cleanly\ntools: [Read, Bash]\n---\nbody\n",
+  );
+  const r = scanPlugin(dir);
+  assert.equal(r.skills.find((s) => s.name === "fine")?.trifecta, null);
+  assert.equal(r.agents.find((a) => a.name === "fine")?.trifecta, null);
+  assert.deepEqual(r.agents.find((a) => a.name === "fine")?.tools, [
+    "Read",
+    "Bash",
+  ]);
+  assert.equal(r.malformedFrontmatter.length, 0);
+  cleanupTmpDir(dir);
+});
+
+// ---------------------------------------------------------------------------
 // skill-resource-resolves — surfaced through scanPlugin
 // ---------------------------------------------------------------------------
 

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -15,6 +15,14 @@
 // helpers — stay out of the public surface, the api reports, and the docs site.
 // (vigiles's own tests import those from the source modules directly.)
 
+// --- reporting: how much did this script actually do? ---
+// `vigiles test` can otherwise see only an exit code, so a file that runs NOTHING
+// prints the same `✓` as one that ran and passed (measured 2026-08-08 on a file
+// exporting an object of tests nobody calls). The tiers below count themselves;
+// call `recordCheck()` yourself when you assert some OTHER way — `node:assert`,
+// vitest's `expect` — so those are visible to the runner too. See check-count.ts.
+export { recordCheck } from "./check-count.js";
+
 // --- unit tier: runScript (the primitive) + runHook (it, plus a decision) ---
 // `runScript` runs any program and reports what it DID (exit, both streams,
 // writes, egress). `runHook` is that plus the hook protocol: event to stdin,


### PR DESCRIPTION
## What and why

Three defects, all found the same way: running vigiles on a real harness and
noticing it said nothing where it should have spoken. Each one is a case of the
tool taking the optimistic branch — the shape it exists to catch elsewhere.

### 1. A bundled script named in a HEADING was invisible (`fix(audit)`, 8f9d02a)

`skillResourceIssues` suppressed a broken reference unless the surrounding line
read like an instruction. That prose gate is load-bearing — a skill teaching how
to build skills mentions `scripts/rotate.py` constantly as an example, and
flagging those once graded a clean skill an F — but it reads PROSE, and a heading
is not prose. So the most common way a skill points at its own script went
unchecked:

```md
## 🏗 START WITH THE MECHANICAL LEG — `scripts/structure.mjs`
```

Measured: that line yields `[]`. Rewrite three words to "Run the mechanical leg" —
same file, same reference, same missing target — and it correctly yields
`{ref: "scripts/structure.mjs", line: 46}`. The answer depended on the author's
choice of verb; the ref was wrong (the file is at the skill root) and the tool was
silent for three days.

An ATX heading now counts as a use-directive, and the widening stops there. The
blanket alternative (any bundle path with an extension is a reference) reopens the
false positives the gate exists for. **FP delta over the 28 SKILL.md files in this
repo plus the vendored corpus: 1 finding before, 1 after — the same one.**

### 2. Malformed frontmatter was regex-salvaged INTO the Safety score (`fix(audit)`, a31b04c)

`readFrontmatter(bad)` returns `{data: null, malformed: true}` — the tool *knows*
the block is broken — while `frontmatterList(…, "allowed-tools")` on that same
block still returns `["Read","Bash"]`, the contract its author meant. Strict
js-yaml throws `bad indentation of a mapping entry`. `scan-core` fed that salvage
straight into the tool contract the lethal-trifecta / Safety ring reads.

So a unit whose `allowed-tools` a strict loader *rejects* scored as if it had
declared exactly the narrow contract intended — `Read` + `Bash` is private + exfil
with no untrusted leg, so: **clean**. What a strict loader actually yields is no
contract at all, which is inherits-all, which holds every leg. The grade came out
better than the truth. Meanwhile `frontmatter-valid` was already reporting the
same file: two paths in one tool disagreeing about one block, with the *scoring*
path taking the optimistic one. The product's thesis turned on the product.

The fix is **one-directional**, and that took a second pass. A salvaged list may
make the verdict worse, never better: all three legs still fires `hard` (with a
note that the names were salvaged); anything less falls back to inherits-all with
a message naming the YAML. The repo's own vendored corpus forced that nuance —
`madappgang-frontend`'s real `tester.md` has *both* a malformed description and an
explicit all-three-legs list, and refusing its salvage outright demoted a genuine
exfil path from ✗ to ⚠ and deleted its `AskUserQuestion` finding.
`scan-vendor.test.ts` went red and was right to. Scoped to the trifecta for the
same reason: the typo / MCP / disallowed-tools cross-references are diagnostics,
and suppressing them would *delete* findings — the optimistic direction again.

### 3. `✓ 1 passed` for a file that ran zero assertions (`feat(testing)`, c1966d5)

```console
$ cat vacuous.harness.mjs
export default { "never runs": () => assert.equal(1, 2) };
$ vigiles test vacuous.harness.mjs
  ✓ vacuous.harness.mjs
1 passed.                                   EXIT=0
```

The assertion is false. It is never called, because nothing calls an exported
object. A consumer repo hit this and now hand-copies a warning into the header of
every new harness file — *"An earlier version exported a `tests` object; nothing
ran and the runner printed ✓"* — because the runner could not enforce it. Eight
harnesses resting on a comment.

`vigiles/testing` gains a check counter, and each tier counts its own runs — at
`runScriptWith` (the primitive under both `runHook` and `runScript`), plus
`runHarnessTest`, `runEvalWith`, `measureTriggerRateWith`, and the in-process
compiled-hook assertions — so existing harnesses report for free, and
`recordCheck()` covers a harness that asserts another way. The runner reports a
clean exit with zero recorded checks as `∅ … 0 CHECKS`, tallied apart from
`passed` — the fourth state, precedented by the third (a skip).

- **Not a failure.** `anyFailed` ignores it, the exit code is unchanged. A release
  that turned CI red for teaching the runner a new word would punish upgrading.
- **Silence is not zero.** A script that never imports `vigiles/testing` cannot
  report, so it stays a plain pass. `undefined` = nobody counted; `0` = counted and
  found nothing — the same distinction `assertNoWrite` already draws. Force-loading
  the counter via `node --import` would close that gap and was rejected: it reports
  `0` for a hand-rolled harness that spawns and asserts on its own.
- **It found one immediately, here.** `oh-my-claudecode-egress.harness.mjs` printed
  "skip: …" and `process.exit(0)` — a skip in prose the runner could only read as a
  pass. It now calls `skip()`.

**No new CLI verb, no new flag.** F1 and F2 fold into existing `audit` findings; F3
is the `vigiles/testing` library (an export) plus the existing `test`/`eval`
summary. `--no-skip` is deliberately untouched: a file that verified nothing is not
a missing capability, and making that flag fail on it would make its name a lie.
Every mechanism is deterministic — a regex over a line, a `malformed` boolean, an
integer in a file. Nothing interprets prose.

## Safety impact

**Direction: strictly more conservative. Nothing can now pass that could not
before.**

- F2 raises Safety findings on units whose contract does not parse (a unit that
  scored clean can now score `advisory`); it never lowers one. Same monotonicity
  direction as #119.
- F1 reports more broken references at `warn` severity; it never suppresses one.
  It cannot execute anything — the detector's only IO is an injected `existsSync`.
- F3 adds a **non-fatal** reporting state. It does not change any exit code, does
  not change what a hook may permit, does not touch the sandbox or
  `interceptTools`, and does not let a read-only path execute anything. The one new
  side effect is a write of an integer to a scratch path the runner itself created
  under `tmpdir()`, in a `try`/`catch` that swallows failure so an unwritable path
  can never crash a passing harness.
- The count env var is read once and **deleted**, so a spawned child cannot report
  over its parent — asserted from inside the child in a test.

## Checks

- [x] `npm test` green apart from 3 failures that are **pre-existing and
      environmental**, baselined by stashing this branch and running them on
      `origin/main`: two `pylint` catalog tests (no `pylint` on PATH in this
      container; CI installs it) and one Stop-hook test needing the `claude` CLI.
- [x] New behaviour has a test — **and each was watched failing by mutation**:
      reverting `inlinePathIsUsed` fails 1; neutering `contractIsUnreadable` fails
      3; removing only the detector's inherits-all fallback fails 3; making
      `statusFor` ignore the count fails 2; dropping the env-var delete fails 2;
      removing the tier instrumentation fails 1.
- [x] Docs updated: `docs/rules/skill-resource-resolves.md`,
      `docs/rules/lethal-trifecta.md` (+ a new cross-reference from
      `docs/rules/frontmatter-valid.md`), `docs/cli.md`,
      `docs/harness-testing.md`, `docs/testing-matrix.md`, and the regenerated
      `api-surface/vigiles-testing.api.md`.
- [x] `npm run lint` clean (0 errors), changed files prettier-clean, `tsc --noEmit`
      clean, `test/types` clean, API surface gate green, dogfood corpus guards green,
      and `vigiles test` on this repo green (12 passed, 1 skipped).

## Found while in here, NOT touched

- **`purity` / `effectBuckets` still read the salvage on a malformed block**, so a
  unit whose YAML does not parse can report `read-only` from a guessed tool list.
  Same optimism class as F2, different ring; deliberately out of scope to keep this
  change's blast radius small. Worth a follow-up decision.
- **`.vigiles/generated.d.ts` is stale on `main`** — it lists 18 npm scripts and
  omits `build:core`. Running `vigiles generate types` (which CI does, without
  `--check`) rewrites it. Reverted here to keep the diff focused.
- **`npm run fmt:check` fails on `main`** for 8 generated `site/checks/*/index.html`
  files, unrelated to this branch.
