### PR TITLE
fix(audit): a hook matcher is a regex, so validate it by probing — not by shape

### DIFF
--- a/docs/rules/hook-matcher.md
+++ b/docs/rules/hook-matcher.md
@@ -1,71 +1,131 @@
 # hook-matcher
 
 Cross-reference each hook's **matcher string** against the harness tool catalog
-and MCP server declarations. A matcher that doesn't exactly name an available
-tool (or a valid MCP reference) silently **never fires** — the hook runs
-zero times with no error, and the gate it was meant to provide is simply absent.
+and MCP server declarations. A matcher that can't select the tool name the
+harness emits silently **never fires** — the hook runs zero times with no error,
+and the gate it was meant to provide is simply absent.
 
 Same detector `vigiles audit` uses (`hookMatcherIssues` in
 `src/core/hook-matcher.ts`); one detector, two callers, no drift.
 
-## What it flags (three kinds)
+## A matcher is a pattern, not a tool name
+
+This is the fact the rule is built on, and it was **measured** against the real
+`claude` CLI (2.1.226) driven by the scripted mock model — one hook per run, a
+marker file the hook writes as the oracle:
+
+| matcher             | tool called                                 | fired  |
+| ------------------- | ------------------------------------------- | ------ |
+| `Write`             | `Write`                                     | yes    |
+| `Writ` / `rit`      | `Write`                                     | **no** |
+| `rit.`              | `Write`                                     | yes    |
+| `W(rit)e`           | `Write`                                     | yes    |
+| `mcp__.*`           | `mcp__some_server__list_events`             | yes    |
+| `mcp__.*__.*`       | `mcp__some_server__list_events`             | yes    |
+| `mcp__[^_]+__[^_]+` | `mcp__some_server__list_events`             | **no** |
+| `mcp__[^_]+__[^_]+` | `mcp__4f54037d-…-6130f3da1ef8__list_events` | yes    |
+| `mcp__\w+__\w+`     | `mcp__some_server__list_events`             | yes    |
+| `mcp__\w+__\w+`     | `mcp__4f54037d-…-6130f3da1ef8__list_events` | **no** |
+
+Two rules follow, and the detector models exactly these:
+
+1. a matcher with **no regex metacharacter** is compared by string **equality**
+   (`rit` does not fire on `Write`, even though it is a substring);
+2. a matcher **with** metacharacters is an **unanchored regex** (`rit.` fires on
+   `Write`; `mcp__[^_]+__[^_]+` fires on the hyphenated server because `[^_]+`
+   only has to reach _into_ the tool segment).
+
+**Why patterns are the correct authoring form for MCP.** The server segment is
+not stable: the same Google Calendar server appears as
+`mcp__Google_Calendar__list_events` in one session and
+`mcp__4f54037d-…__list_events` in another. A hook keyed to one literal id dies
+silently when the id changes — so a pattern is the _robust_ choice, not a sloppy
+one. Accordingly a pattern is validated by **compiling it and running it against
+synthetic probes**, never by checking it against the literal `mcp__server__tool`
+shape (see [#131](https://github.com/zernie/vigiles/issues/131) — shape-checking
+inverted the verdict on both contested forms).
+
+## What it flags (five kinds)
 
 ### tool-typo — close casing / spelling error
 
-A bare token that is a **close typo** (edit distance ≤ 2) of a real built-in
-tool name. The harness's exact-string matcher means `bash` never matches a
-`Bash` tool call:
+A **literal** bare token that is a close typo (edit distance ≤ 2) of a real
+built-in tool name:
 
 ```jsonc
-"hooks": {
-  "PreToolUse": [{ "matcher": "bash", "hooks": [{ "type": "command", "command": "…" }] }]
-}
+{ "matcher": "bash" } // never equals the tool name "Bash"
 ```
 
-→ `bash` doesn't match any built-in. Did you mean `"Bash"`?
+→ Did you mean `"Bash"`? Reuses the same `closestTool` helper as
+`subagent-tool-contract` (one algorithm, no drift).
 
-Reuses the same `closestTool` helper as `subagent-tool-contract` (≤ 2
-edit-distance, one algorithm, no drift).
-
-### mcp-form — MCP-ish token with the wrong shape
-
-A token that **looks like** an MCP tool reference (starts with `mcp`, possibly
-followed by underscores or hyphens) but is **not** the required
-`mcp__<server>__<tool>` double-underscore form:
+### invalid-regex — the matcher doesn't compile
 
 ```jsonc
-{ "matcher": "mcp_memory_search" }   // single underscores → never matches
-{ "matcher": "mcp-memory-search" }   // hyphens → never matches
+{ "matcher": "mcp__[a-" } // unterminated character class
 ```
 
-When the server/tool segments can be recovered, the corrected
-`mcp__<server>__.*` form is suggested.
+A matcher the regex engine rejects can never match anything. It gets its own
+finding rather than being silently treated as valid.
+
+### mcp-form — the pattern can reach no MCP tool name at all
+
+```jsonc
+{ "matcher": "mcp_memory_search" }  // single underscores → not a tool name
+{ "matcher": "mcp-memory-search" }  // hyphens → not a tool name
+{ "matcher": "mcp_memory_*" }       // matches no `mcp__…__…` name
+{ "matcher": "^mcp__srv$" }         // anchored so it can't reach the tool segment
+```
+
+The probes include a server segment containing an underscore
+(`mcp__Google_Calendar__list_events`) and one containing hyphens
+(`mcp__4f54037d-…__update_event`), plus probes **derived from the matcher's own
+literal segments** — so a correctly scoped `mcp__memory__.*` or
+`mcp__memory__search.*` is never called unreachable. When the server segment can
+be recovered, the corrected `mcp__<server>__.*` form is suggested.
+
+### mcp-narrow — it fires, but not on real server names
+
+```jsonc
+{ "matcher": "mcp__[^_]+__[^_]+" } // can't cross the `_` in `Google_Calendar`
+{ "matcher": "mcp__\\w+__\\w+" }   // `\w` can't cross the `-` in the uuid form
+```
+
+This is **not** "never fires", and the message says so: it names the probes the
+matcher actually misses and suggests `mcp__.*__.*`. Only a matcher that pins **no
+literal server** and does match the simplest MCP name is judged here — a matcher
+deliberately scoped to one server or a few tools is narrow on purpose and is
+never flagged.
 
 ### mcp-undeclared — correct form, server not in declared set
-
-A correctly-formed `mcp__<server>__<tool>` token whose server is **not** in the
-plugin's declared MCP servers — the hook can never fire because the server isn't
-available:
 
 ```jsonc
 { "matcher": "mcp__ghost__search" } // server "ghost" not declared
 ```
 
-This mirrors the `mcp-tool-resolves` guard applied to the hook surface.
+Mirrors the `mcp-tool-resolves` guard applied to the hook surface.
 
 ## FP-safety (high-precision — won't cry wolf)
 
 | Guard                      | What it skips                                                                                                                                                         |
 | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Wildcards / regex**      | `*`, `.*`, `**`, tokens ending with `.*` or `*` are patterns, not tool names — skipped entirely.                                                                      |
-| **Alternation**            | `Edit\|Write`, `(Read\|Bash)` — combined matchers are skipped.                                                                                                        |
-| **Far unknowns**           | A bare token with no close built-in match (edit distance > 2) is **not** flagged — it is likely a plugin/MCP tool name vigiles doesn't know about.                    |
+| **Match-all**              | `*`, `.*`, `**`, and the empty matcher are the documented match-everything forms — skipped entirely.                                                                  |
+| **Alternation**            | `Edit\|Write`, `mcp__a__b\|Bash` — each arm would have to be judged separately and a mixed arm set is legitimate, so an alternation is skipped.                       |
+| **Non-MCP patterns**       | `Bash.*`, `(Read)`, `^Edit$` — a pattern over built-in tool names, not a name; only a literal bare token is typo-checked.                                             |
+| **Far unknowns**           | A bare token with no close built-in match (edit distance > 2) is **not** flagged — likely a plugin/MCP tool vigiles doesn't know about.                               |
+| **Deliberate scope**       | A matcher pinning a literal server (`mcp__memory__.*`) is never flagged as "too narrow" — narrowness is judged only for matchers meant to be generic.                 |
 | **No declared MCP set**    | If the plugin declares no MCP servers, `mcp-undeclared` is **never** raised — the server may exist at the user/project level (the same guard as `mcp-tool-resolves`). |
-| **Built-in MCP servers**   | `mcp__ide__…` and other servers in `dialect.knownMcpServers` are allowlisted even when not declared (Claude Code's `ide` server is available everywhere).             |
+| **Built-in MCP servers**   | `mcp__ide__…` and other servers in `dialect.knownMcpServers` are allowlisted even when not declared.                                                                  |
 | **Plugin-namespaced form** | `mcp__plugin_<name>_<server>__…` is skipped — the join is ambiguous.                                                                                                  |
 
 De-duplicates repeated matchers (same string across multiple entries → one
 finding).
+
+**The suggestion converges.** Every `Did you mean` this rule emits is fed back
+through the rule by a property test (`src/core/hook-matcher.test.ts`): applying
+the advice must produce a clean matcher in one step. That test exists because the
+rule once suggested `mcp__.*__.*` for `mcp__.*` and then rejected its own
+suggestion, proposing `mcp__.*__.*__.*`, and so on forever.
 
 ## Configuration
 
@@ -92,10 +152,10 @@ server list are injected via the Codex adapter.
 
 A hook that never matches is enforcement that silently does nothing — exactly
 the "false confidence" failure class vigiles exists to eliminate
-(`research/hook-pain-points.md`). Catching a casing typo or a wrong MCP form
-deterministically, at authoring time and for free, closes a gap no generic JSON
-linter reaches (a linter can check syntax; only vigiles cross-references the
-actual tool catalog and declared server list).
+(`research/hook-pain-points.md`). But a checker that reports a _working_ matcher
+as dead is the same failure with the sign flipped: a user who obeys it ends up
+with a hook that lints clean and never runs. That is why the pattern half of this
+rule is decided by compiling and probing rather than by how the string looks.
 
 ## See also
 

--- a/docs/verifying-instruction-files.md
+++ b/docs/verifying-instruction-files.md
@@ -198,16 +198,16 @@ The per-family tables below give each rule's default severity and what it checks
 
 ### Hooks &amp; MCP
 
-| Rule                                                            | Default  | What it checks                                                                   |
-| --------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------- |
-| [`hook-events`](rules/hook-events.md)                           | `"warn"` | A hook registers under a real event name (a typo never fires)                    |
-| [`hook-matcher`](rules/hook-matcher.md)                         | `"warn"` | A hook `matcher` fires (no tool-name typo / malformed-or-undeclared MCP form)    |
-| [`hook-block-ineffective`](rules/hook-block-ineffective.md)     | `"warn"` | A hook that looks like it blocks actually can (right event + right deny field)   |
-| [`hook-script-exists`](rules/hook-script-exists.md)             | `"warn"` | A hook's referenced script file exists on disk (else it never runs)              |
-| [`mcp-config`](rules/mcp-config.md)                             | `"warn"` | A declared MCP server can start (has a `command` or `url`)                       |
-| [`mcp-tool-resolves`](rules/mcp-tool-resolves.md)               | `"warn"` | A subagent's `mcp__server__tool` names a declared (or built-in) server           |
-| [`mcp-hook-target-resolves`](rules/mcp-hook-target-resolves.md) | `"warn"` | A `type: mcp_tool` hook names a declared server + a tool                         |
-| [`prefer-compiled-hooks`](rules/prefer-compiled-hooks.md)       | `false`  | One nudge: hand-written hooks could be compiled (recommendation; off by default) |
+| Rule                                                            | Default  | What it checks                                                                                                                             |
+| --------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| [`hook-events`](rules/hook-events.md)                           | `"warn"` | A hook registers under a real event name (a typo never fires)                                                                              |
+| [`hook-matcher`](rules/hook-matcher.md)                         | `"warn"` | A hook `matcher` fires as written (typo · uncompilable · an MCP pattern reaching nothing or missing real server names · undeclared server) |
+| [`hook-block-ineffective`](rules/hook-block-ineffective.md)     | `"warn"` | A hook that looks like it blocks actually can (right event + right deny field)                                                             |
+| [`hook-script-exists`](rules/hook-script-exists.md)             | `"warn"` | A hook's referenced script file exists on disk (else it never runs)                                                                        |
+| [`mcp-config`](rules/mcp-config.md)                             | `"warn"` | A declared MCP server can start (has a `command` or `url`)                                                                                 |
+| [`mcp-tool-resolves`](rules/mcp-tool-resolves.md)               | `"warn"` | A subagent's `mcp__server__tool` names a declared (or built-in) server                                                                     |
+| [`mcp-hook-target-resolves`](rules/mcp-hook-target-resolves.md) | `"warn"` | A `type: mcp_tool` hook names a declared server + a tool                                                                                   |
+| [`prefer-compiled-hooks`](rules/prefer-compiled-hooks.md)       | `false`  | One nudge: hand-written hooks could be compiled (recommendation; off by default)                                                           |
 
 ### Skill triggers
 

--- a/src/audit-score.ts
+++ b/src/audit-score.ts
@@ -267,7 +267,8 @@ function structure(r: ScanReport): CategoryScore {
     {
       n: r.hookMatcherFindings.length,
       weight: W_MISSING_HOOK,
-      label: "hook matcher(s) that never fire (typo / wrong MCP form)",
+      label:
+        "hook matcher(s) that don't fire as written (dead, or too narrow for real MCP names)",
     },
   ]);
   // inherit-all (no `tools:` line) is ADVISORY, not graded: it's surfaced as a

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1708,8 +1708,9 @@ async function runLint(
     scanRoot,
   );
 
-  // 7u. Hook-matcher — a hook `matcher` that never fires (tool-name typo, or a
-  // malformed/undeclared MCP form).
+  // 7u. Hook-matcher — a hook `matcher` that doesn't fire as written (tool-name
+  // typo, an uncompilable or unreachable MCP pattern, one too narrow for real
+  // server naming, or an undeclared MCP server).
   const hookMatcher = checkHookMatcher(config, silent, adapter, scanRoot);
 
   // 8. Validate vigiles builder calls inside markdown code blocks. Default
@@ -4503,8 +4504,10 @@ function checkHookBlockIneffective(
 }
 
 /**
- * Apply the `hook-matcher` rule: a hook `matcher` string that silently never
- * fires — a tool-name typo (`bash`→`Bash`) or a malformed/undeclared MCP form.
+ * Apply the `hook-matcher` rule: a hook `matcher` string that doesn't fire as
+ * written — a tool-name typo (`bash`→`Bash`), a matcher that doesn't compile, an
+ * MCP pattern that reaches no tool name or is too narrow for real server naming,
+ * or an undeclared MCP server.
  * Reuses `scanPlugin`'s `hookMatcherFindings` (one detector, no drift). Warning
  * by default; "error" gates CI.
  */

--- a/src/core/hook-matcher.test.ts
+++ b/src/core/hook-matcher.test.ts
@@ -1,10 +1,11 @@
 /**
  * Hook-matcher detector suite (vitest) — the cross-referencing moat applied to
- * the MATCHER string in a hook registration. Asserts all three kinds
- * (tool-typo / mcp-form / mcp-undeclared), the FP-safety guards (wildcards /
- * alternation / no-declared-set / built-in allowlist / far unknowns), and
- * de-duplication. The dialect is injected — same one-detector-no-drift pattern
- * used by every other core detector.
+ * the MATCHER string in a hook registration. Asserts all five kinds (tool-typo /
+ * invalid-regex / mcp-form / mcp-narrow / mcp-undeclared), the FP-safety guards
+ * (wildcards / alternation / no-declared-set / built-in allowlist / far
+ * unknowns), the MEASURED matcher-semantics table from #131, the suggestion
+ * convergence property, and de-duplication. The dialect is injected — same
+ * one-detector-no-drift pattern used by every other core detector.
  */
 import { test } from "vitest";
 import assert from "node:assert/strict";
@@ -198,6 +199,187 @@ test("a repeated matcher across entries is reported only once", () => {
   const findings = hookMatcherIssues(entries, [], d);
   assert.equal(findings.length, 1);
   assert.equal(findings[0].matcher, "bash");
+});
+
+// ---------------------------------------------------------------------------
+// #131 — the MEASURED acceptance table.
+//
+// Every row was measured against the real `claude` CLI (2.1.226) driven by the
+// scripted mock model: one hook per run, a marker file as the oracle, a real MCP
+// server connected under two different names (`some_server` — an underscore in
+// the server segment, like Anthropic's `Google_Calendar` connector — and the
+// uuid form the SAME server takes in another session).
+//
+//   | matcher                        | fires on `some_server` | on the uuid |
+//   | ------------------------------ | ---------------------- | ----------- |
+//   | mcp__some_server__list_events  | yes (literal)          | n/a         |
+//   | mcp__.*                        | YES                    | YES         |
+//   | mcp__.*__.*                    | yes                    | yes         |
+//   | mcp__[^_]+__[^_]+              | NO                     | yes         |
+//   | mcp__\w+__\w+                  | yes                    | NO          |
+//
+// Before the fix the detector had the two bold rows INVERTED: it rejected
+// `mcp__.*` (fires on both) and accepted `mcp__[^_]+__[^_]+` (fires on neither
+// of the two fixtures in the issue).
+// ---------------------------------------------------------------------------
+
+const noFindings = (matcher: string) =>
+  hookMatcherIssues([{ event: "PostToolUse", matcher }], [], d);
+
+test("#131 row 1: the literal `mcp__Google_Calendar__list_events` → accepted", () => {
+  assert.deepEqual(noFindings("mcp__Google_Calendar__list_events"), []);
+});
+
+test("#131 row 2: `mcp__.*` → accepted (it fires — measured)", () => {
+  // The headline false positive: the rule told a user this never fires, and the
+  // user replaced a working matcher on its say-so.
+  assert.deepEqual(noFindings("mcp__.*"), []);
+});
+
+test("#131 row 3: `mcp__.*__.*` → accepted", () => {
+  assert.deepEqual(noFindings("mcp__.*__.*"), []);
+});
+
+test("#131 row 4: `mcp__[^_]+__[^_]+` → rejected (misses an underscored server)", () => {
+  // `[^_]+` cannot cross the `_` in `Google_Calendar` — measured: does NOT fire.
+  const findings = noFindings("mcp__[^_]+__[^_]+");
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "mcp-narrow");
+  assert.match(findings[0].message, /mcp__Google_Calendar__list_events/);
+  // …and it names ONLY what it misses: measured, this matcher DOES fire on the
+  // hyphenated uuid server, so claiming otherwise would be the same overreach
+  // the rule is being fixed for.
+  assert.doesNotMatch(findings[0].message, /4f54037d/);
+  // The honest wording: it fires on SOME tools — it is not a dead matcher.
+  assert.doesNotMatch(findings[0].message, /never fires/);
+});
+
+test("#131 row 5: `mcp__\\w+__\\w+` → rejected (misses the hyphenated uuid server)", () => {
+  // `\w` excludes `-`, so the uuid form of the same server is skipped — measured.
+  const findings = noFindings("mcp__\\w+__\\w+");
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "mcp-narrow");
+  assert.match(findings[0].message, /4f54037d/);
+  // Measured: it DOES fire on `mcp__some_server__list_events`, so the finding
+  // must not accuse it of missing the underscored-server shape.
+  assert.doesNotMatch(findings[0].message, /Google_Calendar__list_events/);
+});
+
+// ---------------------------------------------------------------------------
+// The suggestion convergence property — the check that would have caught the
+// regress in #131 ("apply the suggestion, get told the suggestion is wrong").
+// ---------------------------------------------------------------------------
+
+test("PROPERTY: every `Did you mean` suggestion satisfies the rule that produced it", () => {
+  const bad = [
+    "bash",
+    "read",
+    "mcp_memory_search",
+    "mcp-memory-search",
+    "mcp_memory_*",
+    "mcp__[^_]+__[^_]+",
+    "mcp__\\w+__\\w+",
+    "mcp__memory_search",
+    "^mcp__srv$",
+  ];
+  let suggestions = 0;
+  for (const matcher of bad) {
+    const findings = noFindings(matcher);
+    assert.equal(findings.length, 1, `${matcher} should produce one finding`);
+    const { suggestion } = findings[0];
+    if (suggestion === undefined) continue;
+    suggestions++;
+    // Feed the advice straight back in: it must be clean, in ONE step.
+    assert.deepEqual(
+      noFindings(suggestion),
+      [],
+      `suggestion "${suggestion}" for "${matcher}" is itself rejected`,
+    );
+  }
+  assert.ok(
+    suggestions >= bad.length - 1,
+    "nearly every finding advises a fix",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// invalid-regex — its own finding, not a silent skip and not "never fires by
+// shape". A matcher the engine can't compile can't match anything.
+// ---------------------------------------------------------------------------
+
+test('invalid-regex: "mcp__[a-" (unterminated class) → its own kind', () => {
+  const findings = noFindings("mcp__[a-");
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "invalid-regex");
+  assert.match(findings[0].message, /not a valid regular expression/);
+});
+
+test('invalid-regex: a non-MCP matcher "Bash(" is caught too', () => {
+  const findings = noFindings("Bash(");
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "invalid-regex");
+});
+
+// ---------------------------------------------------------------------------
+// FP-safety for the pattern path: a matcher that is narrow ON PURPOSE.
+// ---------------------------------------------------------------------------
+
+test('a server-scoped "mcp__memory__.*" is not "too narrow" (deliberate scope)', () => {
+  assert.deepEqual(noFindings("mcp__memory__.*"), []);
+});
+
+test('a server+tool-scoped "mcp__memory__search.*" is reachable (derived probe)', () => {
+  // The generic probes can't match it; the probe derived from its own literal
+  // segments can — otherwise a correctly scoped matcher reads as unreachable.
+  assert.deepEqual(noFindings("mcp__memory__search.*"), []);
+});
+
+test('a pattern in the server segment ("mcp__mem.*__list_events") is reachable', () => {
+  assert.deepEqual(noFindings("mcp__mem.*__list_events"), []);
+});
+
+test('"mcp__srv__.*" pins a server, so the narrowness check does not apply', () => {
+  // Guards the probe corpus itself: `srv` is the simple probe's server name, so
+  // a matcher pinning it must not be flagged for missing the other probes.
+  assert.deepEqual(noFindings("mcp__srv__.*"), []);
+});
+
+test('an anchored matcher that cannot reach the tool segment ("^mcp__srv$") is flagged', () => {
+  const findings = noFindings("^mcp__srv$");
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "mcp-form");
+  assert.match(findings[0].message, /never fires/);
+  assert.equal(findings[0].suggestion, "mcp__srv__.*");
+});
+
+test('an anchored but CORRECT matcher ("^mcp__srv__.*$") is clean', () => {
+  // Anchors are stripped before reading the matcher's literal segments, so an
+  // anchored server-scoped matcher gets the same verdict as its bare twin —
+  // otherwise `^` alone would resurrect the "too narrow" false positive.
+  assert.deepEqual(noFindings("^mcp__srv__.*$"), []);
+  assert.deepEqual(noFindings("^mcp__.*__.*$"), []);
+});
+
+test('"mcp__memory_search" (no tool segment) → unreachable, keeps the server whole', () => {
+  // The written segment is kept AS IS rather than split on its underscore: real
+  // servers are named `Google_Calendar`, so `memory_search` is a plausible
+  // server name and re-splitting it would invent a different server.
+  const findings = noFindings("mcp__memory_search");
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "mcp-form");
+  assert.equal(findings[0].suggestion, "mcp__memory_search__.*");
+});
+
+test('an MCP-ish alternation ("mcp__a__b|Bash") is skipped (mixed arms are legitimate)', () => {
+  assert.deepEqual(noFindings("mcp__a__b|Bash"), []);
+});
+
+test("an unrecoverable server segment falls back to spelling out the form", () => {
+  const findings = noFindings("mcp_1_2");
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "mcp-form");
+  assert.equal(findings[0].suggestion, undefined);
+  assert.match(findings[0].message, /mcp__<server>__<tool>/);
 });
 
 test("two different typos each produce their own finding (no cross-dedup)", () => {

--- a/src/core/hook-matcher.ts
+++ b/src/core/hook-matcher.ts
@@ -1,34 +1,73 @@
 /**
  * Hook-matcher verification — the cross-referencing moat applied to the MATCHER
- * string inside a hook registration. A PreToolUse hook fires only when its
- * `matcher` equals the tool name the harness emits (or matches via glob/regex); a
- * typo or wrong form silently prevents the hook from ever running — exactly the
- * FALSE CONFIDENCE failure the compiled-hooks design exists to eliminate
- * (research/hook-pain-points.md).
+ * string inside a hook registration. A hook fires only when its `matcher` selects
+ * the tool name the harness emits; a typo or an unmatchable pattern silently
+ * prevents the hook from ever running — exactly the FALSE CONFIDENCE failure the
+ * compiled-hooks design exists to eliminate (research/hook-pain-points.md).
  *
- * THREE kinds of bad matcher, each verified here (one-detector-no-drift):
+ * ## The matching semantics this detector models (MEASURED, not assumed)
  *
- * 1. **tool-typo** — a bare token that is a CLOSE TYPO (edit distance ≤ 2) of a
- *    real built-in tool name but not an exact match (`bash` → `Bash`, `read` →
- *    `Read`). Suggests the correct casing. Reuses `closestTool` from
- *    `tool-contract.ts` — same edit-distance logic, same ≤ 2 confidence bound.
+ * A matcher is NOT a literal tool name — it is a pattern. Measured against the
+ * real `claude` CLI (2.1.226) with the scripted mock model, one hook per run,
+ * marker file as the oracle:
  *
- * 2. **mcp-form** — a token that looks MCP-ish (starts with `mcp`, case-
- *    insensitive) but is NOT the required `mcp__<server>__<tool>` double-underscore
- *    shape (single underscores, a hyphen, a trailing `*`…). Suggests the corrected
- *    form when the server/tool segments can be recovered.
+ * | matcher              | tool called                                     | fired |
+ * | -------------------- | ----------------------------------------------- | ----- |
+ * | `Write`              | `Write`                                         | yes   |
+ * | `Writ` / `rit`       | `Write`                                         | NO    |
+ * | `rit.`               | `Write`                                         | yes   |
+ * | `W(rit)e`            | `Write`                                         | yes   |
+ * | `mcp__.*`            | `mcp__some_server__list_events`                 | yes   |
+ * | `mcp__.*__.*`        | `mcp__some_server__list_events`                 | yes   |
+ * | `mcp__[^_]+__[^_]+`  | `mcp__some_server__list_events`                 | NO    |
+ * | `mcp__[^_]+__[^_]+`  | `mcp__4f54037d-…-6130f3da1ef8__list_events`      | yes   |
+ * | `mcp__\w+__\w+`      | `mcp__some_server__list_events`                 | yes   |
+ * | `mcp__\w+__\w+`      | `mcp__4f54037d-…-6130f3da1ef8__list_events`      | NO    |
  *
- * 3. **mcp-undeclared** — a correctly-formed `mcp__<server>__…` token whose server
- *    is NOT in the plugin's declared MCP servers. Gated EXACTLY like
- *    `mcp-tool-resolves`: (a) no declared set → skip (reaches global/project
- *    servers); (b) built-ins allowlisted via `dialect.knownMcpServers`; (c) the
- *    plugin-namespaced `mcp__plugin_…__…` form is skipped. Reuses `mcpToolServer`
- *    from `mcp-tool.ts` for the extraction — one parser, no drift.
+ * Two facts follow, and the detector encodes exactly these:
  *
- * FP-SAFE: only a SINGLE bare token is inspected. A matcher that is empty, a pure
- * wildcard (`*` / `.*`), or contains alternation (`|`) or other regex meta-
- * characters is skipped — it is a pattern/glob with legitimate broad matching, not
- * a tool name. Same don't-cry-wolf discipline as every other vigiles detector.
+ * 1. A matcher with NO regex metacharacter is matched by STRING EQUALITY
+ *    (`rit` does not fire on `Write`, though it is a substring).
+ * 2. A matcher WITH metacharacters is matched as an UNANCHORED regex
+ *    (`rit.` fires on `Write`; `mcp__[^_]+__[^_]+` fires on the hyphenated
+ *    server because `[^_]+` only has to reach *into* the tool segment).
+ *
+ * ## What is flagged (five kinds)
+ *
+ * 1. **tool-typo** — a LITERAL bare token that is a close typo (edit distance ≤ 2)
+ *    of a real built-in tool (`bash` → `Bash`). Reuses `closestTool`.
+ * 2. **invalid-regex** — the matcher does not COMPILE. A dead hook no other check
+ *    catches, and its own finding rather than a silent skip.
+ * 3. **mcp-form** — an MCP-ish matcher that can match NO MCP tool name at all:
+ *    a literal that isn't the `mcp__<server>__<tool>` shape (`mcp_memory_search`),
+ *    or a pattern that matches none of the synthetic probes (`mcp_memory_*`).
+ * 4. **mcp-narrow** — an MCP-ish pattern that DOES fire, but not on the server
+ *    naming that occurs in the wild. `mcp__[^_]+__[^_]+` cannot cross the `_` in
+ *    `Google_Calendar`; `mcp__\w+__\w+` cannot cross the `-` in the uuid form —
+ *    and the SAME server appears both ways in different sessions. This is a real
+ *    gap but it is NOT "never fires", and the message says so.
+ * 5. **mcp-undeclared** — a matcher pinning a literal `mcp__<server>__…` the
+ *    plugin doesn't declare. Gated exactly like `mcp-tool-resolves`.
+ *
+ * ## Why patterns are validated by PROBING, not by shape
+ *
+ * The server segment is not stable: the same Google Calendar server is
+ * `mcp__Google_Calendar__list_events` in one session and
+ * `mcp__4f54037d-…__list_events` in another, so a hook keyed to one literal id
+ * dies silently when the id changes — patterns are the CORRECT authoring form.
+ * Validating a pattern against the literal shape therefore inverts the verdict:
+ * it rejected `mcp__.*` (fires on everything) and accepted `mcp__[^_]+__[^_]+`
+ * (fires on nothing with an underscored server). So a pattern is instead COMPILED
+ * and run against synthetic probes — including a probe whose server segment holds
+ * an underscore and one whose server segment holds hyphens, because both occur.
+ * Probes are also DERIVED from the matcher's own literal segments, so a correctly
+ * server-scoped `mcp__memory__.*` is never called unreachable (#131).
+ *
+ * FP-SAFE, unchanged in spirit: a match-all (`*`, `.*`, `**`, empty) or an
+ * ALTERNATION (`Edit|Write`) is skipped — each arm of an alternation would have
+ * to be judged separately, and a mixed arm set is legitimate. A non-MCP token
+ * carrying regex/glob syntax is skipped too (it is a pattern over built-in tool
+ * names, not a name).
  *
  * Pure + ONE detector reused by `scan` + the `hook-matcher` lint rule
  * (one-detector-no-drift). The dialect is injected (core ⊄ adapter).
@@ -42,9 +81,14 @@ import { mcpToolServer } from "./mcp-tool.js";
 // ---------------------------------------------------------------------------
 
 /** Which matching failure was detected in the hook matcher string. */
-export type HookMatcherKind = "tool-typo" | "mcp-form" | "mcp-undeclared";
+export type HookMatcherKind =
+  | "tool-typo"
+  | "invalid-regex"
+  | "mcp-form"
+  | "mcp-narrow"
+  | "mcp-undeclared";
 
-/** One finding for a hook matcher that will silently never fire. */
+/** One finding for a hook matcher that doesn't fire the way it reads. */
 export interface HookMatcherFinding {
   /** The matcher string exactly as written. */
   readonly matcher: string;
@@ -54,6 +98,9 @@ export interface HookMatcherFinding {
    * The corrected matcher when the intent is recoverable (e.g. `Bash` for
    * `bash`, `mcp__memory__.*` for `mcp_memory_*`). Absent when the server
    * segment can't be recovered from a malformed MCP form.
+   *
+   * INVARIANT (property-tested): a suggestion, fed back through this detector,
+   * produces no finding — the advice converges in one step.
    */
   readonly suggestion?: string;
   /** A ready-to-show, actionable message. */
@@ -67,89 +114,309 @@ export interface HookMatcherEntry {
 }
 
 // ---------------------------------------------------------------------------
-// Internal helpers
+// The probe corpus
 // ---------------------------------------------------------------------------
 
 /**
- * Whether a matcher token should be skipped for FP-safety. We ONLY inspect
- * a SINGLE bare token that could plausibly be a literal tool name or MCP
- * reference. Anything with regex / glob meta-characters, alternation, a
- * trailing glob wildcard alone, or an empty string is a pattern — skip it.
- *
- * Conservative by design: an unrecognized form → skip, never flag.
+ * Server segments an MCP tool name really carries. `Google_Calendar` is
+ * Anthropic's own connector naming (an underscore INSIDE the server segment);
+ * the uuid is the SAME server as it appears in another session (hyphens). A
+ * matcher meant to catch "MCP tools" has to reach both.
  */
-function isInspectableToken(token: string): boolean {
-  if (token.length === 0) return false;
-  // Pure wildcard forms used as "match-all" matchers.
-  if (token === "*" || token === ".*" || token === "**") return false;
-  // Contains regex alternation — a combined matcher, not a single tool name.
-  if (token.includes("|")) return false;
-  // Contains a parenthesised group `(…)` — regex, not a tool name.
+const PROBE_SERVERS = [
+  "srv",
+  "Google_Calendar",
+  "4f54037d-0499-426a-8573-6130f3da1ef8",
+] as const;
+
+/** Tool segments: plain, underscored, and the second underscored form. */
+const PROBE_TOOLS = ["tool", "list_events", "update_event"] as const;
+
+/** The simplest possible MCP tool name — "does this pattern match MCP at all". */
+const PROBE_SIMPLE = "mcp__srv__tool";
+
+/**
+ * The two REAL-SHAPE probes a generic MCP matcher must also reach. Both are
+ * measured: `mcp__[^_]+__[^_]+` does not fire on the first, `mcp__\w+__\w+`
+ * does not fire on the second.
+ */
+const REAL_SHAPE_PROBES = [
+  "mcp__Google_Calendar__list_events",
+  "mcp__4f54037d-0499-426a-8573-6130f3da1ef8__update_event",
+] as const;
+
+/** The widest correct MCP matcher — what a too-narrow one should become. */
+const WIDE_MCP_MATCHER = "mcp__.*__.*";
+
+/** Match-all matchers the harness special-cases (and `*` isn't even a regex). */
+const MATCH_ALL = new Set(["", "*", "**", ".*"]);
+
+/** Cap on segments harvested from a matcher — bounds the probe corpus. */
+const MAX_DERIVED_SEGMENTS = 4;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Regex metacharacters — their presence is what makes a matcher a PATTERN. */
+const REGEX_META = /[\\^$.*+?()[\]{}|]/;
+
+/** A matcher with no metacharacter is compared by string equality (measured). */
+function isLiteralMatcher(matcher: string): boolean {
+  return !REGEX_META.test(matcher);
+}
+
+/** Compile a matcher, or null when the regex engine rejects it. */
+function compileMatcher(matcher: string): RegExp | null {
+  try {
+    return new RegExp(matcher);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A token starts with `mcp` followed by a separator — it is trying to be an MCP
+ * tool reference, whether or not it succeeds. A leading `^` is tolerated so an
+ * ANCHORED pattern (`^mcp__srv$`, which cannot reach the tool segment) is judged
+ * as MCP rather than skipped as an unknown built-in.
+ */
+function looksMcpIsh(token: string): boolean {
+  return /^\^?mcp[_-]/i.test(token);
+}
+
+/**
+ * Whether a NON-MCP token should be inspected as a possible tool-name typo. We
+ * only inspect a single bare token that could plausibly BE a tool name; regex /
+ * glob syntax means it is a pattern over tool names, not one. Conservative by
+ * design: an unrecognized form → skip, never flag.
+ */
+function isBareToolToken(token: string): boolean {
   if (token.includes("(") || token.includes(")")) return false;
-  // Contains a `[` — character class; skip.
   if (token.includes("[")) return false;
-  // A leading `^` or trailing `$` — anchored regex.
   if (token.startsWith("^") || token.endsWith("$")) return false;
-  // Leading `.*` — regex prefix; always a pattern.
   if (token.startsWith(".*")) return false;
-  // A trailing `.*`/`*` is a glob/regex suffix on a plain TOOL matcher (`Bash.*`,
-  // `Read*`) → skip. But for an MCP-ish token the trailing wildcard is EXACTLY
-  // what we must inspect: `mcp__server__.*` is the legitimate match-all-tools
-  // form, and `mcp_memory_*` is the classic single-underscore typo we want to
-  // catch — so do NOT skip a wildcard suffix on an `mcp`-ish token.
-  if (!looksMcpIsh(token) && (token.endsWith(".*") || token.endsWith("*")))
-    return false;
+  if (token.endsWith(".*") || token.endsWith("*")) return false;
   return true;
 }
 
 /**
- * A token starts with `mcp` (case-insensitive) and contains at least one
- * `_` (making it look like an MCP tool reference, not a harness built-in).
+ * Strip the regex anchors so an anchored matcher (`^mcp__memory__.*$`) is read
+ * structurally the same as its unanchored twin. The anchors stay in the compiled
+ * regex — this is only for reading the matcher's literal segments.
  */
-function looksMcpIsh(token: string): boolean {
-  return /^mcp[_-]/i.test(token);
+function withoutAnchors(matcher: string): string {
+  return matcher.replace(/^\^/, "").replace(/\$$/, "");
+}
+
+/** The literal server segment of `mcp__<server>__…`, or null when it's a pattern. */
+function literalServerSegment(matcher: string): string | null {
+  return /^mcp__([A-Za-z0-9_-]+)__/.exec(withoutAnchors(matcher))?.[1] ?? null;
+}
+
+/** Literal name-shaped runs inside one segment of a matcher (`mem.*` → `mem`). */
+function literalRuns(segment: string): string[] {
+  return (segment.match(/[A-Za-z0-9][A-Za-z0-9_-]*/g) ?? []).slice(
+    0,
+    MAX_DERIVED_SEGMENTS,
+  );
 }
 
 /**
- * Whether `token` matches the canonical `mcp__<server>__<rest>` double-
- * underscore shape (the valid MCP matcher form). We use the dialect's own
- * `mcpToolPattern` extended to allow trailing `.*` for wildcard matchers,
- * since a hook `matcher` may be `mcp__server__.*` (match-all-tools-on-server).
+ * Synthetic MCP tool names to test a matcher against: the generic corpus (the
+ * real-world server/tool shapes) PLUS names built from the matcher's OWN literal
+ * segments, so a legitimately scoped `mcp__memory__search.*` has something to
+ * match. Derivation is POSITIONAL — segments are read from the `mcp__`-split
+ * positions they occupy, never re-used as a different segment — so a malformed
+ * `mcp_memory_search` cannot manufacture a probe that rescues it.
  */
-function isValidMcpForm(token: string, dialect: HarnessDialect): boolean {
-  // The canonical pattern from the dialect: `mcp__server__tool`.
-  if (dialect.mcpToolPattern.test(token)) return true;
-  // Also allow the wildcard suffix form `mcp__server__.*`.
-  if (/^mcp__[a-z0-9_-]+__\.\*$/i.test(token)) return true;
-  return false;
+function mcpProbes(matcher: string): string[] {
+  const parts = withoutAnchors(matcher).split("__");
+  const derivedServers =
+    parts[0] === "mcp" && parts.length > 1 ? literalRuns(parts[1]) : [];
+  const derivedTools =
+    parts[0] === "mcp" && parts.length > 2
+      ? literalRuns(parts.slice(2).join("__"))
+      : [];
+  const servers = [...derivedServers, ...PROBE_SERVERS];
+  const tools = [...derivedTools, ...PROBE_TOOLS];
+  const probes: string[] = [];
+  for (const server of servers)
+    for (const tool of tools) probes.push(`mcp__${server}__${tool}`);
+  return probes;
 }
 
 /**
- * Attempt to recover the server segment from a malformed MCP token so we can
- * suggest the corrected `mcp__<server>__.*` form. Returns null when no
- * segment can be confidently recovered.
+ * Recover the server segment from a malformed MCP token so the corrected
+ * `mcp__<server>__.*` form can be suggested. Returns null when nothing
+ * name-shaped can be recovered (then the message spells the form out instead).
  *
- * Handles:
- *   - Single-underscore: `mcp_memory_search` → server=`memory`, tool=`search`
- *   - Hyphenated:        `mcp-memory-search` → server=`memory`, tool=`search`
- *   - Glob suffix:       `mcp_memory_*`       → server=`memory`
- *   - Mixed:             `mcp__memory_*`      → only one `__` segment found
+ * Handles the `__`-separated form first — the segment the user actually wrote is
+ * kept whole (`mcp__memory_search` → `memory_search`, since a real server IS
+ * named like `Google_Calendar`) — then the single-underscore / hyphen typos
+ * (`mcp_memory_search`, `mcp-memory-search`, `mcp_memory_*` → `memory`).
  */
 function recoverMcpServer(token: string): string | null {
-  // Strip a leading `mcp` and then a separator (`__`, `_`, `-`).
-  const rest = token.replace(/^mcp(?:__|_|-)/i, "");
-  if (!rest || rest === token) return null;
+  const parts = withoutAnchors(token).split("__");
+  const candidate =
+    parts.length > 1 && parts[1].length > 0
+      ? parts[1]
+      : firstSeparatedSegment(token);
+  if (candidate === null) return null;
+  // A recovered segment must be name-shaped, or the "suggestion" would be a
+  // regex fragment — the bug that made the old advice grow `__.*` forever.
+  return /^[A-Za-z][A-Za-z0-9_-]*$/.test(candidate) ? candidate : null;
+}
 
-  // Split on single underscores or hyphens (not `__`) to get the next segment.
-  // We want the first non-empty segment after the `mcp` prefix separator.
-  const segments = rest.split(/(?<!_)_(?!_)|(?<!-)(?:-(?!-))/);
-  const server = segments[0];
-  if (!server || server.length === 0) return null;
+/** The segment after a single `_`/`-` separator following the `mcp` prefix. */
+function firstSeparatedSegment(token: string): string | null {
+  const rest = withoutAnchors(token).replace(/^mcp(?:_|-)/i, "");
+  if (rest === token || rest.length === 0) return null;
+  const segment = rest.split(/(?<!_)_(?!_)|-/)[0];
+  return segment.length > 0 ? segment : null;
+}
 
-  // Reject segments that are clearly numeric-only or single chars (too ambiguous).
-  if (/^\d+$/.test(server)) return null;
+// ---------------------------------------------------------------------------
+// Finding builders
+// ---------------------------------------------------------------------------
 
-  return server;
+/** The matcher can match NO MCP tool name — the hook is dead. */
+function unreachableFinding(matcher: string): HookMatcherFinding {
+  const server = recoverMcpServer(matcher);
+  const suggestion = server === null ? undefined : `mcp__${server}__.*`;
+  const hint =
+    suggestion === undefined
+      ? " Use the form `mcp__<server>__<tool>` (double underscores), or a pattern that produces it."
+      : ` Did you mean "${suggestion}"?`;
+  return {
+    matcher,
+    kind: "mcp-form",
+    ...(suggestion === undefined ? {} : { suggestion }),
+    message: `Hook matcher "${matcher}" matches no MCP tool name — MCP tools are named \`mcp__<server>__<tool>\`, so this hook never fires.${hint}`,
+  };
+}
+
+/**
+ * The matcher fires on some MCP tools but misses real-world server naming. The
+ * message names the probes it actually misses — not the whole corpus — so the
+ * finding is checkable rather than a vague "too narrow".
+ */
+function narrowFinding(
+  matcher: string,
+  missed: readonly string[],
+): HookMatcherFinding {
+  const names = missed.map((m) => `"${m}"`).join(" or ");
+  return {
+    matcher,
+    kind: "mcp-narrow",
+    suggestion: WIDE_MCP_MATCHER,
+    message: `Hook matcher "${matcher}" fires on some MCP tools but not on ${names} — real server segments contain "_" and "-" (the same server appears as \`mcp__Google_Calendar__…\` in one session and \`mcp__<uuid>__…\` in another), so this matcher silently skips them. Did you mean "${WIDE_MCP_MATCHER}"?`,
+  };
+}
+
+/** The matcher isn't a regex the engine accepts — it can never match. */
+function invalidRegexFinding(matcher: string): HookMatcherFinding {
+  return {
+    matcher,
+    kind: "invalid-regex",
+    message: `Hook matcher "${matcher}" is not a valid regular expression — the harness can't compile it, so the hook never fires.`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-matcher checks
+// ---------------------------------------------------------------------------
+
+/**
+ * The shape half of the MCP check: can this matcher produce an MCP tool name at
+ * all, and if so does it reach the ones that occur in the wild? `re` is null for
+ * a literal matcher (compared by string equality, so only the shape can be
+ * checked).
+ */
+function mcpShapeFinding(
+  matcher: string,
+  re: RegExp | null,
+  dialect: HarnessDialect,
+): HookMatcherFinding | null {
+  if (re === null)
+    return dialect.mcpToolPattern.test(matcher)
+      ? null
+      : unreachableFinding(matcher);
+  if (!mcpProbes(matcher).some((p) => re.test(p)))
+    return unreachableFinding(matcher);
+  // The narrowness check applies only to a matcher meant to be GENERIC: one that
+  // pins no literal server yet matches the simplest MCP name. A matcher scoped to
+  // one server (or to specific tools) is narrow ON PURPOSE — never flag it.
+  if (literalServerSegment(matcher) !== null || !re.test(PROBE_SIMPLE))
+    return null;
+  const missed = REAL_SHAPE_PROBES.filter((p) => !re.test(p));
+  return missed.length === 0 ? null : narrowFinding(matcher, missed);
+}
+
+/**
+ * The resolution half: a matcher pinning a literal server the plugin doesn't
+ * declare can't fire. Gated EXACTLY like `mcp-tool-resolves` — no declared set →
+ * silent (the server may be user-global), built-ins allowlisted, the
+ * plugin-namespaced form skipped.
+ */
+function mcpUndeclaredFinding(
+  matcher: string,
+  declaredServers: readonly string[],
+  dialect: HarnessDialect,
+): HookMatcherFinding | null {
+  if (declaredServers.length === 0) return null;
+  const server =
+    mcpToolServer(matcher, dialect) ?? literalServerSegment(matcher);
+  if (server === null) return null;
+  if (/^plugin_/i.test(server)) return null;
+  const known = new Set<string>([
+    ...declaredServers,
+    ...(dialect.knownMcpServers ?? []),
+  ]);
+  if (known.has(server)) return null;
+  return {
+    matcher,
+    kind: "mcp-undeclared",
+    message: `Hook matcher "${matcher}" references MCP server "${server}", which the plugin doesn't declare (declared: ${declaredServers.join(", ")}) — the hook can't fire.`,
+  };
+}
+
+/** A literal bare token that is a close typo of a real built-in tool. */
+function toolTypoFinding(
+  matcher: string,
+  dialect: HarnessDialect,
+): HookMatcherFinding | null {
+  if (!isBareToolToken(matcher)) return null;
+  if (new Set(dialect.builtinAgentTools).has(matcher)) return null;
+  const near = closestTool(matcher, dialect);
+  if (near === null) return null; // far/unknown → likely a plugin tool, not a typo
+  return {
+    matcher,
+    kind: "tool-typo",
+    suggestion: near,
+    message: `Hook matcher "${matcher}" doesn't match any built-in tool — the hook silently never fires. Did you mean "${near}"?`,
+  };
+}
+
+/** The whole per-matcher decision. Null when the matcher is fine (or skipped). */
+function matcherFinding(
+  matcher: string,
+  declaredServers: readonly string[],
+  dialect: HarnessDialect,
+): HookMatcherFinding | null {
+  if (MATCH_ALL.has(matcher)) return null;
+  // Alternation: each arm would have to be judged on its own, and a mixed set
+  // (`mcp__x__y|Bash`) is legitimate — skip, same don't-cry-wolf discipline.
+  if (matcher.includes("|")) return null;
+  const literal = isLiteralMatcher(matcher);
+  const re = literal ? null : compileMatcher(matcher);
+  if (!literal && re === null) return invalidRegexFinding(matcher);
+  if (looksMcpIsh(matcher))
+    return (
+      mcpShapeFinding(matcher, re, dialect) ??
+      mcpUndeclaredFinding(matcher, declaredServers, dialect)
+    );
+  return literal ? toolTypoFinding(matcher, dialect) : null;
 }
 
 // ---------------------------------------------------------------------------
@@ -157,10 +424,10 @@ function recoverMcpServer(token: string): string | null {
 // ---------------------------------------------------------------------------
 
 /**
- * Verify hook-matcher strings for the three forms that silently never fire.
+ * Verify hook-matcher strings for the ways a matcher fails to fire as written.
  * Returns one {@link HookMatcherFinding} per offending entry. De-duplicates
- * repeated matchers. Returns `[]` when all matchers are FP-safe to skip or
- * are correct.
+ * repeated matchers. Returns `[]` when every matcher is FP-safe to skip or is
+ * correct.
  */
 export function hookMatcherIssues(
   entries: readonly HookMatcherEntry[],
@@ -169,83 +436,11 @@ export function hookMatcherIssues(
 ): HookMatcherFinding[] {
   const findings: HookMatcherFinding[] = [];
   const seen = new Set<string>();
-
   for (const { matcher } of entries) {
-    // De-dupe repeated matchers across entries.
-    if (seen.has(matcher)) continue;
+    if (seen.has(matcher)) continue; // de-dupe repeated matchers across entries
     seen.add(matcher);
-
-    // Skip wildcards, alternation, regex patterns — FP-safety.
-    if (!isInspectableToken(matcher)) continue;
-
-    // ── kind: mcp-form ──────────────────────────────────────────────────────
-    // The token looks MCP-ish but is NOT the valid double-underscore form.
-    if (looksMcpIsh(matcher)) {
-      if (!isValidMcpForm(matcher, dialect)) {
-        const server = recoverMcpServer(matcher);
-        const suggestion = server ? `mcp__${server}__.*` : undefined;
-        const hintPart =
-          suggestion !== undefined
-            ? ` Did you mean "${suggestion}"?`
-            : " Use the form `mcp__<server>__<tool>` (double underscores).";
-        findings.push({
-          matcher,
-          kind: "mcp-form",
-          ...(suggestion !== undefined ? { suggestion } : {}),
-          message: `Hook matcher "${matcher}" is not a valid MCP tool reference (requires double underscores: \`mcp__server__tool\`).${hintPart}`,
-        });
-        continue;
-      }
-
-      // ── kind: mcp-undeclared ──────────────────────────────────────────────
-      // A correctly-formed MCP token whose server isn't in the declared set.
-      // Guard 1: no declared set → skip (reaches global/project servers).
-      if (declaredServers.length === 0) continue;
-
-      // `mcpToolServer` reads the `mcp__server__tool` form; a server-wide WILDCARD
-      // matcher (`mcp__server__.*`) isn't a concrete tool, so fall back to the
-      // wildcard server segment so an undeclared server is still caught.
-      const server =
-        mcpToolServer(matcher, dialect) ??
-        /^mcp__([a-z0-9_-]+)__\.\*$/i.exec(matcher)?.[1] ??
-        null;
-      if (server === null) continue; // plugin-namespaced form → guard 3, skip
-      // The plugin-namespaced `mcp__plugin_<plugin>_<server>__` form is the
-      // plugin's OWN server — never an undeclared reference (mirrors mcpToolServer).
-      if (/^plugin_/i.test(server)) continue;
-
-      const known = new Set<string>([
-        ...declaredServers,
-        ...(dialect.knownMcpServers ?? []),
-      ]);
-
-      // Guard 2: built-in server → skip.
-      if (known.has(server)) continue;
-
-      findings.push({
-        matcher,
-        kind: "mcp-undeclared",
-        message: `Hook matcher "${matcher}" references MCP server "${server}", which the plugin doesn't declare (declared: ${declaredServers.join(", ")}) — the hook can't fire.`,
-      });
-      continue;
-    }
-
-    // ── kind: tool-typo ─────────────────────────────────────────────────────
-    // A bare token that is NOT an exact built-in tool but IS a close typo of one.
-    const knownTools = new Set(dialect.builtinAgentTools);
-    if (knownTools.has(matcher)) continue; // exact match → no issue
-
-    // Reuse the same ≤ 2 edit-distance helper from tool-contract.ts.
-    const near = closestTool(matcher, dialect);
-    if (near === null) continue; // far/unknown → likely a plugin tool, not a typo
-
-    findings.push({
-      matcher,
-      kind: "tool-typo",
-      suggestion: near,
-      message: `Hook matcher "${matcher}" doesn't match any built-in tool — the hook silently never fires. Did you mean "${near}"?`,
-    });
+    const finding = matcherFinding(matcher, declaredServers, dialect);
+    if (finding !== null) findings.push(finding);
   }
-
   return findings;
 }

--- a/src/core/rule-meta.ts
+++ b/src/core/rule-meta.ts
@@ -228,7 +228,8 @@ export const RULE_META: Record<RuleName, RuleMeta> = {
     bucket: "structural-closed",
     surface: ["hook"],
     defaultSeverity: "warn",
-    summary: "A hook matcher fires (no tool-name typo / malformed MCP form).",
+    summary:
+      "A hook matcher fires as written (no tool-name typo, no MCP pattern that reaches nothing or misses real server names).",
     detector: "hookMatcherIssues",
     upstreamPrevention: "compiled hook tool()/tools() matcher is typed",
   },

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -311,12 +311,16 @@ export interface RulesConfig {
    */
   "hook-block-ineffective"?: RuleSeverity;
   /**
-   * Flag a hook `matcher` string that silently never fires — a close typo of a
-   * built-in tool (`bash`→`Bash`), or a malformed/undeclared MCP form
-   * (`mcp_memory_*` instead of `mcp__memory__.*`, or a server the plugin doesn't
-   * declare). High-precision (close-typo only; MCP gated on a declared set,
-   * built-ins allowlisted; wildcards/regex skipped). Default "warn"; raise to
-   * "error" to gate CI. Same detector as `scan` (hookMatcherFindings). See
+   * Flag a hook `matcher` string that doesn't fire the way it reads — a close
+   * typo of a built-in tool (`bash`→`Bash`), a matcher that doesn't COMPILE, an
+   * MCP pattern that can match no tool name at all (`mcp_memory_*` instead of
+   * `mcp__memory__.*`), an MCP pattern too narrow for real server naming
+   * (`mcp__[^_]+__[^_]+` can't cross the `_` in `mcp__Google_Calendar__…`), or a
+   * server the plugin doesn't declare. A matcher is a PATTERN, so patterns are
+   * validated by compiling and probing, never by literal shape. High-precision
+   * (close-typo only; MCP gated on a declared set, built-ins allowlisted;
+   * match-all and alternation skipped). Default "warn"; raise to "error" to gate
+   * CI. Same detector as `scan` (hookMatcherFindings). See
    * docs/rules/hook-matcher.md.
    */
   "hook-matcher"?: RuleSeverity;

--- a/src/core/validate.ts
+++ b/src/core/validate.ts
@@ -122,8 +122,9 @@ export const DEFAULT_RULES: Required<RulesConfig> = {
   // A hook that looks like it blocks but silently doesn't (#19009) — WARN by
   // default (FP-safe literal patterns); raise to error to gate CI.
   "hook-block-ineffective": "warn",
-  // A hook matcher that never fires (tool typo / wrong MCP form) — WARN by
-  // default (high-precision); raise to error to gate CI.
+  // A hook matcher that doesn't fire as written (tool typo, an MCP pattern
+  // that matches no tool name, or one too narrow for real server names) — WARN
+  // by default (high-precision); raise to error to gate CI.
   "hook-matcher": "warn",
 };
 

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -333,9 +333,10 @@ export interface ScanReport {
    */
   readonly hookBlockFindings: readonly HookBlockFinding[];
   /**
-   * Hook `matcher` strings that silently never fire — a tool-name typo or a
-   * malformed/undeclared MCP form. Shared by `scan` and the `hook-matcher` lint
-   * rule (one detector, no drift).
+   * Hook `matcher` strings that don't fire as written — a tool-name typo, a
+   * matcher that doesn't compile, an MCP pattern that matches no tool name or is
+   * too narrow for real server naming, or an undeclared MCP server. Shared by
+   * `scan` and the `hook-matcher` lint rule (one detector, no drift).
    */
   readonly hookMatcherFindings: readonly HookMatcherFinding[];
   /** Skills/agents whose `---` block isn't valid YAML — informational (may still load via salvage). */
@@ -941,7 +942,7 @@ export function formatScanReport(r: ScanReport): string {
 
   out.push(
     ...section(
-      "Hook matchers that never fire",
+      "Hook matchers that don't fire as written",
       r.hookMatcherFindings.map((m) => `  ✗ ${m.message}`),
     ),
   );

--- a/src/score-core.ts
+++ b/src/score-core.ts
@@ -272,7 +272,8 @@ export function reportDeductions(r: ScanReport): Deduction[] {
     {
       n: r.hookMatcherFindings.length,
       weight: W_MISSING_HOOK,
-      label: "hook matcher(s) that never fire (typo / wrong MCP form)",
+      label:
+        "hook matcher(s) that don't fire as written (dead, or too narrow for real MCP names)",
     },
     // NB: delegationTrifecta (like the advisory per-unit/inherits-all trifecta) is a
     // ⚠ RISK, surfaced but NOT graded — only the HARD per-unit trifecta above scores.

--- a/tools/README.md
+++ b/tools/README.md
@@ -16,6 +16,17 @@ repo root. (The BUILD pipeline — `api-extractor.mjs`, `build-report.mjs` — l
   release or after a detector change, to prove no false-positive regression on
   real plugins (breadth, vs the few SHA-pinned slices asserted in tests).
 
+## Live — harness ground truth
+
+- **`measure-hook-matcher-semantics.mjs`** — measure how the harness ACTUALLY
+  matches a hook `matcher` (literal equality vs unanchored regex; which MCP
+  patterns fire on which server naming), by running the real `claude` CLI against
+  the scripted mock model with one hook per row and a marker file as the oracle.
+  No API key, no cost. **Run when:** a new Claude Code version lands, or before
+  changing `src/core/hook-matcher.ts` — that detector encodes this table, and
+  issue #131 is what happens when it is assumed instead of measured. Usage:
+  `node tools/measure-hook-matcher-semantics.mjs [--suite=builtin|mcp] [--server=<name>]`.
+
 ## Occasional — pre-launch
 
 - **`fp-sweep.sh`** — launch-readiness "don't cry wolf" sweep: clone popular

--- a/tools/measure-hook-matcher-semantics.mjs
+++ b/tools/measure-hook-matcher-semantics.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/**
+ * MEASURE how the harness actually matches a hook `matcher` — the ground truth
+ * behind `src/core/hook-matcher.ts` (and behind issue #131, where the detector
+ * had judged a matcher by its literal SHAPE and inverted its verdict on both
+ * contested MCP forms).
+ *
+ * Nothing here is argued. Each row runs the real `claude` CLI against the
+ * scripted mock model (no API key, no cost), with ONE PostToolUse hook whose
+ * matcher is under test and whose only job is to append a marker to a file.
+ * The marker is the oracle: present ⇒ the hook fired.
+ *
+ * Two suites:
+ *   builtin — matchers against a `Write` call (is a matcher a literal or a regex,
+ *             and is the regex anchored?)
+ *   mcp     — matchers against a REAL MCP server connected under a name given by
+ *             --server (default `some_server`, an underscore inside the server
+ *             segment like Anthropic's own `Google_Calendar` connector). Pass a
+ *             uuid-shaped name to measure the hyphenated form of the same server.
+ *
+ * Run (from the repo root, after `npm run build`):
+ *   node tools/measure-hook-matcher-semantics.mjs
+ *   node tools/measure-hook-matcher-semantics.mjs --suite=mcp
+ *   node tools/measure-hook-matcher-semantics.mjs --suite=mcp --server=4f54037d-0499-426a-8573-6130f3da1ef8
+ *
+ * Measured 2026-08-09 on claude 2.1.226 (the table lives in the detector header
+ * and docs/rules/hook-matcher.md):
+ *   `Write` fires · `Writ`/`rit` do NOT · `rit.` and `W(rit)e` DO
+ *     ⇒ no metacharacter = string EQUALITY; metacharacters = an UNANCHORED regex.
+ *   `mcp__.*` and `mcp__.*__.*` fire on both server namings.
+ *   `mcp__[^_]+__[^_]+` does NOT fire on `mcp__some_server__…`  (but does on the uuid).
+ *   `mcp__\w+__\w+`     does NOT fire on `mcp__<uuid>__…`       (but does on some_server).
+ */
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { runHarnessTest, scriptModel, claudeAvailable } =
+  await import("../dist/harness-test.js").then((m) => m.default ?? m);
+
+const arg = (name, fallback) =>
+  process.argv.find((a) => a.startsWith(`--${name}=`))?.split("=")[1] ??
+  fallback;
+
+const suite = arg("suite", "builtin");
+const server = arg("server", "some_server");
+
+const BUILTIN_MATCHERS = ["Write", "Writ", "rit", "rit.", "W(rit)e", "rit|zzz"];
+const MCP_MATCHERS = [
+  `mcp__${server}__list_events`,
+  "mcp__.*",
+  "mcp__.*__.*",
+  "mcp__[^_]+__[^_]+",
+  "mcp__\\w+__\\w+",
+  "NoSuchToolAtAll",
+];
+
+/** A minimal REAL MCP server over stdio that also answers `tools/call`. */
+const MCP_SERVER_SOURCE = `
+let buf = "";
+process.stdin.setEncoding("utf-8");
+process.stdin.on("data", (c) => {
+  buf += c;
+  let nl = buf.indexOf("\\n");
+  while (nl >= 0) {
+    const line = buf.slice(0, nl).trim();
+    buf = buf.slice(nl + 1);
+    if (line) handle(line);
+    nl = buf.indexOf("\\n");
+  }
+});
+const send = (o) => process.stdout.write(JSON.stringify(o) + "\\n");
+function handle(line) {
+  let m; try { m = JSON.parse(line); } catch { return; }
+  if (m.method === "initialize")
+    send({ jsonrpc: "2.0", id: m.id, result: { protocolVersion: "2024-11-05", capabilities: { tools: {} }, serverInfo: { name: "fixture", version: "0.0.0" } } });
+  else if (m.method === "tools/list")
+    send({ jsonrpc: "2.0", id: m.id, result: { tools: [{ name: "list_events", description: "List events.", inputSchema: { type: "object", properties: {} } }] } });
+  else if (m.method === "tools/call")
+    send({ jsonrpc: "2.0", id: m.id, result: { content: [{ type: "text", text: "one event" }] } });
+  else if (m.method !== "notifications/initialized" && m.id !== undefined)
+    send({ jsonrpc: "2.0", id: m.id, error: { code: -32601, message: "method not found" } });
+}
+`;
+
+const hookOn = (matcher) => ({
+  PostToolUse: [
+    {
+      matcher,
+      hooks: [{ type: "command", command: "echo FIRED >> {cwd}/hook.log" }],
+    },
+  ],
+});
+
+async function probeBuiltin(matcher) {
+  const r = await runHarnessTest({
+    settings: { hooks: hookOn(matcher) },
+    model: scriptModel([
+      { tool: "Write", input: { file_path: "hello.txt", content: "banana" } },
+      { text: "done" },
+    ]),
+    timeoutMs: 120000,
+  });
+  try {
+    return {
+      matcher,
+      tool: "Write",
+      ran: r.file("hello.txt") === "banana",
+      fired: /FIRED/.test(r.file("hook.log") ?? ""),
+    };
+  } finally {
+    await r.cleanup?.();
+  }
+}
+
+async function probeMcp(matcher, serverPath) {
+  const tool = `mcp__${server}__list_events`;
+  const r = await runHarnessTest({
+    files: {
+      ".mcp.json": JSON.stringify({
+        mcpServers: { [server]: { command: "node", args: [serverPath] } },
+      }),
+    },
+    settings: { enableAllProjectMcpServers: true, hooks: hookOn(matcher) },
+    allowedTools: ["Read", "Write", "Bash", tool],
+    transcript: true,
+    model: scriptModel([{ tool, input: {} }, { text: "done" }]),
+    timeoutMs: 120000,
+  });
+  try {
+    return {
+      matcher,
+      tool,
+      ran: (r.toolCalls ?? []).some((c) => c.name === tool),
+      fired: /FIRED/.test(r.file("hook.log") ?? ""),
+    };
+  } finally {
+    await r.cleanup?.();
+  }
+}
+
+if (!claudeAvailable()) {
+  console.error("claude CLI not on PATH — this measurement needs it (no key).");
+  process.exit(77);
+}
+
+const dir = mkdtempSync(join(tmpdir(), "vigiles-matcher-"));
+const serverPath = join(dir, "mcp-server.mjs");
+writeFileSync(serverPath, MCP_SERVER_SOURCE);
+
+const rows = [];
+try {
+  for (const m of suite === "mcp" ? MCP_MATCHERS : BUILTIN_MATCHERS) {
+    const row =
+      suite === "mcp" ? await probeMcp(m, serverPath) : await probeBuiltin(m);
+    rows.push(row);
+    console.log(JSON.stringify(row));
+  }
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+console.log(`\n--- ${suite} suite (server: ${server}) ---`);
+console.table(rows);


### PR DESCRIPTION
Fixes #131.

## The defect, in one line

`hook-matcher` validated a matcher **as if it were a literal tool name**. Claude Code matchers are **patterns**, so the rule inverted its verdict on the two forms that matter: it reported the working `mcp__.*` as *"never fires"* and accepted `mcp__[^_]+__[^_]+`, which fires on nothing when the server segment holds an underscore. Someone who obeyed the finding replaced a working matcher with a dead one that lints clean — the exact failure the rule exists to prevent, reached by complying with it.

## Measured, not argued

The issue reported one live observation. Rather than reason from it, I measured the whole question against the real `claude` CLI (2.1.226) driven by the scripted mock model — one hook per run, a marker file the hook writes as the oracle, a real MCP server connected under two names. The script is committed as `tools/measure-hook-matcher-semantics.mjs` (no API key, no cost) so the table can be re-measured when a new CC version lands:

| matcher | tool called | fired |
|---|---|---|
| `Write` | `Write` | yes |
| `Writ` / `rit` | `Write` | **no** |
| `rit.` | `Write` | yes |
| `W(rit)e` | `Write` | yes |
| `mcp__.*` | `mcp__some_server__list_events` | yes |
| `mcp__.*__.*` | `mcp__some_server__list_events` | yes |
| `mcp__[^_]+__[^_]+` | `mcp__some_server__list_events` | **no** |
| `mcp__[^_]+__[^_]+` | `mcp__4f54037d-…__list_events` | yes |
| `mcp__\w+__\w+` | `mcp__some_server__list_events` | yes |
| `mcp__\w+__\w+` | `mcp__4f54037d-…__list_events` | **no** |
| `NoSuchToolAtAll` | either | no (control) |

Two facts fall out, and the detector now models exactly these:

1. **no regex metacharacter ⇒ string equality** — `rit` does *not* fire on `Write`, though it is a substring;
2. **metacharacters ⇒ an unanchored regex** — `rit.` fires on `Write`, and `mcp__[^_]+__[^_]+` fires on the hyphenated server because `[^_]+` only has to reach *into* the tool segment.

Fact 2 also means the issue's inference of full-match semantics was slightly off, in a way that matters for the message text: `mcp__[^_]+__[^_]+` is not dead everywhere — it is dead on `Google_Calendar`-style names and alive on the uuid form.

## Logic or text? Both — and here is the split

Point 3 of the issue asked which it was. The answer is that the old finding conflated **two different claims**, so it needed one of each:

- **Logic fix — reachability.** *"Matches no MCP tool name"* was decided by literal shape, which is simply wrong for a pattern. A pattern is now **compiled and run against synthetic probes**: a server segment holding an underscore (`mcp__Google_Calendar__list_events`), one holding hyphens (`mcp__4f54037d-…__update_event`), the simplest shape (`mcp__srv__tool`), **plus probes derived positionally from the matcher's own literal segments** — so `mcp__memory__.*`, `mcp__memory__search.*` and `mcp__mem.*__list_events` are never called unreachable. Derivation is positional (segments are read from the `mcp__`-split slots they occupy and never reused as a different slot), so a malformed `mcp_memory_search` cannot manufacture a probe that rescues itself. A **literal** keeps the shape check, because a literal is compared by equality.
- **Text fix — narrowness.** `mcp__[^_]+__[^_]+` and `mcp__\w+__\w+` *do* fire; they just skip server namings that occur in the wild. That is a real defect but it is **not** "never fires", and "never fires" is what made a user replace a working matcher. It is now a separate kind, `mcp-narrow`, whose message names **the probes it actually misses** and suggests `mcp__.*__.*`. It is judged only for a matcher that pins **no literal server** — deliberate scope (`mcp__memory__.*`, `mcp__memory__(search|write)`) is not a defect and is never flagged.

Also in scope:

- **`invalid-regex` is its own finding.** A matcher the engine rejects (`mcp__[a-`, `Bash(`) used to pass silently; it can never match anything.
- **Anchors are stripped before reading a matcher's literal segments**, so `^mcp__srv__.*$` gets the same verdict as its bare twin — otherwise a leading `^` alone would resurrect the "too narrow" false positive.
- **The suggestion converges.** `mcp__.*` → `mcp__.*__.*` → `mcp__.*__.*__.*` → … is gone, and a **property test** feeds every `Did you mean` this rule emits back through the rule and requires a clean result in one step. That is the check that would have caught the regress, and it is now permanent.

No new CLI verb or flag — this is the same `audit` finding, with different logic and different words. Nothing depends on a model reading prose: regex compilation and matching only.

## Acceptance table, as tests

Every row of the issue's table is a test case in `src/core/hook-matcher.test.ts`, including the two inverted ones; the two `mcp-narrow` rows additionally assert the message names **only** the probe the matcher really misses (measured), because over-claiming there would be the same defect with the sign flipped.

**Mutation-verified.** Reverting `hook-matcher.ts` to `main` turns **11 of the 17 new tests red**, including all four contested rows, the property test, and both `invalid-regex` tests. The six that stay green are regression guards for behaviour that was already correct (the literal row, `mcp__memory__.*`, `mcp__srv__.*`, `^mcp__srv__.*$`, the alternation skip, the unrecoverable-server message) and are labelled as such. Five targeted mutations of the individual new guards each turn their own test red:

| mutation | test that caught it |
|---|---|
| drop the pinned-server guard on the narrowness check | `"mcp__srv__.*" pins a server…` |
| drop the matcher-derived probes | 6 tests, incl. the two pre-existing `mcp__ghost__.*` / `mcp__memory__.*` ones |
| match full-string instead of the measured unanchored semantics | `#131 row 4` |
| treat a literal matcher as a regex | 6 tests, incl. the two original tool-typo ones |
| drop the anchor normalization | both anchored-matcher tests |

## Verification

`npm run build` · full vitest suite (2508 passing; the 3 failures are pre-existing on `main` in this container — two need `pylint` on PATH, one is the flaky real-CLI Stop-hook test) · `tsc --noEmit` (root, `test/types`, `site`) · generated-types compile · `eslint src/` (0 errors) · `prettier --check .` · `npx jest` cross-runner · API surface gate (no drift) · bench corpus guards · `node dist/cli.js lint` (exit 0) · `node dist/cli.js test` (12 passed, 1 skipped) · plus an end-to-end `vigiles audit` on a fixture repo carrying all three matchers: `mcp__.*` is now clean, the other two report accurately.

## Noticed, not touched

- An MCP-ish matcher with **uppercase** in the `mcp__` prefix (`MCP__Foo__Bar`) is still accepted: `dialect.mcpToolPattern` carries the `i` flag, while real tool names and matcher comparison are case-sensitive. Fixing it means changing the dialect's own pattern, which reaches past this rule.
- **Alternation is still skipped entirely** (`Edit|Write`, `mcp__a__b|Bash`) — each arm would have to be judged separately and a mixed arm set is legitimate. So a dead arm inside an alternation goes unreported. Measured bonus finding from the experiment: `rit|zzz` does **not** fire on `Write`, i.e. the harness appears to split on `|` and compare each arm, which is what a per-arm check would need to model.
- `src/audit-score.ts` and `src/score-core.ts` carry a **duplicated** deduction table (both needed the same label edit).
