### PR TITLE
feat(hook): runtime-owned named state — a hook can remember a fact without reaching for the filesystem

### DIFF
--- a/api-surface/vigiles-hook.api.md
+++ b/api-surface/vigiles-hook.api.md
@@ -4,11 +4,17 @@
 
 ```ts
 
+// @public
+export function admissibleWrites(writes: readonly unknown[]): {
+    readonly ok: readonly StateWrite[];
+    readonly refused: readonly string[];
+};
+
 // @public (undocumented)
 export const allow: () => Decision;
 
 // @public (undocumented)
-export type AnyHook = HookProgram<ErasedNeeds> | FileGateHook<ErasedNeeds> | PromptGateHook<ErasedNeeds> | StopGateHook<ErasedNeeds> | InjectHook | ReactHook;
+export type AnyHook = HookProgram<ErasedNeeds> | FileGateHook<ErasedNeeds> | PromptGateHook<ErasedNeeds> | StopGateHook<ErasedNeeds> | InjectHook<ErasedNeeds> | ReactHook<ErasedNeeds>;
 
 // @public (undocumented)
 export const ask: (reason: string) => Decision;
@@ -40,8 +46,8 @@ export interface CommandView {
     writesTo(prefixes: readonly string[]): boolean;
 }
 
-// @public
-export function commandView(raw: string, root?: string): CommandView;
+// @public (undocumented)
+export function commandView(raw: string): CommandView;
 
 // @public
 export interface CompiledHookProgram {
@@ -78,8 +84,7 @@ export function decideFileGate<N extends readonly NeedSpec[]>(hook: FileGateHook
     tool_input?: {
         file_path?: unknown;
     };
-    cwd?: unknown;
-}, ctx?: Record<string, string | boolean>, root?: string | undefined): Decision;
+}, ctx?: RawCtx): Decision;
 
 // @public
 export function decideProgram<N extends readonly NeedSpec[]>(program: HookProgram<N>, rawEvent: {
@@ -87,18 +92,17 @@ export function decideProgram<N extends readonly NeedSpec[]>(program: HookProgra
     tool_input?: {
         command?: unknown;
     };
-    cwd?: unknown;
-}, ctx?: Record<string, string | boolean>, root?: string | undefined): Decision;
+}, ctx?: RawCtx): Decision;
 
 // @public
 export function decidePromptGate<N extends readonly NeedSpec[]>(hook: PromptGateHook<N>, raw: {
     prompt?: unknown;
-}, ctx?: Record<string, string | boolean>): Decision;
+}, ctx?: RawCtx): Decision;
 
 // @public
 export function decideStopGate<N extends readonly NeedSpec[]>(hook: StopGateHook<N>, raw: {
     stop_hook_active?: unknown;
-}, ctx?: Record<string, string | boolean>): Decision;
+}, ctx?: RawCtx): Decision;
 
 // @public (undocumented)
 export type Decision = {
@@ -121,7 +125,7 @@ export function defineFileGate<const N extends readonly NeedSpec[] = readonly []
 export function defineHook<const N extends readonly NeedSpec[] = readonly []>(p: HookProgram<N>): HookProgram<N>;
 
 // @public (undocumented)
-export const defineInject: (p: Omit<InjectHook, "role">) => InjectHook;
+export function defineInject<const N extends readonly NeedSpec[] = readonly []>(p: Omit<InjectHook<N>, "role">): InjectHook<N>;
 
 // @public (undocumented)
 export function definePromptGate<const N extends readonly NeedSpec[] = readonly []>(p: Omit<PromptGateHook<N>, "role">): PromptGateHook<N>;
@@ -134,7 +138,7 @@ export const defineProvider: <const Name extends string>(p: {
 }) => RegisteredProvider<Name>;
 
 // @public (undocumented)
-export const defineReact: (p: Omit<ReactHook, "role">) => ReactHook;
+export function defineReact<const N extends readonly NeedSpec[] = readonly []>(p: Omit<ReactHook<N>, "role">): ReactHook<N>;
 
 // @public (undocumented)
 export function defineStopGate<const N extends readonly NeedSpec[] = readonly []>(p: Omit<StopGateHook<N>, "role">): StopGateHook<N>;
@@ -147,6 +151,12 @@ export type DispatchKind = "bash-gate" | "file-gate" | "prompt-gate" | "stop-gat
 
 // @public (undocumented)
 export function dispatchKind(hook: AnyHook): DispatchKind;
+
+// @public
+export type Duration = `${number}${"s" | "m" | "h" | "d"}`;
+
+// @public
+export function durationSeconds(d: string): number | null;
 
 // @public (undocumented)
 export interface FileGateHook<N extends readonly NeedSpec[] = readonly ProviderName[]> {
@@ -232,6 +242,7 @@ export type HookProgramOutcome = {
 } | {
     readonly kind: "injection";
     readonly context: string;
+    readonly records: readonly StateWrite[];
 } | {
     readonly kind: "reaction";
     readonly reaction: Reaction;
@@ -243,14 +254,19 @@ export function hookRouting(hook: AnyHook): {
     matcher?: string;
 };
 
-// @public (undocumented)
-export const inject: (context: string) => Injection;
+// @public
+export class HookStateError extends Error {
+}
+
+// @public
+export const inject: (context: string, ...records: readonly StateWrite[]) => Injection;
 
 // @public (undocumented)
-export interface InjectHook {
+export interface InjectHook<N extends readonly NeedSpec[] = readonly ProviderName[]> {
+    readonly needs?: N;
     // (undocumented)
     readonly on: string;
-    readonly produce: (e: SessionEvent) => Injection;
+    readonly produce: (e: SessionEvent<N>) => Injection;
     // (undocumented)
     readonly role: "inject";
 }
@@ -261,7 +277,13 @@ export interface Injection {
     readonly context: string;
     // (undocumented)
     readonly kind: "inject";
+    readonly records: readonly StateWrite[];
 }
+
+// @public
+export function injectionOf<N extends readonly NeedSpec[]>(hook: InjectHook<N>, raw: {
+    source?: string;
+}, ctx?: RawCtx): Injection;
 
 // @public
 export interface InlineProvider<Name extends string = string> {
@@ -276,6 +298,18 @@ export interface InlineProvider<Name extends string = string> {
 }
 
 // @public
+export function invalidToolPatterns(tools: readonly string[]): string[];
+
+// @public
+export function isStateNeed(need: unknown): need is StateNeed;
+
+// @public
+export function isStateWrite(w: unknown): w is StateWrite;
+
+// @public (undocumented)
+export function isValidStateKey(key: string): boolean;
+
+// @public
 export function leafCommandsNormalized(command: string): NormalizedLeaf[];
 
 // @public
@@ -287,7 +321,10 @@ export interface LeafRedirect {
 }
 
 // @public
-export type NeedSpec = ProviderName | InlineProvider | RegisteredRef;
+export function matchesTool(tools: readonly string[], name: string): boolean;
+
+// @public
+export type NeedSpec = ProviderName | InlineProvider | RegisteredRef | StateNeed;
 
 // @public
 export interface NormalizedLeaf {
@@ -302,21 +339,26 @@ export interface NormalizedLeaf {
 }
 
 // @public
-export const nothing: () => Reaction;
+export const nothing: (...records: readonly StateWrite[]) => Reaction;
 
 // @public
-export const notice: (message: string) => Reaction;
+export const notice: (message: string, ...records: readonly StateWrite[]) => Reaction;
+
+// @public
+export function outcomeWrites(outcome: HookProgramOutcome): {
+    readonly ok: readonly StateWrite[];
+    readonly refused: readonly string[];
+};
 
 // @public
 export interface PathView {
     // (undocumented)
     readonly raw: string;
-    readonly rel: string | undefined;
     under(prefixes: readonly string[]): boolean;
 }
 
-// @public
-export function pathView(raw: string, root?: string): PathView;
+// @public (undocumented)
+export function pathView(raw: string): PathView;
 
 // @public
 export interface PromptEvent<N extends readonly NeedSpec[] = readonly ProviderName[]> {
@@ -360,7 +402,6 @@ export interface ProviderResults {
 
 // @public
 export interface RawHookEvent {
-    readonly cwd?: string;
     readonly prompt?: string;
     readonly source?: string;
     readonly stop_hook_active?: boolean;
@@ -375,7 +416,8 @@ export interface RawHookEvent {
 }
 
 // @public
-export interface ReactEvent {
+export interface ReactEvent<N extends readonly NeedSpec[] = readonly ProviderName[]> {
+    readonly ctx: HookCtx<N>;
     // (undocumented)
     readonly event: string;
     // (undocumented)
@@ -386,14 +428,14 @@ export interface ReactEvent {
 }
 
 // @public (undocumented)
-export interface ReactHook {
-    // (undocumented)
-    readonly match: {
+export interface ReactHook<N extends readonly NeedSpec[] = readonly ProviderName[]> {
+    readonly match?: {
         readonly tools: readonly string[];
     };
+    readonly needs?: N;
     // (undocumented)
     readonly on: string;
-    readonly react: (e: ReactEvent) => Reaction;
+    readonly react: (e: ReactEvent<N>) => Reaction;
     // (undocumented)
     readonly role: "react";
 }
@@ -402,9 +444,14 @@ export interface ReactHook {
 export type Reaction = RunReaction | {
     readonly kind: "notice";
     readonly message: string;
+    readonly records: readonly StateWrite[];
 } | {
     readonly kind: "none";
+    readonly records: readonly StateWrite[];
 };
+
+// @public
+export function record(name: string, value?: string): StateWrite;
 
 // @public
 export interface RegisteredProvider<Name extends string = string> {
@@ -437,15 +484,15 @@ export interface ResponseView {
 export function responseView(raw: unknown): ResponseView;
 
 // @public
-export const run: (command: string) => RunReaction;
+export const run: (command: string, ...records: readonly StateWrite[]) => RunReaction;
 
 // @public
-export function runHookProgram(hook: AnyHook, event: RawHookEvent, ctx?: Record<string, string | boolean>, root?: string | undefined): HookProgramOutcome;
+export function runHookProgram(hook: AnyHook, event: RawHookEvent, ctx?: RawCtx): HookProgramOutcome;
 
 // @public
-export function runInject(hook: InjectHook, raw: {
+export function runInject<N extends readonly NeedSpec[]>(hook: InjectHook<N>, raw: {
     source?: string;
-}): {
+}, ctx?: RawCtx): {
     hookSpecificOutput: {
         hookEventName: string;
         additionalContext: string;
@@ -453,14 +500,13 @@ export function runInject(hook: InjectHook, raw: {
 };
 
 // @public
-export function runReact(hook: ReactHook, raw: {
+export function runReact<N extends readonly NeedSpec[]>(hook: ReactHook<N>, raw: {
     tool_name?: string;
     tool_input?: {
         file_path?: unknown;
     };
     tool_response?: unknown;
-    cwd?: unknown;
-}, root?: string | undefined): Reaction;
+}, ctx?: RawCtx): Reaction;
 
 // @public (undocumented)
 export interface RunReaction {
@@ -470,10 +516,13 @@ export interface RunReaction {
     readonly effect: BashEffect;
     // (undocumented)
     readonly kind: "run";
+    // (undocumented)
+    readonly records: readonly StateWrite[];
 }
 
 // @public
-export interface SessionEvent {
+export interface SessionEvent<N extends readonly NeedSpec[] = readonly ProviderName[]> {
+    readonly ctx: HookCtx<N>;
     // (undocumented)
     readonly event: string;
     // (undocumented)
@@ -482,6 +531,50 @@ export interface SessionEvent {
 
 // @public
 export function stampHook(source: string): SHA256Hash;
+
+// @public
+export function state<const Name extends string>(name: Name): StateNeed<Name>;
+
+// @public
+export interface StateEntry {
+    // (undocumented)
+    readonly at: string;
+    // (undocumented)
+    readonly by?: string;
+    // (undocumented)
+    readonly value: string;
+}
+
+// @public
+export interface StateFact {
+    readonly ageSeconds: number;
+    readonly at: string;
+    fresherThan(within: Duration): boolean;
+    olderThan(within: Duration): boolean;
+    readonly recorded: boolean;
+    readonly value: string;
+}
+
+// @public
+export function stateFact(entry: StateEntry | null, nowMs: number): StateFact;
+
+// @public
+export interface StateNeed<Name extends string = string> {
+    // (undocumented)
+    readonly kind: "state";
+    // (undocumented)
+    readonly name: Name;
+}
+
+// @public
+export interface StateWrite {
+    // (undocumented)
+    readonly kind: "record";
+    // (undocumented)
+    readonly name: string;
+    // (undocumented)
+    readonly value: string;
+}
 
 // @public
 export interface StopEvent<N extends readonly NeedSpec[] = readonly ProviderName[]> {

--- a/api-surface/vigiles-hook.api.md
+++ b/api-surface/vigiles-hook.api.md
@@ -46,8 +46,8 @@ export interface CommandView {
     writesTo(prefixes: readonly string[]): boolean;
 }
 
-// @public (undocumented)
-export function commandView(raw: string): CommandView;
+// @public
+export function commandView(raw: string, root?: string): CommandView;
 
 // @public
 export interface CompiledHookProgram {
@@ -84,7 +84,8 @@ export function decideFileGate<N extends readonly NeedSpec[]>(hook: FileGateHook
     tool_input?: {
         file_path?: unknown;
     };
-}, ctx?: RawCtx): Decision;
+    cwd?: unknown;
+}, ctx?: RawCtx, root?: string | undefined): Decision;
 
 // @public
 export function decideProgram<N extends readonly NeedSpec[]>(program: HookProgram<N>, rawEvent: {
@@ -92,7 +93,8 @@ export function decideProgram<N extends readonly NeedSpec[]>(program: HookProgra
     tool_input?: {
         command?: unknown;
     };
-}, ctx?: RawCtx): Decision;
+    cwd?: unknown;
+}, ctx?: RawCtx, root?: string | undefined): Decision;
 
 // @public
 export function decidePromptGate<N extends readonly NeedSpec[]>(hook: PromptGateHook<N>, raw: {
@@ -354,11 +356,12 @@ export function outcomeWrites(outcome: HookProgramOutcome): {
 export interface PathView {
     // (undocumented)
     readonly raw: string;
+    readonly rel: string | undefined;
     under(prefixes: readonly string[]): boolean;
 }
 
-// @public (undocumented)
-export function pathView(raw: string): PathView;
+// @public
+export function pathView(raw: string, root?: string): PathView;
 
 // @public
 export interface PromptEvent<N extends readonly NeedSpec[] = readonly ProviderName[]> {
@@ -402,6 +405,7 @@ export interface ProviderResults {
 
 // @public
 export interface RawHookEvent {
+    readonly cwd?: string;
     readonly prompt?: string;
     readonly source?: string;
     readonly stop_hook_active?: boolean;
@@ -487,7 +491,7 @@ export function responseView(raw: unknown): ResponseView;
 export const run: (command: string, ...records: readonly StateWrite[]) => RunReaction;
 
 // @public
-export function runHookProgram(hook: AnyHook, event: RawHookEvent, ctx?: RawCtx): HookProgramOutcome;
+export function runHookProgram(hook: AnyHook, event: RawHookEvent, ctx?: RawCtx, root?: string | undefined): HookProgramOutcome;
 
 // @public
 export function runInject<N extends readonly NeedSpec[]>(hook: InjectHook<N>, raw: {
@@ -506,7 +510,8 @@ export function runReact<N extends readonly NeedSpec[]>(hook: ReactHook<N>, raw:
         file_path?: unknown;
     };
     tool_response?: unknown;
-}, ctx?: RawCtx): Reaction;
+    cwd?: unknown;
+}, ctx?: RawCtx, root?: string | undefined): Reaction;
 
 // @public (undocumented)
 export interface RunReaction {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
+  renameSync,
   lstatSync,
   realpathSync,
   type Dirent,
@@ -220,7 +221,9 @@ import {
   decideFileGate,
   decidePromptGate,
   decideStopGate,
-  runInject,
+  injectionOf,
+  outcomeWrites,
+  type HookProgramOutcome,
   runReact,
   dispatchKind,
   hookRouting,
@@ -262,7 +265,12 @@ import {
   type RegisteredProvider,
 } from "./core/hook-providers.js";
 import { parse as parseToml } from "@iarna/toml";
-import type { SHA256Hash } from "./core/hash.js";
+import { sha256short, type SHA256Hash } from "./core/hash.js";
+import {
+  type StateEntry,
+  type StateFact,
+  type StateWrite,
+} from "./core/hook-state.js";
 import {
   evaluatePreToolUse,
   readActiveAgent,
@@ -6405,6 +6413,97 @@ function hookStampPath(file: string): string {
   return resolve(process.cwd(), ".vigiles/hooks", basename(file) + ".json");
 }
 
+/**
+ * The directory a hook's recorded facts live in — the SCOPE of `state()`/`record()`.
+ *
+ * Derived from the hook's own location and never from anything the hook said, so
+ * a key cannot address another owner's store: hooks shipped in the same directory
+ * share their facts (the requirement — one hook records, another reads), a
+ * vendored plugin's hooks get their own. The layout MIRRORS the hook's directory
+ * rather than slugging it, which keeps it injective and lets a human debugging a
+ * hook find the fact by walking the path they already know:
+ *
+ *   .claude/hooks/calendar-sync-record.hook.ts
+ *     → .vigiles/state/.claude/hooks/calendar.synced.json
+ *
+ * A hook outside the project (an absolute path elsewhere) falls back to a hash of
+ * its directory: still stable and still isolated, just not readable — which is the
+ * right trade for a case that should not happen in a project's own harness.
+ */
+function hookStateDir(file: string): string {
+  const dir = dirname(resolve(process.cwd(), file));
+  const rel = relative(process.cwd(), dir);
+  const inside = rel !== "" && !rel.startsWith("..") && !isAbsolute(rel);
+  return resolve(
+    process.cwd(),
+    ".vigiles/state",
+    inside ? rel : `external-${sha256short(dir)}`,
+  );
+}
+
+/** Read one recorded fact for a hook, or `null` if it was never recorded. */
+function readHookState(file: string, key: string): StateEntry | null {
+  try {
+    const raw = readFileSync(
+      resolve(hookStateDir(file), key + ".json"),
+      "utf-8",
+    );
+    const parsed = JSON.parse(raw) as StateEntry;
+    return typeof parsed.value === "string" && typeof parsed.at === "string"
+      ? parsed
+      : null;
+  } catch {
+    // Never recorded, unreadable, or corrupt — all "no fact", which `stateFact`
+    // turns into an infinite age, so the reading hook SPEAKS. Failing toward
+    // noise is the whole point; a store problem must never look like freshness.
+    return null;
+  }
+}
+
+/**
+ * Record one fact. Atomic: written to a temp file in the same directory and
+ * `rename()`d over, so a concurrent reader sees the whole old entry or the whole
+ * new one — never one write's value with another's timestamp. Distinct keys are
+ * distinct files and never interact at all.
+ */
+function writeHookState(file: string, w: StateWrite): void {
+  const dir = hookStateDir(file);
+  const target = resolve(dir, w.name + ".json");
+  const entry: StateEntry = {
+    value: w.value,
+    at: new Date().toISOString(),
+    by: normalizeHookRef(file),
+  };
+  mkdirSync(dir, { recursive: true });
+  const tmp = `${target}.${String(process.pid)}.tmp`;
+  writeFileSync(tmp, JSON.stringify(entry, null, 2) + "\n");
+  renameSync(tmp, target);
+}
+
+/**
+ * Perform the state writes a hook declared, after its output has been emitted.
+ * A refused write (a hand-built record object with a key `record()` would have
+ * thrown on) is announced — silence here would be a hook that believes it
+ * remembered something.
+ */
+function applyHookWrites(file: string, outcome: HookProgramOutcome): void {
+  const { ok, refused } = outcomeWrites(outcome);
+  for (const name of refused) {
+    console.error(
+      `vigiles: refused to record ${name} from ${file} — not a valid state key.`,
+    );
+  }
+  for (const w of ok) {
+    try {
+      writeHookState(file, w);
+    } catch (e) {
+      console.error(
+        `vigiles: could not record ${w.name} from ${file}: ${String(e)}`,
+      );
+    }
+  }
+}
+
 /** What installing one hook did — for the `compile` summary line. */
 interface HookInstallResult {
   readonly role: DispatchKind;
@@ -6586,7 +6685,8 @@ async function installHooks(
  */
 async function gatherHookContext(
   program: AnyHook,
-): Promise<Record<string, string | boolean>> {
+  file: string,
+): Promise<Record<string, string | boolean | StateFact>> {
   const needs = hookNeeds(program);
   if (needs.length === 0) return {};
   // Only load the registered-provider registry if a provider() ref is declared.
@@ -6608,6 +6708,10 @@ async function gatherHookContext(
       cwd: process.cwd(),
       platform: process.platform,
       isCI,
+      // The namespace is bound HERE, from the hook's own path — core never sees
+      // it, so no key a hook can spell reaches another owner's store.
+      readState: (key) => readHookState(file, key),
+      now: Date.now(),
     },
     registry,
   );
@@ -6963,13 +7067,31 @@ async function runHookProgramCommand(file: string | undefined): Promise<void> {
 
   switch (dispatchKind(program)) {
     case "inject": {
-      const out = runInject(program as InjectHook, { source: event.source });
-      process.stdout.write(JSON.stringify(out) + "\n");
+      const ctx = await gatherHookContext(program, file);
+      const injection = injectionOf(program as InjectHook, event, ctx);
+      process.stdout.write(
+        JSON.stringify({
+          hookSpecificOutput: {
+            hookEventName: program.on,
+            additionalContext: injection.context,
+          },
+        }) + "\n",
+      );
+      // Writes land AFTER the output is emitted: a hook that recorded "I spoke"
+      // must not have recorded it if emitting threw.
+      applyHookWrites(file, {
+        kind: "injection",
+        context: injection.context,
+        records: injection.records,
+      });
       return;
     }
     case "react": {
+      const ctx = await gatherHookContext(program, file);
       warnIfPathUndecidable(event, projectRoot);
-      const reaction = runReact(program as ReactHook, event, projectRoot);
+      const reaction = runReact(program as ReactHook, event, ctx, projectRoot);
+      if (reaction.kind === "notice") console.error(reaction.message);
+      applyHookWrites(file, { kind: "reaction", reaction });
       if (reaction.kind === "run") {
         const { spawnSync } =
           require("node:child_process") as typeof import("node:child_process");
@@ -6979,11 +7101,10 @@ async function runHookProgramCommand(file: string | undefined): Promise<void> {
         });
         process.exit(res.status ?? 0);
       }
-      if (reaction.kind === "notice") console.error(reaction.message);
       return;
     }
     case "file-gate": {
-      const ctx = await gatherHookContext(program);
+      const ctx = await gatherHookContext(program, file);
       warnIfPathUndecidable(event, projectRoot);
       emitGate(
         decideFileGate(program as FileGateHook, event, ctx, projectRoot),
@@ -6994,7 +7115,7 @@ async function runHookProgramCommand(file: string | undefined): Promise<void> {
       return;
     }
     case "bash-gate": {
-      const ctx = await gatherHookContext(program);
+      const ctx = await gatherHookContext(program, file);
       // The same `projectRoot` the file gates get: without it every
       // repo-relative prefix in a DENYLIST matcher (`touches`/`writesTo`) is
       // matched by over-blocking alone, and with it an absolute token is placed
@@ -7009,7 +7130,7 @@ async function runHookProgramCommand(file: string | undefined): Promise<void> {
       return;
     }
     case "prompt-gate": {
-      const ctx = await gatherHookContext(program);
+      const ctx = await gatherHookContext(program, file);
       emitGate(
         decidePromptGate(program as PromptGateHook, event, ctx),
         program.on,
@@ -7019,7 +7140,7 @@ async function runHookProgramCommand(file: string | undefined): Promise<void> {
       return;
     }
     case "stop-gate": {
-      const ctx = await gatherHookContext(program);
+      const ctx = await gatherHookContext(program, file);
       emitGate(
         decideStopGate(program as StopGateHook, event, ctx),
         program.on,

--- a/src/core/hook-program.test.ts
+++ b/src/core/hook-program.test.ts
@@ -1449,7 +1449,7 @@ test("runReact: an ABSOLUTE file_path fires the react — via the root arg AND v
     tool_name: "Edit",
     tool_input: { file_path: `${MINE}/migratsiya/papers/x/main.tex` },
   };
-  assert.equal(runReact(paperNudge, abs, MINE).kind, "notice");
+  assert.equal(runReact(paperNudge, abs, {}, MINE).kind, "notice");
   assert.equal(runReact(paperNudge, { ...abs, cwd: MINE }).kind, "notice");
   // No root anywhere → silence, never a false fire.
   assert.equal(runReact(paperNudge, abs).kind, "none");
@@ -1463,6 +1463,7 @@ test("runReact: an ABSOLUTE file_path fires the react — via the root arg AND v
           file_path: "/home/user/other/migratsiya/papers/x/main.tex",
         },
       },
+      {},
       MINE,
     ).kind,
     "none",

--- a/src/core/hook-program.ts
+++ b/src/core/hook-program.ts
@@ -1786,13 +1786,10 @@ export function outcomeWrites(outcome: HookProgramOutcome): {
   readonly ok: readonly StateWrite[];
   readonly refused: readonly string[];
 } {
-  const declared =
-    outcome.kind === "injection"
-      ? outcome.records
-      : outcome.kind === "reaction"
-        ? outcome.reaction.records
-        : [];
-  return admissibleWrites(declared);
+  if (outcome.kind === "injection") return admissibleWrites(outcome.records);
+  if (outcome.kind === "reaction")
+    return admissibleWrites(outcome.reaction.records);
+  return admissibleWrites([]);
 }
 
 /**

--- a/src/core/hook-program.ts
+++ b/src/core/hook-program.ts
@@ -50,6 +50,70 @@ import {
   type NeedSpec,
   type HookCtx,
 } from "./hook-providers.js";
+import {
+  admissibleWrites,
+  type StateFact,
+  type StateWrite,
+} from "./hook-state.js";
+
+/**
+ * The erased runtime shape of a gathered context. Author-facing types keep the
+ * precise `HookCtx<N>`; the decode functions re-narrow and cast.
+ */
+type RawCtx = Record<string, string | boolean | StateFact>;
+
+/**
+ * Does `name` match a hook's declared tool list, under the SAME semantics as the
+ * matcher the compiler emits for it?
+ *
+ * 🔴 IT DID NOT, AND THE DISAGREEMENT WAS SILENT. `hookRouting` joins a react's
+ * tools with `|` and emits that as the harness matcher, and a Claude Code matcher
+ * is a REGEX — `Edit|Write|MultiEdit` only works because it is one. The runtime
+ * meanwhile compared with `Array.includes`, i.e. exact string equality. So a hook
+ * declaring a tool FAMILY compiled fine, was wired up fine, was routed to by the
+ * harness fine, and was then dropped by vigiles' own filter without a word.
+ *
+ * MEASURED 2026-08-12 against the real runtime, before the fix:
+ *
+ *   $ echo '{"tool_name":"mcp__4f54037d-0499__list_events",…}' \
+ *       | vigiles hook-runtime run-program mcp-family.hook.mjs
+ *   exit=0                       # silence — react() never ran
+ *   $ echo '{"tool_name":"mcp__.*",…}' | …
+ *   FIRED on mcp__.*             # fires only for a tool LITERALLY named "mcp__.*"
+ *
+ * That is the false-confidence class this whole subsystem exists to eliminate,
+ * living inside the subsystem. The live evidence that the harness really does
+ * route these: the knowledge base has shipped `"matcher": "mcp__.*"` in
+ * `.claude/settings.json` for months and its stamp file was last written the
+ * morning this was measured. The MCP server's id changes per session, so an exact
+ * list cannot be written down — a family matcher is the only correct spelling.
+ *
+ * Anchored `^(…)$` so a pattern cannot match a longer tool name by accident, and
+ * identical to `includes` for ordinary names, which contain no metacharacters.
+ * An unparseable pattern is rejected at COMPILE ({@link invalidToolPatterns}), so
+ * the fallback here is unreachable in a compiled hook and exists only so that a
+ * hand-constructed one degrades to exact matching rather than throwing mid-event.
+ */
+export function matchesTool(tools: readonly string[], name: string): boolean {
+  if (tools.includes(name)) return true;
+  try {
+    return new RegExp(`^(${tools.join("|")})$`).test(name);
+  } catch {
+    return false;
+  }
+}
+
+/** Tool patterns that are not valid regexes — rejected at compile, see {@link matchesTool}. */
+export function invalidToolPatterns(tools: readonly string[]): string[] {
+  return tools.filter((t) => {
+    try {
+      new RegExp(`^(${t})$`);
+      return false;
+    } catch {
+      return true;
+    }
+  });
+}
 
 // ---------------------------------------------------------------------------
 // The closed vocabulary (this is the entire surface a hook author may touch)
@@ -670,7 +734,7 @@ export function decideProgram<N extends readonly NeedSpec[]>(
     tool_input?: { command?: unknown };
     cwd?: unknown;
   },
-  ctx: Record<string, string | boolean> = {},
+  ctx: RawCtx = {},
   root: string | undefined = typeof rawEvent.cwd === "string"
     ? rawEvent.cwd
     : undefined,
@@ -788,8 +852,8 @@ export type AnyHook =
   | FileGateHook<ErasedNeeds>
   | PromptGateHook<ErasedNeeds>
   | StopGateHook<ErasedNeeds>
-  | InjectHook
-  | ReactHook;
+  | InjectHook<ErasedNeeds>
+  | ReactHook<ErasedNeeds>;
 /* eslint-enable @typescript-eslint/no-unnecessary-type-arguments */
 
 /**
@@ -838,6 +902,8 @@ export function hookRouting(hook: AnyHook): {
       hook.role === "stop-gate"
     )
       return { on: hook.on };
+    // A react MAY also be tool-less (Stop/SessionEnd) — same shape, same reason.
+    if (hook.match === undefined) return { on: hook.on };
     return { on: hook.on, matcher: hook.match.tools.join("|") };
   }
   return { on: hook.on, matcher: hook.match.tool };
@@ -904,6 +970,18 @@ export function compileHookProgram(
     );
   }
   const { on, matcher: rawMatcher } = hookRouting(hook);
+  // A tool pattern that is not a valid regex cannot match under the semantics the
+  // emitted matcher is read with, so it would compile to a hook that never fires.
+  // Reject it here rather than let `matchesTool` fall back silently.
+  if ("match" in hook && hook.match !== undefined && "tools" in hook.match) {
+    const bad = invalidToolPatterns(hook.match.tools);
+    if (bad.length > 0) {
+      throw new HookCompileError(
+        `invalid tool matcher pattern(s): ${bad.join(", ")} — a tool matcher is a ` +
+          `regex (that is why "Edit|Write" works), so it must parse as one.`,
+      );
+    }
+  }
   // A hook registered under an event the harness never fires is dead — reject it.
   if (opts.dialect) {
     const issues = verifyHookEvents([on], opts.dialect);
@@ -1246,11 +1324,12 @@ export function decideFileGate<N extends readonly NeedSpec[]>(
     tool_input?: { file_path?: unknown };
     cwd?: unknown;
   },
-  ctx: Record<string, string | boolean> = {},
+  ctx: RawCtx = {},
   root: string | undefined = typeof raw.cwd === "string" ? raw.cwd : undefined,
 ): Decision {
   const t = raw.tool_name ?? "";
-  if (!hook.match.tools.includes(t)) return allow();
+  // Same matcher semantics as the emitted settings block — see {@link matchesTool}.
+  if (!matchesTool(hook.match.tools, t)) return allow();
   const fp =
     typeof raw.tool_input?.file_path === "string"
       ? raw.tool_input.file_path
@@ -1311,7 +1390,7 @@ export function definePromptGate<
 export function decidePromptGate<N extends readonly NeedSpec[]>(
   hook: PromptGateHook<N>,
   raw: { prompt?: unknown },
-  ctx: Record<string, string | boolean> = {},
+  ctx: RawCtx = {},
 ): Decision {
   const prompt = typeof raw.prompt === "string" ? raw.prompt : "";
   return hook.decide({
@@ -1362,7 +1441,7 @@ export function defineStopGate<
 export function decideStopGate<N extends readonly NeedSpec[]>(
   hook: StopGateHook<N>,
   raw: { stop_hook_active?: unknown },
-  ctx: Record<string, string | boolean> = {},
+  ctx: RawCtx = {},
 ): Decision {
   return hook.decide({
     event: hook.on,
@@ -1377,47 +1456,93 @@ export function decideStopGate<N extends readonly NeedSpec[]>(
 export interface Injection {
   readonly kind: "inject";
   readonly context: string;
+  /** Facts to record — a DECLARATION; the trusted runtime performs the write. */
+  readonly records: readonly StateWrite[];
 }
-export const inject = (context: string): Injection => ({
+/**
+ * Context to add, plus any facts that just became true:
+ * `inject(text, record("calendar.nagged"))`.
+ *
+ * The writes are trailing arguments on every output builder, so there is one rule
+ * to learn rather than a per-role spelling — and a hook that records nothing is
+ * written exactly as it was before.
+ */
+export const inject = (
+  context: string,
+  ...records: readonly StateWrite[]
+): Injection => ({
   kind: "inject",
   context,
+  records,
 });
 
-/** The event an inject hook produces from (no tool — SessionStart/UserPromptSubmit). */
-export interface SessionEvent {
+/**
+ * The event an inject hook produces from (no tool — SessionStart/UserPromptSubmit).
+ * Generic over its declared `needs`, exactly like the gate events.
+ */
+export interface SessionEvent<
+  N extends readonly NeedSpec[] = readonly ProviderName[],
+> {
   readonly event: string;
   readonly source: string;
+  /** Host-gathered, DECLARED facts — built-ins, inline providers, and `state()` reads. */
+  readonly ctx: HookCtx<N>;
 }
 
-export interface InjectHook {
+export interface InjectHook<
+  N extends readonly NeedSpec[] = readonly ProviderName[],
+> {
   readonly role: "inject";
   readonly on: string;
+  /**
+   * Declared context providers the trusted runtime gathers into `e.ctx`.
+   *
+   * Injects and reacts could not declare `needs` at all until state landed, for
+   * no reason anyone had recorded — and a fact a hook cannot read is not a
+   * feature. `needs` is now uniform across every role.
+   */
+  readonly needs?: N;
   /** Produces context to add. Its return type (Injection) has no `deny` — by design. */
-  readonly produce: (e: SessionEvent) => Injection;
+  readonly produce: (e: SessionEvent<N>) => Injection;
 }
-export const defineInject = (p: Omit<InjectHook, "role">): InjectHook => ({
-  role: "inject",
-  ...p,
-});
+export function defineInject<const N extends readonly NeedSpec[] = readonly []>(
+  p: Omit<InjectHook<N>, "role">,
+): InjectHook<N> {
+  return { role: "inject", ...p };
+}
 
 /**
  * Run an inject hook → the CC JSON the author never hand-writes. The compiler
  * targets `additionalContext` (the RIGHT field for this event), so the
  * wrong-JSON-field pain can't occur.
  */
-export function runInject(
-  hook: InjectHook,
+export function runInject<N extends readonly NeedSpec[]>(
+  hook: InjectHook<N>,
   raw: { source?: string },
+  ctx: RawCtx = {},
 ): {
   hookSpecificOutput: { hookEventName: string; additionalContext: string };
 } {
-  const out = hook.produce({ event: hook.on, source: raw.source ?? "startup" });
+  const out = injectionOf(hook, raw, ctx);
   return {
     hookSpecificOutput: {
       hookEventName: hook.on,
       additionalContext: out.context,
     },
   };
+}
+
+/** The full {@link Injection} — the runtime needs its `records`, which the CC JSON drops. */
+export function injectionOf<N extends readonly NeedSpec[]>(
+  hook: InjectHook<N>,
+  raw: { source?: string },
+  ctx: RawCtx = {},
+): Injection {
+  return hook.produce({
+    event: hook.on,
+    source: raw.source ?? "startup",
+    ctx: ctx as unknown as HookCtx<N>,
+  });
 }
 
 // --- PROBE 3 — the REACT shape (PostToolUse): where side effects re-enter ---
@@ -1470,68 +1595,124 @@ export function responseView(raw: unknown): ResponseView {
 }
 
 /** The event a react hook reacts over — the tool, the file path, AND its response. */
-export interface ReactEvent {
+export interface ReactEvent<
+  N extends readonly NeedSpec[] = readonly ProviderName[],
+> {
   readonly event: string;
   readonly tool: string;
   readonly path: PathView;
   /** The tool's response (PostToolUse) — react only on an error, capture output, … */
   readonly response: ResponseView;
+  /** Host-gathered, DECLARED facts — built-ins, inline providers, and `state()` reads. */
+  readonly ctx: HookCtx<N>;
 }
 
 export interface RunReaction {
   readonly kind: "run";
   readonly command: string;
   readonly effect: BashEffect;
+  readonly records: readonly StateWrite[];
 }
 export type Reaction =
   | RunReaction
-  | { readonly kind: "notice"; readonly message: string }
-  | { readonly kind: "none" };
+  | {
+      readonly kind: "notice";
+      readonly message: string;
+      readonly records: readonly StateWrite[];
+    }
+  | { readonly kind: "none"; readonly records: readonly StateWrite[] };
 
-/** Run a command in reaction — its effect is classified AT CONSTRUCTION (audit/diff-able). */
-export const run = (command: string): RunReaction => ({
+/**
+ * Run a command in reaction — its effect is classified AT CONSTRUCTION
+ * (audit/diff-able). Trailing arguments record facts.
+ *
+ * ⚠️ `run()` is for invoking a real TOOL. Using it to write a stamp
+ * (`run("date +%s > .claude/.stamp")`) was the only way to remember anything
+ * before `record()` existed; it is now the wrong tool — it spends a subprocess
+ * and a shell on a variable assignment, and it classifies as side-effecting.
+ */
+export const run = (
+  command: string,
+  ...records: readonly StateWrite[]
+): RunReaction => ({
   kind: "run",
   command,
   effect: classifyBashCommand(command),
+  records,
 });
-/** Surface a non-blocking note (no execution). */
-export const notice = (message: string): Reaction => ({
+/** Surface a non-blocking note (no execution). Trailing arguments record facts. */
+export const notice = (
+  message: string,
+  ...records: readonly StateWrite[]
+): Reaction => ({
   kind: "notice",
   message,
+  records,
 });
-/** Do nothing. */
-export const nothing = (): Reaction => ({ kind: "none" });
+/**
+ * Take no action. Trailing arguments still record facts — `nothing(record("x"))`
+ * is the shape of a hook whose entire job is to WITNESS that something happened
+ * (an MCP call, a deploy) so a different hook can read it later.
+ */
+export const nothing = (...records: readonly StateWrite[]): Reaction => ({
+  kind: "none",
+  records,
+});
 
-export interface ReactHook {
+export interface ReactHook<
+  N extends readonly NeedSpec[] = readonly ProviderName[],
+> {
   readonly role: "react";
   readonly on: string;
-  readonly match: { readonly tools: readonly string[] };
+  /**
+   * Which tools to react to. OMIT IT for an event that carries no tool at all
+   * (`Stop`, `SubagentStop`, `SessionEnd`), exactly as inject and the prompt/stop
+   * gates already do — `hookRouting` then emits no matcher.
+   *
+   * 🔴 IT USED TO BE REQUIRED, WHICH MADE EVERY TOOL-LESS REACT DEAD. `runReact`
+   * gates on `tool_name`; a `Stop` event carries none, so the name defaulted to
+   * `""`, matched nothing, and the hook returned `nothing()` forever. MEASURED
+   * 2026-08-12 against the real runtime: a `Stop` react printed nothing and
+   * exited 0 — indistinguishable from a hook that decided to stay quiet, which
+   * is the whole reason advisory hooks die unnoticed. Three of the seven hooks
+   * this feature was built for are `Stop` nudges.
+   */
+  readonly match?: { readonly tools: readonly string[] };
+  /** Declared context providers the trusted runtime gathers into `e.ctx`. */
+  readonly needs?: N;
   /** Reacts to a tool that already ran. Returns a Reaction — NO `deny` exists here. */
-  readonly react: (e: ReactEvent) => Reaction;
+  readonly react: (e: ReactEvent<N>) => Reaction;
 }
-export const defineReact = (p: Omit<ReactHook, "role">): ReactHook => ({
-  role: "react",
-  ...p,
-});
+export function defineReact<const N extends readonly NeedSpec[] = readonly []>(
+  p: Omit<ReactHook<N>, "role">,
+): ReactHook<N> {
+  return { role: "react", ...p };
+}
 
 /**
  * Run a react hook against a raw PostToolUse event → the (classified) Reaction.
  *
  * `root` behaves exactly as in {@link decideFileGate}: the event's own `cwd` by
- * default, the CLI's {@link projectRootOf} when the runtime supplies one.
+ * default, the CLI's {@link projectRootOf} when the runtime supplies one. It
+ * trails `ctx` so the argument order matches {@link decideProgram} and
+ * {@link decideFileGate} — every decode function reads `(hook, raw, ctx, root)`.
  */
-export function runReact(
-  hook: ReactHook,
+export function runReact<N extends readonly NeedSpec[]>(
+  hook: ReactHook<N>,
   raw: {
     tool_name?: string;
     tool_input?: { file_path?: unknown };
     tool_response?: unknown;
     cwd?: unknown;
   },
+  ctx: RawCtx = {},
   root: string | undefined = typeof raw.cwd === "string" ? raw.cwd : undefined,
 ): Reaction {
   const t = raw.tool_name ?? "";
-  if (!hook.match.tools.includes(t)) return nothing();
+  // No `match` → a tool-less event (Stop/SessionEnd): there is nothing to filter
+  // on, and filtering on the empty string is how these hooks used to die.
+  if (hook.match !== undefined && !matchesTool(hook.match.tools, t))
+    return nothing();
   const fp =
     typeof raw.tool_input?.file_path === "string"
       ? raw.tool_input.file_path
@@ -1541,6 +1722,7 @@ export function runReact(
     tool: t,
     path: pathView(fp, root),
     response: responseView(raw.tool_response),
+    ctx: ctx as unknown as HookCtx<N>,
   });
 }
 
@@ -1579,8 +1761,32 @@ export interface RawHookEvent {
 /** The normalized outcome of running a hook program — discriminated by role. */
 export type HookProgramOutcome =
   | { readonly kind: "decision"; readonly decision: Decision }
-  | { readonly kind: "injection"; readonly context: string }
+  | {
+      readonly kind: "injection";
+      readonly context: string;
+      readonly records: readonly StateWrite[];
+    }
   | { readonly kind: "reaction"; readonly reaction: Reaction };
+
+/**
+ * The state writes an outcome declares, filtered to the ones the runtime may
+ * actually perform. A gate's `Decision` carries none — deliberately: a gate is
+ * the role that must be trustworthy and runs on every tool call, so it READS
+ * state (via `needs`) and never writes it. Adding a write there later is easy;
+ * removing one would not be.
+ */
+export function outcomeWrites(outcome: HookProgramOutcome): {
+  readonly ok: readonly StateWrite[];
+  readonly refused: readonly string[];
+} {
+  const declared =
+    outcome.kind === "injection"
+      ? outcome.records
+      : outcome.kind === "reaction"
+        ? outcome.reaction.records
+        : [];
+  return admissibleWrites(declared);
+}
 
 /**
  * The file a hook program was LOADED from — the one coverage attribution in this
@@ -1625,7 +1831,7 @@ export function hookSource(hook: AnyHook): string | undefined {
 export function runHookProgram(
   hook: AnyHook,
   event: RawHookEvent,
-  ctx: Record<string, string | boolean> = {},
+  ctx: RawCtx = {},
   root: string | undefined = event.cwd,
 ): HookProgramOutcome {
   const kind = dispatchKind(hook);
@@ -1650,16 +1856,14 @@ export function runHookProgram(
         kind: "decision",
         decision: decideStopGate(hook as StopGateHook, event, ctx),
       };
-    case "inject":
-      return {
-        kind: "injection",
-        context: runInject(hook as InjectHook, event).hookSpecificOutput
-          .additionalContext,
-      };
+    case "inject": {
+      const out = injectionOf(hook as InjectHook, event, ctx);
+      return { kind: "injection", context: out.context, records: out.records };
+    }
     case "react":
       return {
         kind: "reaction",
-        reaction: runReact(hook as ReactHook, event, root),
+        reaction: runReact(hook as ReactHook, event, ctx, root),
       };
     default:
       return assertNever(kind);

--- a/src/core/hook-program.ts
+++ b/src/core/hook-program.ts
@@ -95,6 +95,13 @@ type RawCtx = Record<string, string | boolean | StateFact>;
  * hand-constructed one degrades to exact matching rather than throwing mid-event.
  */
 export function matchesTool(tools: readonly string[], name: string): boolean {
+  // An EMPTY list matches NOTHING. Found by a mutation that was meant to disable
+  // tool-less reacts and didn't: with no tools the joined pattern is `^()$`,
+  // which matches the EMPTY STRING — and a tool-less event's name is the empty
+  // string. Without this line `tools()` would quietly be a catch-all on exactly
+  // the events where a react has no tool to check. Declaring nothing must mean
+  // nothing, not everything.
+  if (tools.length === 0) return false;
   if (tools.includes(name)) return true;
   try {
     return new RegExp(`^(${tools.join("|")})$`).test(name);

--- a/src/core/hook-providers.test.ts
+++ b/src/core/hook-providers.test.ts
@@ -23,6 +23,7 @@ import {
   type ProviderRegistry,
 } from "./hook-providers.js";
 import { isReadOnlyBash } from "./bash-effects.js";
+import { type StateEntry } from "./hook-state.js";
 
 /** A fake IO that answers a fixed map of commands. */
 function fakeIO(
@@ -30,11 +31,17 @@ function fakeIO(
   cwd = "/repo",
   platform: NodeJS.Platform = "linux",
   isCI = false,
+  store: Record<string, StateEntry> = {},
+  now = Date.parse("2026-08-12T12:00:00.000Z"),
 ): ProviderIO {
   return {
     cwd,
     platform,
     isCI,
+    // The state port and a PINNED clock: every ProviderIO carries them, and the
+    // default here ("nothing was ever recorded") is what the provider tests mean.
+    readState: (key) => store[key] ?? null,
+    now,
     exec: (command) => {
       if (command in answers) return answers[command];
       throw new Error(`fake exec: command failed: ${command}`);

--- a/src/core/hook-providers.ts
+++ b/src/core/hook-providers.ts
@@ -68,7 +68,11 @@ export interface InlineProvider<Name extends string = string> {
  * from outside the hook, and reading an undeclared one is a `tsc` error. See the
  * design note in `hook-state.ts`.
  */
-export type NeedSpec = ProviderName | InlineProvider | RegisteredRef | StateNeed;
+export type NeedSpec =
+  | ProviderName
+  | InlineProvider
+  | RegisteredRef
+  | StateNeed;
 
 /**
  * Declare an INLINE read-only fact: `provide("k8sCtx", "kubectl config current-context")`.

--- a/src/core/hook-providers.ts
+++ b/src/core/hook-providers.ts
@@ -19,6 +19,13 @@
  * testable with a fake exec and core depends on no child_process.
  */
 import { isReadOnlyBash } from "./bash-effects.js";
+import {
+  isStateNeed,
+  stateFact,
+  type StateEntry,
+  type StateFact,
+  type StateNeed,
+} from "./hook-state.js";
 
 /** The closed set of built-in facts a gate may declare via `needs`, with value types. */
 export interface ProviderResults {
@@ -52,8 +59,16 @@ export interface InlineProvider<Name extends string = string> {
   readonly dangerous: boolean;
 }
 
-/** A `needs` entry — a built-in name, an inline `provide`/`dangerously`, or a `provider()` ref. */
-export type NeedSpec = ProviderName | InlineProvider | RegisteredRef;
+/**
+ * A `needs` entry — a built-in name, an inline `provide`/`dangerously`, a
+ * `provider()` ref, or a `state()` read of a fact some hook recorded.
+ *
+ * `state()` rides this union rather than getting its own accessor so that ALL of
+ * a hook's external inputs stay in one declared list: the dependency is auditable
+ * from outside the hook, and reading an undeclared one is a `tsc` error. See the
+ * design note in `hook-state.ts`.
+ */
+export type NeedSpec = ProviderName | InlineProvider | RegisteredRef | StateNeed;
 
 /**
  * Declare an INLINE read-only fact: `provide("k8sCtx", "kubectl config current-context")`.
@@ -123,10 +138,14 @@ type NeedName<E extends NeedSpec> = E extends ProviderName
     ? Nm
     : E extends RegisteredRef<infer Rn>
       ? Rn
-      : never;
+      : E extends StateNeed<infer Sn>
+        ? Sn
+        : never;
 type NeedValue<E extends NeedSpec> = E extends ProviderName
   ? ProviderResults[E]
-  : string;
+  : E extends StateNeed
+    ? StateFact
+    : string;
 
 /**
  * The typed `e.ctx` for a hook that declared `needs: N` — ONLY the declared facts
@@ -151,6 +170,14 @@ export interface ProviderIO {
   readonly platform: NodeJS.Platform;
   /** Whether the process is on a CI server (the CLI injects `ci-info`'s verdict). */
   readonly isCI: boolean;
+  /**
+   * Read one recorded fact from THIS hook's state namespace, or `null` if it was
+   * never recorded. The namespace is resolved by the caller, so a key can never
+   * address another owner's store — see `hook-state.ts`.
+   */
+  readonly readState: (key: string) => StateEntry | null;
+  /** Epoch milliseconds, injected so fact ages are pinnable in a test. */
+  readonly now: number;
 }
 
 interface ProviderDef<K extends ProviderName> {
@@ -222,6 +249,10 @@ export function unknownProviders(
   const out: string[] = [];
   for (const n of needs) {
     if (isInline(n)) continue;
+    // A `state()` key is self-defining: it resolves to "never recorded" until
+    // some hook records it, which is a legitimate steady state (the very first
+    // run of every throttled hook), not a dangling reference.
+    if (isStateNeed(n)) continue;
     if (isRef(n)) {
       if (!registered.has(n.name)) out.push(n.name);
     } else if (!(n in BUILTIN_PROVIDERS)) out.push(n);
@@ -261,10 +292,15 @@ export function gatherContext(
   needs: readonly NeedSpec[],
   io: ProviderIO,
   registry: ProviderRegistry = {},
-): Record<string, string | boolean> {
-  const ctx: Record<string, string | boolean> = {};
+): Record<string, string | boolean | StateFact> {
+  const ctx: Record<string, string | boolean | StateFact> = {};
   for (const need of needs) {
-    if (isInline(need)) ctx[need.name] = tryExec(io, need.run);
+    if (isStateNeed(need)) {
+      // The one need that reaches no subprocess: the trusted runtime hands the
+      // stored entry (or null) straight in, and the fact view does the clamping
+      // every shell stamp-reader used to re-implement by hand.
+      ctx[need.name] = stateFact(io.readState(need.name), io.now);
+    } else if (isInline(need)) ctx[need.name] = tryExec(io, need.run);
     else if (isRef(need)) {
       const def = registry[need.name];
       ctx[need.name] = def ? tryExec(io, def.run) : "";

--- a/src/core/hook-state.test.ts
+++ b/src/core/hook-state.test.ts
@@ -392,6 +392,11 @@ test("matchesTool follows the SAME regex semantics as the matcher the compiler e
   assert.equal(matchesTool(["mcp__.*"], "not_mcp__x"), false);
   // A literal name containing metacharacters still matches itself (includes-first).
   assert.equal(matchesTool(["a(b"], "a(b"), true);
+  // An EMPTY declaration matches nothing — including the empty tool name a
+  // tool-less event carries. `^()$` matches "", so without an explicit guard
+  // `tools()` becomes a catch-all on precisely the events with no tool.
+  assert.equal(matchesTool([], ""), false);
+  assert.equal(matchesTool([], "Edit"), false);
 });
 
 test("a tool pattern that is not a valid regex does NOT compile", () => {

--- a/src/core/hook-state.test.ts
+++ b/src/core/hook-state.test.ts
@@ -1,0 +1,451 @@
+/**
+ * Runtime-owned named state (vitest). Every check has BOTH halves — it fires on a
+ * planted defect AND stays correct on realistic clean input — because the whole
+ * point of this feature is hooks whose success looks like silence.
+ *
+ * The load-bearing tests are the ones that pin the SAFE DIRECTION: a fact that was
+ * never recorded, or whose stored timestamp is corrupt, must read as infinitely
+ * old so the hook SPEAKS. Every historical failure in this area was a hook that
+ * went quiet, so a test that only checks the happy path checks nothing.
+ */
+import { test } from "vitest";
+import assert from "node:assert/strict";
+
+import {
+  state,
+  record,
+  stateFact,
+  durationSeconds,
+  isValidStateKey,
+  isStateNeed,
+  isStateWrite,
+  admissibleWrites,
+  HookStateError,
+  type StateEntry,
+} from "./hook-state.js";
+import {
+  defineReact,
+  defineInject,
+  defineHook,
+  tool,
+  tools,
+  notice,
+  nothing,
+  run,
+  inject,
+  allow,
+  deny,
+  runHookProgram,
+  outcomeWrites,
+  matchesTool,
+  invalidToolPatterns,
+  compileHookProgram,
+  HookCompileError,
+} from "./hook-program.js";
+import { gatherContext, type ProviderIO } from "./hook-providers.js";
+
+const NOW = Date.parse("2026-08-12T12:00:00.000Z");
+const agoEntry = (seconds: number, value = ""): StateEntry => ({
+  value,
+  at: new Date(NOW - seconds * 1000).toISOString(),
+});
+
+function io(store: Record<string, StateEntry> = {}): ProviderIO {
+  return {
+    exec: () => {
+      throw new Error("no exec in this test");
+    },
+    cwd: "/repo",
+    platform: "linux",
+    isCI: false,
+    readState: (k) => store[k] ?? null,
+    now: NOW,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Duration parsing
+// ---------------------------------------------------------------------------
+
+test("durationSeconds parses the four units, and REFUSES anything else", () => {
+  assert.equal(durationSeconds("90s"), 90);
+  assert.equal(durationSeconds("30m"), 1800);
+  assert.equal(durationSeconds("1h"), 3600);
+  assert.equal(durationSeconds("12h"), 43200);
+  assert.equal(durationSeconds("7d"), 604800);
+  // The defect half: a plausible-but-wrong duration must not silently become a
+  // number. "1 hour" turning into 1 (second) would make a throttle useless, and
+  // turning into 0 or Infinity would make it wrong in one of the two directions
+  // this feature exists to control.
+  for (const bad of ["1 hour", "1H", "hour", "", "3", "-1h", "1w", "1.h"]) {
+    assert.equal(durationSeconds(bad), null, `"${bad}" must not parse`);
+  }
+});
+
+test("a bad duration THROWS at the freshness test, it does not default", () => {
+  const f = stateFact(agoEntry(10), NOW);
+  assert.throws(() => f.fresherThan("1 hour" as never), HookStateError);
+  assert.throws(() => f.olderThan("" as never), HookStateError);
+  // Clean half: a good duration answers.
+  assert.equal(f.fresherThan("1h"), true);
+});
+
+// ---------------------------------------------------------------------------
+// The read view — and the direction of every default
+// ---------------------------------------------------------------------------
+
+test("a NEVER-RECORDED fact is infinitely old, so every freshness test lets the hook speak", () => {
+  const f = stateFact(null, NOW);
+  assert.equal(f.recorded, false);
+  assert.equal(f.value, "");
+  assert.equal(f.at, "");
+  assert.equal(f.ageSeconds, Infinity);
+  assert.equal(f.fresherThan("100d"), false, "never recorded is NOT fresh");
+  assert.equal(f.olderThan("1s"), true, "never recorded IS stale");
+
+  // 🔴 THE REGRESSION THIS PINS. With `ageSeconds: number | null`, the natural
+  // spelling of the same test reads a never-recorded fact as FRESH, because
+  // `null < 3600` is true in JavaScript. A hook that had never run would then
+  // never run — silently, forever. Assert the arithmetic directly so the reason
+  // survives even if someone changes the type back.
+  assert.equal((null as unknown as number) < 3600, true, "the footgun is real");
+  assert.equal(f.ageSeconds < 3600, false, "Infinity defuses it");
+});
+
+test("a recorded fact reports its age, value and instant, and the window boundary is exact", () => {
+  const f = stateFact(agoEntry(3600, "claude/hook-state"), NOW);
+  assert.equal(f.recorded, true);
+  assert.equal(f.value, "claude/hook-state");
+  assert.equal(f.ageSeconds, 3600);
+  // Exactly at the window is NOT fresher-than (strict <) and IS older-than (>=):
+  // the two are exact complements, so no age falls through both.
+  assert.equal(f.fresherThan("1h"), false);
+  assert.equal(f.olderThan("1h"), true);
+  assert.equal(f.fresherThan("2h"), true);
+  assert.equal(f.olderThan("2h"), false);
+  for (const secs of [0, 1, 3599, 3600, 3601, 999999]) {
+    const g = stateFact(agoEntry(secs), NOW);
+    assert.notEqual(
+      g.fresherThan("1h"),
+      g.olderThan("1h"),
+      `fresherThan and olderThan must partition at age ${String(secs)}`,
+    );
+  }
+});
+
+test("a CORRUPT timestamp reads as never-recorded (noisy), not as recorded-now (silent)", () => {
+  const corrupt = stateFact({ value: "x", at: "not-a-date" }, NOW);
+  assert.equal(corrupt.recorded, false);
+  assert.equal(corrupt.ageSeconds, Infinity);
+  assert.equal(corrupt.fresherThan("100d"), false, "corruption must not silence");
+  // Clean half: a well-formed entry is honoured.
+  assert.equal(stateFact(agoEntry(5), NOW).recorded, true);
+});
+
+test("a clock that went backwards clamps to age 0 rather than going negative", () => {
+  const future = stateFact(
+    { value: "", at: new Date(NOW + 60_000).toISOString() },
+    NOW,
+  );
+  assert.equal(future.ageSeconds, 0);
+  assert.equal(future.fresherThan("1s"), true);
+});
+
+// ---------------------------------------------------------------------------
+// Keys — the containment property
+// ---------------------------------------------------------------------------
+
+test("a key is a NAME, not a path: traversal, hidden files and the reserved sigil are unspellable", () => {
+  for (const good of [
+    "calendar.synced",
+    "retro.nagged",
+    "a",
+    "A1",
+    "x_y-z.1",
+    "0",
+    "a".repeat(64),
+  ]) {
+    assert.equal(isValidStateKey(good), true, `"${good}" should be valid`);
+  }
+  for (const bad of [
+    "",
+    ".",
+    "..",
+    "../../settings",
+    "a/b",
+    "a\\b",
+    ".hidden",
+    "-flag",
+    "_leading",
+    "@fired",
+    "a b",
+    "ключ",
+    "a".repeat(65),
+    "a\nb",
+  ]) {
+    assert.equal(isValidStateKey(bad), false, `"${bad}" must be rejected`);
+  }
+});
+
+test("record()/state() THROW on an invalid key — at the tier the hook's own test runs", () => {
+  assert.throws(() => record("../../settings"), HookStateError);
+  assert.throws(() => record("@fired"), HookStateError);
+  assert.throws(() => state(".."), HookStateError);
+  // Clean half: valid keys build the expected declarations.
+  assert.deepEqual(record("calendar.synced"), {
+    kind: "record",
+    name: "calendar.synced",
+    value: "",
+  });
+  assert.deepEqual(record("merge.nagged", "main"), {
+    kind: "record",
+    name: "merge.nagged",
+    value: "main",
+  });
+  assert.deepEqual(state("calendar.synced"), {
+    kind: "state",
+    name: "calendar.synced",
+  });
+  assert.equal(isStateNeed(state("x")), true);
+  assert.equal(isStateNeed("git.branch"), false);
+  assert.equal(isStateWrite(record("x")), true);
+  assert.equal(isStateWrite({ kind: "run", command: "ls" }), false);
+});
+
+test("admissibleWrites REFUSES a hand-built write that bypassed record()", () => {
+  // The real threat: `record()` throws, but nothing stops a hook returning the
+  // object literal directly. The runtime re-checks before it computes any path.
+  const smuggled = { kind: "record", name: "../../settings", value: "x" };
+  const got = admissibleWrites([record("ok.key"), smuggled, "garbage", null]);
+  assert.deepEqual(
+    got.ok.map((w) => w.name),
+    ["ok.key"],
+  );
+  assert.equal(got.refused.length, 3);
+  assert.ok(got.refused.includes("../../settings"));
+  // Clean half: an all-valid list is passed through untouched.
+  assert.deepEqual(admissibleWrites([record("a"), record("b")]).refused, []);
+});
+
+// ---------------------------------------------------------------------------
+// Reading rides `needs` — one declared list for every external input
+// ---------------------------------------------------------------------------
+
+test("state() reads through needs/ctx, and ONLY what was declared appears", () => {
+  const ctx = gatherContext(
+    [state("calendar.synced")],
+    io({ "calendar.synced": agoEntry(7200) }),
+  );
+  const fact = ctx["calendar.synced"];
+  assert.equal(typeof fact, "object");
+  assert.equal((fact as ReturnType<typeof stateFact>).ageSeconds, 7200);
+  assert.equal(
+    (fact as ReturnType<typeof stateFact>).fresherThan("12h"),
+    true,
+    "synced 2h ago is fresh within 12h",
+  );
+  // Undeclared keys are absent even when the store holds them.
+  assert.deepEqual(Object.keys(ctx), ["calendar.synced"]);
+  // Defect half: a declared key with nothing in the store is present, and stale.
+  const empty = gatherContext([state("calendar.synced")], io());
+  assert.equal(
+    (empty["calendar.synced"] as ReturnType<typeof stateFact>).recorded,
+    false,
+  );
+});
+
+test("a state() need is never reported as an unknown provider, and reaches no subprocess", () => {
+  const throwing: ProviderIO = {
+    ...io({ "a.b": agoEntry(1) }),
+    exec: () => {
+      throw new Error("gathering state must not shell out");
+    },
+  };
+  assert.doesNotThrow(() => gatherContext([state("a.b")], throwing));
+});
+
+// ---------------------------------------------------------------------------
+// Writing is a DECLARATION — the hook never touches the world
+// ---------------------------------------------------------------------------
+
+test("a react that only WITNESSES returns nothing() and still declares its record", () => {
+  const hook = defineReact({
+    on: "PostToolUse",
+    match: tools("mcp__.*"),
+    react: () => nothing(record("calendar.synced")),
+  });
+  const outcome = runHookProgram(hook, {
+    tool_name: "mcp__4f54037d__list_events",
+  });
+  assert.equal(outcome.kind, "reaction");
+  assert.deepEqual(
+    outcomeWrites(outcome).ok.map((w) => w.name),
+    ["calendar.synced"],
+  );
+  // Defect half: a tool the hook does not match records NOTHING. A witness that
+  // fires on the wrong event is worse than one that never fires, because the
+  // fact it writes is false.
+  const other = runHookProgram(hook, { tool_name: "Bash" });
+  assert.deepEqual(outcomeWrites(other).ok, []);
+});
+
+test("records ride notice()/run()/inject() as trailing arguments, and are optional", () => {
+  assert.deepEqual(notice("hi").records, []);
+  assert.deepEqual(run("ls").records, []);
+  assert.deepEqual(inject("ctx").records, []);
+  assert.deepEqual(nothing().records, []);
+  assert.deepEqual(
+    notice("hi", record("a"), record("b")).records.map((w) => w.name),
+    ["a", "b"],
+  );
+  assert.equal(run("ls", record("a")).effect !== undefined, true);
+  assert.deepEqual(
+    inject("ctx", record("a")).records.map((w) => w.name),
+    ["a"],
+  );
+});
+
+test("an inject reads state and records its own nudge in ONE return", () => {
+  const hook = defineInject({
+    on: "UserPromptSubmit",
+    needs: [state("calendar.synced"), state("calendar.nagged")] as const,
+    produce: (e) =>
+      e.ctx["calendar.synced"].fresherThan("12h")
+        ? inject("")
+        : e.ctx["calendar.nagged"].fresherThan("3h")
+          ? inject("short escalation")
+          : inject("FULL BLOCK", record("calendar.nagged")),
+  });
+  const fresh = runHookProgram(hook, {}, {
+    "calendar.synced": stateFact(agoEntry(60), NOW),
+    "calendar.nagged": stateFact(null, NOW),
+  });
+  assert.equal(fresh.kind === "injection" && fresh.context, "");
+  assert.deepEqual(outcomeWrites(fresh).ok, [], "silence records nothing");
+
+  const nagged = runHookProgram(hook, {}, {
+    "calendar.synced": stateFact(agoEntry(90000), NOW),
+    "calendar.nagged": stateFact(agoEntry(60), NOW),
+  });
+  assert.equal(nagged.kind === "injection" && nagged.context, "short escalation");
+  assert.deepEqual(
+    outcomeWrites(nagged).ok,
+    [],
+    "the escalation line must NOT move the nag stamp, or it silences the full block",
+  );
+
+  const full = runHookProgram(hook, {}, {
+    "calendar.synced": stateFact(agoEntry(90000), NOW),
+    "calendar.nagged": stateFact(null, NOW),
+  });
+  assert.equal(full.kind === "injection" && full.context, "FULL BLOCK");
+  assert.deepEqual(
+    outcomeWrites(full).ok.map((w) => w.name),
+    ["calendar.nagged"],
+    "only the branch that SPEAKS records that it spoke",
+  );
+});
+
+test("a GATE cannot record: a Decision carries no writes, in either direction", () => {
+  const gate = defineHook({
+    on: "PreToolUse",
+    match: tool("Bash"),
+    needs: [state("deploy.done")] as const,
+    decide: (e) => (e.ctx["deploy.done"].fresherThan("1h") ? allow() : deny("no")),
+  });
+  for (const fact of [stateFact(agoEntry(10), NOW), stateFact(null, NOW)]) {
+    const outcome = runHookProgram(
+      gate,
+      { tool_name: "Bash", tool_input: { command: "ls" } },
+      { "deploy.done": fact },
+    );
+    assert.equal(outcome.kind, "decision");
+    assert.deepEqual(outcomeWrites(outcome).ok, []);
+  }
+  // Clean half: the gate still DECIDES on the state it read.
+  const allowed = runHookProgram(
+    gate,
+    { tool_name: "Bash", tool_input: { command: "ls" } },
+    { "deploy.done": stateFact(agoEntry(10), NOW) },
+  );
+  assert.equal(
+    allowed.kind === "decision" && allowed.decision.kind,
+    "allow",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The two routing defects the dogfood exposed
+// ---------------------------------------------------------------------------
+
+test("matchesTool follows the SAME regex semantics as the matcher the compiler emits", () => {
+  // The defect: an exact-string filter drops a family matcher the harness routes.
+  assert.equal(
+    matchesTool(["mcp__.*"], "mcp__4f54037d-0499__list_events"),
+    true,
+    "a family matcher must match a member",
+  );
+  assert.equal(matchesTool(["Edit", "Write"], "Edit"), true);
+  assert.equal(matchesTool(["Edit", "Write"], "Read"), false);
+  // Anchored: a pattern must not match a LONGER name by accident.
+  assert.equal(matchesTool(["Edit"], "EditNotebook"), false);
+  assert.equal(matchesTool(["mcp__.*"], "not_mcp__x"), false);
+  // A literal name containing metacharacters still matches itself (includes-first).
+  assert.equal(matchesTool(["a(b"], "a(b"), true);
+});
+
+test("a tool pattern that is not a valid regex does NOT compile", () => {
+  const bad = defineReact({
+    on: "PostToolUse",
+    match: tools("a(b"),
+    react: () => nothing(),
+  });
+  assert.deepEqual(invalidToolPatterns(["a(b", "Edit", "mcp__.*"]), ["a(b"]);
+  assert.throws(
+    () => compileHookProgram("import {} from 'vigiles/hook';", bad),
+    HookCompileError,
+  );
+  // Clean half: a valid family pattern compiles.
+  const good = defineReact({
+    on: "PostToolUse",
+    match: tools("mcp__.*"),
+    react: () => nothing(),
+  });
+  assert.doesNotThrow(() =>
+    compileHookProgram("import {} from 'vigiles/hook';", good),
+  );
+});
+
+test("a react on a TOOL-LESS event fires; one that declared tools still filters", () => {
+  const stopHook = defineReact({
+    on: "Stop",
+    react: () => notice("substantive session"),
+  });
+  const outcome = runHookProgram(stopHook, { stop_hook_active: false });
+  assert.equal(outcome.kind, "reaction");
+  assert.equal(
+    outcome.kind === "reaction" && outcome.reaction.kind,
+    "notice",
+    "a Stop react used to return none() forever — the hook was dead",
+  );
+  // …and it emits no tool matcher, like every other tool-less role.
+  const compiled = compileHookProgram(
+    "import {} from 'vigiles/hook';",
+    stopHook,
+  );
+  assert.equal(JSON.parse(compiled.settingsBlock).hooks.Stop[0].matcher, undefined);
+
+  // Defect half: omitting `match` must not turn every react into a catch-all.
+  const toolHook = defineReact({
+    on: "PostToolUse",
+    match: tools("Edit"),
+    react: () => notice("edited"),
+  });
+  assert.equal(
+    runHookProgram(toolHook, { tool_name: "Bash" }).kind === "reaction" &&
+      (runHookProgram(toolHook, { tool_name: "Bash" }) as {
+        reaction: { kind: string };
+      }).reaction.kind,
+    "none",
+  );
+});

--- a/src/core/hook-state.test.ts
+++ b/src/core/hook-state.test.ts
@@ -137,7 +137,11 @@ test("a CORRUPT timestamp reads as never-recorded (noisy), not as recorded-now (
   const corrupt = stateFact({ value: "x", at: "not-a-date" }, NOW);
   assert.equal(corrupt.recorded, false);
   assert.equal(corrupt.ageSeconds, Infinity);
-  assert.equal(corrupt.fresherThan("100d"), false, "corruption must not silence");
+  assert.equal(
+    corrupt.fresherThan("100d"),
+    false,
+    "corruption must not silence",
+  );
   // Clean half: a well-formed entry is honoured.
   assert.equal(stateFact(agoEntry(5), NOW).recorded, true);
 });
@@ -309,35 +313,50 @@ test("an inject reads state and records its own nudge in ONE return", () => {
   const hook = defineInject({
     on: "UserPromptSubmit",
     needs: [state("calendar.synced"), state("calendar.nagged")] as const,
-    produce: (e) =>
-      e.ctx["calendar.synced"].fresherThan("12h")
-        ? inject("")
-        : e.ctx["calendar.nagged"].fresherThan("3h")
-          ? inject("short escalation")
-          : inject("FULL BLOCK", record("calendar.nagged")),
+    produce: (e) => {
+      if (e.ctx["calendar.synced"].fresherThan("12h")) return inject("");
+      if (e.ctx["calendar.nagged"].fresherThan("3h"))
+        return inject("short escalation");
+      return inject("FULL BLOCK", record("calendar.nagged"));
+    },
   });
-  const fresh = runHookProgram(hook, {}, {
-    "calendar.synced": stateFact(agoEntry(60), NOW),
-    "calendar.nagged": stateFact(null, NOW),
-  });
+  const fresh = runHookProgram(
+    hook,
+    {},
+    {
+      "calendar.synced": stateFact(agoEntry(60), NOW),
+      "calendar.nagged": stateFact(null, NOW),
+    },
+  );
   assert.equal(fresh.kind === "injection" && fresh.context, "");
   assert.deepEqual(outcomeWrites(fresh).ok, [], "silence records nothing");
 
-  const nagged = runHookProgram(hook, {}, {
-    "calendar.synced": stateFact(agoEntry(90000), NOW),
-    "calendar.nagged": stateFact(agoEntry(60), NOW),
-  });
-  assert.equal(nagged.kind === "injection" && nagged.context, "short escalation");
+  const nagged = runHookProgram(
+    hook,
+    {},
+    {
+      "calendar.synced": stateFact(agoEntry(90000), NOW),
+      "calendar.nagged": stateFact(agoEntry(60), NOW),
+    },
+  );
+  assert.equal(
+    nagged.kind === "injection" && nagged.context,
+    "short escalation",
+  );
   assert.deepEqual(
     outcomeWrites(nagged).ok,
     [],
     "the escalation line must NOT move the nag stamp, or it silences the full block",
   );
 
-  const full = runHookProgram(hook, {}, {
-    "calendar.synced": stateFact(agoEntry(90000), NOW),
-    "calendar.nagged": stateFact(null, NOW),
-  });
+  const full = runHookProgram(
+    hook,
+    {},
+    {
+      "calendar.synced": stateFact(agoEntry(90000), NOW),
+      "calendar.nagged": stateFact(null, NOW),
+    },
+  );
   assert.equal(full.kind === "injection" && full.context, "FULL BLOCK");
   assert.deepEqual(
     outcomeWrites(full).ok.map((w) => w.name),
@@ -351,7 +370,8 @@ test("a GATE cannot record: a Decision carries no writes, in either direction", 
     on: "PreToolUse",
     match: tool("Bash"),
     needs: [state("deploy.done")] as const,
-    decide: (e) => (e.ctx["deploy.done"].fresherThan("1h") ? allow() : deny("no")),
+    decide: (e) =>
+      e.ctx["deploy.done"].fresherThan("1h") ? allow() : deny("no"),
   });
   for (const fact of [stateFact(agoEntry(10), NOW), stateFact(null, NOW)]) {
     const outcome = runHookProgram(
@@ -368,10 +388,7 @@ test("a GATE cannot record: a Decision carries no writes, in either direction", 
     { tool_name: "Bash", tool_input: { command: "ls" } },
     { "deploy.done": stateFact(agoEntry(10), NOW) },
   );
-  assert.equal(
-    allowed.kind === "decision" && allowed.decision.kind,
-    "allow",
-  );
+  assert.equal(allowed.kind === "decision" && allowed.decision.kind, "allow");
 });
 
 // ---------------------------------------------------------------------------
@@ -438,7 +455,10 @@ test("a react on a TOOL-LESS event fires; one that declared tools still filters"
     "import {} from 'vigiles/hook';",
     stopHook,
   );
-  assert.equal(JSON.parse(compiled.settingsBlock).hooks.Stop[0].matcher, undefined);
+  const block = JSON.parse(compiled.settingsBlock) as {
+    hooks: Record<string, { matcher?: string }[]>;
+  };
+  assert.equal(block.hooks.Stop[0].matcher, undefined);
 
   // Defect half: omitting `match` must not turn every react into a catch-all.
   const toolHook = defineReact({
@@ -448,9 +468,11 @@ test("a react on a TOOL-LESS event fires; one that declared tools still filters"
   });
   assert.equal(
     runHookProgram(toolHook, { tool_name: "Bash" }).kind === "reaction" &&
-      (runHookProgram(toolHook, { tool_name: "Bash" }) as {
-        reaction: { kind: string };
-      }).reaction.kind,
+      (
+        runHookProgram(toolHook, { tool_name: "Bash" }) as {
+          reaction: { kind: string };
+        }
+      ).reaction.kind,
     "none",
   );
 });

--- a/src/core/hook-state.ts
+++ b/src/core/hook-state.ts
@@ -1,0 +1,409 @@
+/**
+ * RUNTIME-OWNED NAMED STATE — the one thing a compiled hook could not do.
+ *
+ * ## In one sentence
+ *
+ * A hook names a fact; the runtime stores it; any hook in the same directory can
+ * declare that name in `needs` and read it back with its age.
+ *
+ * There is no "and also". Throttling is not a second feature — it is this one,
+ * used twice: a hook records the fact that it spoke, and reads that fact's age
+ * before speaking again. See "Why there is no `throttle:` field" below, which is
+ * the design's load-bearing decision and the one a reader should challenge first.
+ *
+ * ## The hole it fills, measured
+ *
+ * `prefer-compiled-hooks` says a hook should be a typed program the compiler can
+ * check. In the knowledge base this repo dogfoods on, ALL SEVEN advisory hooks
+ * were still hand-written shell (measured 2026-08-12), and the reason was uniform:
+ * every one of them both READS and WRITES a stamp file.
+ *
+ *   calendar-heartbeat    reads .cal-last-sync + .cal-last-nag   writes .cal-last-nag
+ *   calendar-sync-record  —                                      writes .cal-last-sync
+ *   merge-nudge           reads stamp + branch age               writes stamp
+ *   paper-status-gates    reads status lines                     writes —
+ *   retro-nudge           reads clock + git log                  writes stamp
+ *   scratchpad-guard      reads artifact mtimes                  writes stamp
+ *   vigiles-check         reads last report                      writes report + stamp
+ *
+ * The vocabulary could express the READ (`needs` → `e.ctx`) and could express a
+ * WRITE only by shelling out through a react's `run()` — which hands the hook a
+ * subprocess to get a timestamp into a file. So "remind at most once an hour" was
+ * inexpressible, and seven hooks stayed shell.
+ *
+ * ## What is UNREPRESENTABLE afterwards, and what is merely legible
+ *
+ * The product's claim is "remove the capability, don't catch its misuse", so the
+ * honest accounting has two columns.
+ *
+ * Gone by construction — a hook CANNOT:
+ *   - touch the filesystem. `record()` returns a VALUE. The hook's return type is
+ *     data; the trusted runtime performs the write. `checkHookImports` still
+ *     rejects every import but `vigiles/hook`, and this API hands out no writer.
+ *   - name another owner's state. Namespaces are not in the vocabulary at all —
+ *     {@link StateWrite} and {@link StateNeed} carry a KEY and nothing else, and
+ *     the runtime derives the namespace from the hook's own path. There is no
+ *     string a hook can pass to reach a sibling plugin's store.
+ *   - escape its namespace through the key. {@link isValidStateKey} admits
+ *     `[A-Za-z0-9][A-Za-z0-9._-]{0,63}` and nothing else, so `../`, `/`, `.`,
+ *     `..` and the reserved `@` are all unspellable, and {@link record} THROWS on
+ *     a bad key rather than returning a value that fails later.
+ *   - read a fact it did not declare — inherited from `needs`/`HookCtx`: an
+ *     undeclared key is a `tsc` error, not an empty string at runtime.
+ *   - silence itself by never having run. The freshness reads are TOTAL over
+ *     "never recorded" (see the `Infinity` note on {@link StateFact.ageSeconds}).
+ *
+ * Legible but still possible — a hook CAN:
+ *   - record a fact under a name that misdescribes what happened. Nothing in a
+ *     runtime can decide whether "the calendar was really synced"; that is a
+ *     claim about the world. What the design guarantees is narrower and is the
+ *     property that was actually missing: **the framework never writes a fact on
+ *     its own initiative.** Every entry in the store exists because some hook's
+ *     source contains a `record("that-name")` at a site a reader can point at,
+ *     and the entry records WHICH hook wrote it ({@link StateEntry.by}). Under
+ *     the old shell design and under any automatic-stamp design, the write is
+ *     implicit and there is no such site.
+ *
+ * ## Why there is no `throttle:` field
+ *
+ * A throttle field was the obvious shape and it was designed first: `throttle:
+ * "1h"`, the runtime reads a hidden stamp, skips while fresh, updates on emit.
+ * Two measurements killed it.
+ *
+ * 1. IT CHANGES BEHAVIOUR THE HOOKS DEPEND ON. An automatic stamp can only be
+ *    written at one place — where the runtime sees the hook emit. Of the five
+ *    hooks that want throttling, `scratchpad-guard` stamps BEFORE its own
+ *    threshold test (it marks "I looked" at line 25 and only decides whether to
+ *    speak at line 43), so an emit-triggered stamp silently converts "check
+ *    hourly" into "check every turn until something is worth saying". The write
+ *    site is a design decision per hook; a field takes it away.
+ *
+ * 2. IT IS THE EXACT DEFECT THIS FEATURE EXISTS TO RETIRE. The knowledge base ran
+ *    a single automatic stamp for months: `calendar-heartbeat` wrote it at print
+ *    time, so an IGNORED reminder silenced itself for an hour and a skipped sync
+ *    became indistinguishable from a completed one. Cost, from that repo's own
+ *    record: 28 unclosed events and six blank calendar days behind a hook that
+ *    was firing correctly the entire time. The fix that repo reached for was to
+ *    split the stamp in two and add a SECOND hook whose only job is to write the
+ *    "it really happened" one. A `throttle:` field would have re-manufactured the
+ *    stamp whose meaning was wrong, given it no name, and made it the ergonomic
+ *    default.
+ *
+ * So the two meanings of a stamp stay apart the only way that survives contact:
+ * BOTH are named, and neither is automatic. "I spoke at T" is
+ * `record("retro.nagged")` written on the branch that speaks. "The work happened
+ * at T" is `record("calendar.synced")` written by the hook that WATCHED the work
+ * — a different hook, on a different event. A reader can see which is which by
+ * reading the name and the site; a framework-manufactured stamp offers neither.
+ *
+ * The cost is one line per throttled hook:
+ *
+ *     needs: [state("retro.nagged")],
+ *     react: (e) => e.ctx["retro.nagged"].fresherThan("1d")
+ *       ? nothing()
+ *       : notice(MESSAGE, record("retro.nagged")),
+ *
+ * and the line says out loud what the field would have hidden.
+ *
+ * ## What this SUBTRACTS
+ *
+ * - The stamp-file convention it replaces: seven bespoke `.claude/.*-last` files,
+ *   each with its own hand-rolled read-and-clamp (`case "$v" in '' | *[!0-9]*) v=0`
+ *   appears in three of the seven, because a raw file is untyped and every reader
+ *   has to re-derive that a missing file means "never"). The clamp is what
+ *   {@link StateFact} is: the parse happens once, in the runtime, typed.
+ * - `run()`'s side career as a writer. Today the only sanctioned way for a react
+ *   to remember anything is `run("date +%s > .claude/.stamp")` — a subprocess, a
+ *   shell, a path, and an effect-classification of "side-effecting" for what is
+ *   really a variable assignment. After this, `run()` goes back to meaning what
+ *   its doc comment says it means: invoke a real tool.
+ * - An asymmetry in `needs`. Gates could declare context; injects and reacts could
+ *   not, for no reason anyone recorded. State is useless to a hook that cannot
+ *   read it, so `needs` is now uniform across roles — one fewer special case
+ *   rather than one more.
+ *
+ * It does NOT retire the `observe`-mode record (`.vigiles/hook-observations.jsonl`):
+ * that is an append-only audit log of what a gate WOULD have blocked, a different
+ * shape (many rows, never read back by a hook) from a named current-value fact.
+ *
+ * ## Failure modes, and whether they are loud
+ *
+ *   forget to `record`          → the reader's fact never freshens → it fires
+ *                                 EVERY TIME. Loud (noisy), self-announcing.
+ *   `record` the wrong key      → same as forgetting. Loud.
+ *   `record` too eagerly        → the reader goes QUIET. This is the dangerous
+ *                                 direction and the design does not make it
+ *                                 impossible; it makes it locatable. Every entry
+ *                                 carries `by`, so `cat .vigiles/state/**` names
+ *                                 the hook that claimed the fact.
+ *   invalid key                 → {@link record} throws, in-process, in the hook's
+ *                                 own unit test — the tier this product exists to
+ *                                 make cheap. A hand-built `{kind:"record",…}`
+ *                                 object that bypasses the constructor is refused
+ *                                 again by the runtime before the write.
+ *   fact never recorded         → age is `Infinity`, so every freshness test says
+ *                                 "not fresh" and the hook SPEAKS. Fails toward
+ *                                 noise, never toward silence.
+ *
+ * That last one is not a slogan; it is why the read view exposes `Infinity`
+ * instead of `null`. MEASURED: `null < 3600` is `true` in JavaScript (null
+ * numifies to 0), so the natural spelling of a freshness test — the one every
+ * author writes first — reads a NEVER-RECORDED fact as maximally fresh and
+ * silences the hook forever. That is the precise failure this whole feature was
+ * commissioned to end, reintroduced by a type choice. `Infinity` makes every
+ * comparison come out the safe way with no special case to remember.
+ *
+ * ## Alternatives rejected, with what rejected them
+ *
+ * - **Give reacts a filesystem.** Trades one unchecked capability for another and
+ *   makes `checkHookImports` theatre: if the sanctioned API hands out a writer,
+ *   "capability = API surface" says nothing. Concretely it also puts
+ *   `.claude/settings.json` and `.git/hooks/*` one path string away from a guard
+ *   that could then rewrite its own wiring. And it does not even solve the stated
+ *   problem well: the seven shell hooks touch eight stamp paths between them and
+ *   three re-implement the same numeric clamp, which is what a raw file interface
+ *   COSTS rather than what it saves.
+ * - **Keep throttle as its own feature.** Rejected by the two measurements above.
+ * - **`ageSeconds: number | null`.** Rejected by `null < 3600 === true`.
+ * - **A separate accessor, `e.state("k")`, instead of `needs`.** Rejected: it
+ *   would be a second way to read external facts, and it would destroy the
+ *   property that makes `needs` worth having — the dependency is declared, so it
+ *   is auditable from the outside and an undeclared read does not compile.
+ * - **One store file per HOOK** (isolation by hook rather than by directory).
+ *   Rejected because it cannot express the requirement: the case that forced this
+ *   feature is one hook recording a fact for a DIFFERENT hook to read tomorrow.
+ * - **One JSON blob per namespace.** Rejected on concurrency — see below.
+ *
+ * ## Storage, scope and concurrency
+ *
+ * One file per key, under a directory the runtime derives from the hook's own
+ * location: `.vigiles/state/<hook's dir>/<key>.json`. The layout mirrors the
+ * directory rather than slugging it, so it is injective and a human debugging a
+ * hook can find the fact by walking the path they already know.
+ *
+ * Scope is the hook's DIRECTORY. Hooks shipped together share their facts (which
+ * is the requirement); a vendored plugin's hooks live in the plugin's own
+ * directory and cannot see or clobber the project's. Two unrelated plugins that
+ * both install into `.claude/hooks/` do share — and they also share
+ * `settings.json` and the checkout, so they are already one trust domain.
+ *
+ * Concurrency: two hook processes can run at once, and the store is designed so
+ * the answer is "nothing to coordinate" rather than "acceptable loss". Distinct
+ * keys are distinct files and never interact — which is exactly why a single JSON
+ * blob was rejected, since read-modify-write on a shared blob loses a concurrent
+ * write silently. Same-key concurrent writes are resolved by writing a temp file
+ * in the same directory and `rename()`ing it over, which is atomic on POSIX: a
+ * reader sees the whole old entry or the whole new one, never a torn mix of one
+ * write's value with another's timestamp. Two writers of the same key are both
+ * writing "now", so either outcome is correct.
+ *
+ * Pure by construction: this module reads no disk and imports nothing. The store
+ * I/O lives in the trusted runtime and is injected, so the whole model is
+ * testable against a fake store with no filesystem.
+ */
+
+/** A duration a freshness test is measured against: `"90s"`, `"30m"`, `"1h"`, `"7d"`. */
+export type Duration = `${number}${"s" | "m" | "h" | "d"}`;
+
+const UNIT_SECONDS: Readonly<Record<string, number>> = {
+  s: 1,
+  m: 60,
+  h: 3600,
+  d: 86400,
+};
+
+/**
+ * Seconds in a duration string, or `null` if it is not one. A bad duration must
+ * not quietly become 0 (which would read as "always stale" — noisy but wrong) nor
+ * `Infinity` (silent, the failure this feature exists to end), so callers turn
+ * `null` into a throw at the point the author can see it.
+ */
+export function durationSeconds(d: string): number | null {
+  const m = /^(\d+(?:\.\d+)?)([smhd])$/.exec(d);
+  if (m === null) return null;
+  const unit = UNIT_SECONDS[m[2]];
+  if (unit === undefined) return null;
+  return Number(m[1]) * unit;
+}
+
+/**
+ * The stored shape of one named fact. `at` is ISO-8601 so the store is readable
+ * with `cat`; `by` names the hook that claimed it, which is the only handle a
+ * human has on "who decided this fact is true" (see the failure modes above).
+ */
+export interface StateEntry {
+  readonly value: string;
+  readonly at: string;
+  readonly by?: string;
+}
+
+/**
+ * A recorded fact as a hook reads it — the typed replacement for "cat the stamp
+ * file and clamp whatever comes back".
+ */
+export interface StateFact {
+  /** Has this key ever been recorded? The only way to distinguish "never" from "long ago". */
+  readonly recorded: boolean;
+  /** The recorded string; `""` when never recorded. */
+  readonly value: string;
+  /** ISO-8601 instant of the recording; `""` when never recorded. */
+  readonly at: string;
+  /**
+   * Seconds since the recording — `Infinity` when never recorded, never `null`.
+   *
+   * 🔴 THE TYPE IS THE SAFETY PROPERTY. With `number | null`, the test every
+   * author writes first (`age < 3600`) reads a never-recorded fact as FRESH,
+   * because `null < 3600` is `true` in JavaScript. A hook that has never run
+   * would therefore never run. With `Infinity` every comparison lands on the
+   * side that speaks, and there is no null case to forget.
+   */
+  readonly ageSeconds: number;
+  /** True iff recorded within `within`. Never-recorded → `false` (so the hook speaks). */
+  fresherThan(within: Duration): boolean;
+  /** True iff not recorded within `within`. Never-recorded → `true` (so the hook speaks). */
+  olderThan(within: Duration): boolean;
+}
+
+/** Thrown for a malformed duration or key — a programming error, surfaced in the hook's own test. */
+export class HookStateError extends Error {}
+
+function secondsOrThrow(within: string): number {
+  const s = durationSeconds(within);
+  if (s === null) {
+    throw new HookStateError(
+      `invalid duration "${within}" — use <number><s|m|h|d>, e.g. "90s", "30m", "1h", "7d".`,
+    );
+  }
+  return s;
+}
+
+/**
+ * Build the read view of a stored entry. `entry === null` means the key has never
+ * been recorded. `nowMs` is passed in rather than read from the clock so the whole
+ * model stays pure and a test can pin the age exactly.
+ */
+export function stateFact(entry: StateEntry | null, nowMs: number): StateFact {
+  const parsed = entry === null ? NaN : Date.parse(entry.at);
+  // An unparseable `at` is corruption, and it must fail toward NOISE: treat the
+  // key as never recorded rather than as recorded-just-now, which would silence
+  // a throttled hook for a window with no way to notice.
+  const recorded = entry !== null && !Number.isNaN(parsed);
+  const ageSeconds = recorded ? Math.max(0, (nowMs - parsed) / 1000) : Infinity;
+  return {
+    recorded,
+    value: recorded ? entry.value : "",
+    at: recorded ? entry.at : "",
+    ageSeconds,
+    fresherThan: (within) => ageSeconds < secondsOrThrow(within),
+    olderThan: (within) => ageSeconds >= secondsOrThrow(within),
+  };
+}
+
+/**
+ * Keys a hook may name. Deliberately narrow: it must be a safe path segment on
+ * every filesystem, greppable, and unable to reach out of its directory.
+ *
+ * The leading-alphanumeric requirement is what does the security work — it makes
+ * `.`, `..`, `.hidden` and the reserved `@` unspellable in one rule, rather than
+ * as a list of special cases someone extends later and gets wrong. There is no
+ * `@` namespace in this design (no automatic stamps exist to protect), but the
+ * character stays reserved so that adding one later cannot collide with a key
+ * some hook already records.
+ */
+const STATE_KEY = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
+export function isValidStateKey(key: string): boolean {
+  return STATE_KEY.test(key);
+}
+
+/** A declaration that the runtime should record a fact. Carries a key — never a path, never a namespace. */
+export interface StateWrite {
+  readonly kind: "record";
+  readonly name: string;
+  readonly value: string;
+}
+
+/**
+ * Declare that a named fact just became true: `record("calendar.synced")`.
+ *
+ * The hook performs no write — it returns this, attached to whatever it was
+ * already returning, and the trusted runtime stores it. An optional `value` lets
+ * a hook remember WHAT as well as WHEN (`record("merge.nagged", branch)`), which
+ * is how a nudge avoids repeating itself about the same thing.
+ *
+ * Throws on an invalid key rather than returning a value that fails somewhere
+ * later: a compiled hook's decision is a pure function that its own test calls
+ * in-process, so this surfaces at the cheapest possible tier.
+ */
+export function record(name: string, value = ""): StateWrite {
+  if (!isValidStateKey(name)) {
+    throw new HookStateError(
+      `invalid state key "${name}" — must match ${String(STATE_KEY)} ` +
+        `(letters, digits, dot, dash, underscore; must start with a letter or digit). ` +
+        `A key is a name, not a path: the runtime chooses where it is stored.`,
+    );
+  }
+  return { kind: "record", name, value };
+}
+
+/** A `needs` entry that reads a recorded fact: `needs: [state("calendar.synced")]`. */
+export interface StateNeed<Name extends string = string> {
+  readonly kind: "state";
+  readonly name: Name;
+}
+
+/**
+ * Declare a recorded fact as an input: `state("calendar.synced")` in `needs` makes
+ * `e.ctx["calendar.synced"]` a {@link StateFact}. Rides the existing `needs`
+ * path on purpose — a second way to read external state would give up the
+ * property that the dependency is declared and checkable from outside the hook.
+ */
+export function state<const Name extends string>(name: Name): StateNeed<Name> {
+  if (!isValidStateKey(name)) {
+    throw new HookStateError(
+      `invalid state key "${name}" — must match ${String(STATE_KEY)}.`,
+    );
+  }
+  return { kind: "state", name };
+}
+
+/** True iff a `needs` entry is a {@link StateNeed}. */
+export function isStateNeed(need: unknown): need is StateNeed {
+  return (
+    typeof need === "object" &&
+    need !== null &&
+    (need as StateNeed).kind === "state"
+  );
+}
+
+/** True iff a value is a {@link StateWrite} (the runtime re-checks what it is handed). */
+export function isStateWrite(w: unknown): w is StateWrite {
+  return (
+    typeof w === "object" &&
+    w !== null &&
+    (w as StateWrite).kind === "record" &&
+    typeof (w as StateWrite).name === "string" &&
+    typeof (w as StateWrite).value === "string"
+  );
+}
+
+/**
+ * The writes the runtime may actually perform, given what a hook returned.
+ *
+ * Defence in depth, and the threat is specific: {@link record} throws on a bad
+ * key, but nothing stops a hook returning a hand-built `{kind:"record", name:
+ * "../../settings"}` object literal that never went through the constructor.
+ * Everything that is not a well-formed write with a valid key is dropped here,
+ * before any path is computed from it.
+ */
+export function admissibleWrites(
+  writes: readonly unknown[],
+): { readonly ok: readonly StateWrite[]; readonly refused: readonly string[] } {
+  const ok: StateWrite[] = [];
+  const refused: string[] = [];
+  for (const w of writes) {
+    if (isStateWrite(w) && isValidStateKey(w.name)) ok.push(w);
+    else refused.push(isStateWrite(w) ? w.name : JSON.stringify(w));
+  }
+  return { ok, refused };
+}

--- a/src/core/hook-state.ts
+++ b/src/core/hook-state.ts
@@ -396,9 +396,10 @@ export function isStateWrite(w: unknown): w is StateWrite {
  * Everything that is not a well-formed write with a valid key is dropped here,
  * before any path is computed from it.
  */
-export function admissibleWrites(
-  writes: readonly unknown[],
-): { readonly ok: readonly StateWrite[]; readonly refused: readonly string[] } {
+export function admissibleWrites(writes: readonly unknown[]): {
+  readonly ok: readonly StateWrite[];
+  readonly refused: readonly string[];
+} {
   const ok: StateWrite[] = [];
   const refused: string[] = [];
   for (const w of writes) {

--- a/src/hook-state-runtime.test.ts
+++ b/src/hook-state-runtime.test.ts
@@ -164,7 +164,8 @@ test("a key can never address a path: a smuggled write is refused, LOUDLY, and i
   assert.match(res.stderr, /refused to record \.\.\/\.\.\/\.\.\/pwned/);
   assert.equal(res.code, 0, "an advisory react must stay advisory");
   assert.ok(
-    !existsSync(join(dir, "pwned.json")) && !existsSync(join(dir, "..", "pwned.json")),
+    !existsSync(join(dir, "pwned.json")) &&
+      !existsSync(join(dir, "..", "pwned.json")),
     "traversal must produce no file anywhere",
   );
   // Only the store directory exists, and only the valid key is in it — a refusal
@@ -174,9 +175,11 @@ test("a key can never address a path: a smuggled write is refused, LOUDLY, and i
     ["legit.key.json"],
   );
   assert.equal(
-    (JSON.parse(readFileSync(statePath(dir, "legit.key"), "utf-8")) as {
-      value: string;
-    }).value,
+    (
+      JSON.parse(readFileSync(statePath(dir, "legit.key"), "utf-8")) as {
+        value: string;
+      }
+    ).value,
     "ok",
   );
 });
@@ -211,7 +214,10 @@ test("scope is the hook's DIRECTORY: siblings share a fact, a vendored plugin ca
   // A second hook set, shipped somewhere else in the same checkout — the shape a
   // vendored plugin has.
   mkdirSync(join(dir, "vendor", "plugin", "hooks"), { recursive: true });
-  writeFileSync(join(dir, "vendor", "plugin", "hooks", "reader.hook.mjs"), READER);
+  writeFileSync(
+    join(dir, "vendor", "plugin", "hooks", "reader.hook.mjs"),
+    READER,
+  );
 
   runHook(dir, "witness.hook.mjs", {
     tool_name: "mcp__x__list_events",
@@ -235,7 +241,15 @@ test("scope is the hook's DIRECTORY: siblings share a fact, a vendored plugin ca
   );
   assert.ok(
     existsSync(
-      join(dir, ".vigiles", "state", "vendor", "plugin", "hooks", "calendar.nagged.json"),
+      join(
+        dir,
+        ".vigiles",
+        "state",
+        "vendor",
+        "plugin",
+        "hooks",
+        "calendar.nagged.json",
+      ),
     ),
     "the store MIRRORS the hook's directory, so a human can find the fact",
   );

--- a/src/hook-state-runtime.test.ts
+++ b/src/hook-state-runtime.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Runtime-owned named state, END TO END against the real CLI.
+ *
+ * The pure model is tested in `core/hook-state.test.ts`. Everything asserted HERE
+ * lives in the trusted runtime and cannot be seen from a unit test: where the
+ * store lands on disk, that a key can never address a path, that one hook's
+ * record is what a DIFFERENT hook reads back, and that the write happens through
+ * the runtime rather than through anything the hook can reach.
+ *
+ * That distinction is the whole reason this file exists. The predicates could all
+ * be green while the runtime wrote to the wrong directory, or wrote nothing, and
+ * an advisory hook whose success looks like silence would never tell anyone.
+ */
+import { test } from "vitest";
+import assert from "node:assert/strict";
+import {
+  writeFileSync,
+  mkdirSync,
+  symlinkSync,
+  existsSync,
+  readFileSync,
+  readdirSync,
+} from "node:fs";
+import { resolve, join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { makeTmpDir } from "./core/test-utils.js";
+
+const REPO_ROOT = resolve(__dirname, "..");
+const CLI = resolve(REPO_ROOT, "dist", "cli.js");
+
+/** Records a fact when an MCP calendar tool ran — the WITNESS half. */
+const WITNESS = `import { defineReact, tools, nothing, record } from "vigiles/hook";
+export default defineReact({
+  on: "PostToolUse",
+  match: tools("mcp__.*"),
+  react: () => nothing(record("calendar.synced")),
+});
+`;
+
+/** Reads that fact and self-throttles its own nudge — the READER half. */
+const READER = `import { defineInject, state, inject, record } from "vigiles/hook";
+export default defineInject({
+  on: "UserPromptSubmit",
+  needs: [state("calendar.synced"), state("calendar.nagged")],
+  produce: (e) => {
+    if (e.ctx["calendar.synced"].fresherThan("12h")) return inject("");
+    if (e.ctx["calendar.nagged"].fresherThan("3h")) return inject("SHORT");
+    return inject("FULL", record("calendar.nagged"));
+  },
+});
+`;
+
+/** Hand-builds its declaration, bypassing `record()`'s validation entirely. */
+const SMUGGLER = `import { defineReact, nothing } from "vigiles/hook";
+export default defineReact({
+  on: "Stop",
+  react: () => ({ ...nothing(), records: [
+    { kind: "record", name: "../../../pwned", value: "x" },
+    { kind: "record", name: "legit.key", value: "ok" },
+  ] }),
+});
+`;
+
+function makeFixture(hooks: Record<string, string>): string {
+  const dir = makeTmpDir("hook-state");
+  mkdirSync(join(dir, "node_modules"), { recursive: true });
+  symlinkSync(REPO_ROOT, join(dir, "node_modules", "vigiles"), "dir");
+  mkdirSync(join(dir, ".claude", "hooks"), { recursive: true });
+  writeFileSync(
+    join(dir, "package.json"),
+    `{ "name": "state-fixture", "private": true, "type": "module" }\n`,
+  );
+  for (const [name, src] of Object.entries(hooks)) {
+    writeFileSync(join(dir, ".claude", "hooks", name), src);
+  }
+  return dir;
+}
+
+function runHook(
+  dir: string,
+  hook: string,
+  event: Record<string, unknown>,
+): { code: number; stdout: string; stderr: string } {
+  const res = spawnSync(
+    process.execPath,
+    [CLI, "hook-runtime", "run-program", `.claude/hooks/${hook}`],
+    { cwd: dir, encoding: "utf-8", input: JSON.stringify(event) },
+  );
+  return { code: res.status ?? -1, stdout: res.stdout, stderr: res.stderr };
+}
+
+const injected = (stdout: string): string =>
+  (
+    JSON.parse(stdout) as {
+      hookSpecificOutput: { additionalContext: string };
+    }
+  ).hookSpecificOutput.additionalContext;
+
+const statePath = (dir: string, key: string): string =>
+  join(dir, ".vigiles", "state", ".claude", "hooks", `${key}.json`);
+
+// ---------------------------------------------------------------------------
+
+test("one hook RECORDS a fact and a DIFFERENT hook reads it back", () => {
+  const dir = makeFixture({
+    "witness.hook.mjs": WITNESS,
+    "reader.hook.mjs": READER,
+  });
+
+  // 1. Nothing recorded yet. The reader must SPEAK — the direction that matters,
+  //    because the failure this feature exists to end is a hook going quiet.
+  const first = runHook(dir, "reader.hook.mjs", {});
+  assert.equal(injected(first.stdout), "FULL");
+
+  // 2. It recorded its OWN nudge, so the next turn escalates instead of repeating.
+  assert.ok(existsSync(statePath(dir, "calendar.nagged")));
+  assert.equal(injected(runHook(dir, "reader.hook.mjs", {}).stdout), "SHORT");
+
+  // 3. The witness — a different hook, a different event — records the fact the
+  //    reader is actually gated on. Nothing else in the session changes.
+  const witnessed = runHook(dir, "witness.hook.mjs", {
+    tool_name: "mcp__4f54037d-0499-426a-8573-6130f3da1ef8__list_events",
+    tool_input: {},
+    tool_response: "ok",
+  });
+  assert.equal(witnessed.code, 0);
+  const entry = JSON.parse(
+    readFileSync(statePath(dir, "calendar.synced"), "utf-8"),
+  ) as { value: string; at: string; by: string };
+  assert.equal(entry.value, "");
+  assert.ok(!Number.isNaN(Date.parse(entry.at)), "at must be a real instant");
+  assert.equal(
+    entry.by,
+    ".claude/hooks/witness.hook.mjs",
+    "the store must name WHO claimed the fact — the only handle a human debugging this has",
+  );
+
+  // 4. …and the reader now goes quiet, on a fact it did not write.
+  assert.equal(injected(runHook(dir, "reader.hook.mjs", {}).stdout), "");
+});
+
+test("the witness fires for a tool FAMILY, and not for an unrelated tool", () => {
+  const dir = makeFixture({ "witness.hook.mjs": WITNESS });
+  // The defect half, measured before the fix: an exact-string filter dropped this
+  // event, so the hook was wired up, routed to, and silently never ran.
+  runHook(dir, "witness.hook.mjs", {
+    tool_name: "mcp__deadbeef__create_event",
+    tool_input: {},
+  });
+  assert.ok(existsSync(statePath(dir, "calendar.synced")));
+
+  // Clean half: a witness that fires on the wrong tool writes a FALSE fact, which
+  // is worse than not firing. `Bash` must record nothing.
+  const other = makeFixture({ "witness.hook.mjs": WITNESS });
+  runHook(other, "witness.hook.mjs", { tool_name: "Bash", tool_input: {} });
+  assert.ok(!existsSync(statePath(other, "calendar.synced")));
+});
+
+test("a key can never address a path: a smuggled write is refused, LOUDLY, and its valid sibling still lands", () => {
+  const dir = makeFixture({ "smuggle.hook.mjs": SMUGGLER });
+  const res = runHook(dir, "smuggle.hook.mjs", { stop_hook_active: false });
+
+  assert.match(res.stderr, /refused to record \.\.\/\.\.\/\.\.\/pwned/);
+  assert.equal(res.code, 0, "an advisory react must stay advisory");
+  assert.ok(
+    !existsSync(join(dir, "pwned.json")) && !existsSync(join(dir, "..", "pwned.json")),
+    "traversal must produce no file anywhere",
+  );
+  // Only the store directory exists, and only the valid key is in it — a refusal
+  // must not silently drop the whole batch either.
+  assert.deepEqual(
+    readdirSync(join(dir, ".vigiles", "state", ".claude", "hooks")).sort(),
+    ["legit.key.json"],
+  );
+  assert.equal(
+    (JSON.parse(readFileSync(statePath(dir, "legit.key"), "utf-8")) as {
+      value: string;
+    }).value,
+    "ok",
+  );
+});
+
+test("a react on Stop runs at all — it used to be dead, and dead looked exactly like quiet", () => {
+  const dir = makeFixture({
+    "stop.hook.mjs": `import { defineReact, notice, record, state } from "vigiles/hook";
+export default defineReact({
+  on: "Stop",
+  needs: [state("retro.nagged")],
+  react: (e) => e.ctx["retro.nagged"].fresherThan("1d")
+    ? notice("QUIET")
+    : notice("NUDGE", record("retro.nagged")),
+});
+`,
+  });
+  const first = runHook(dir, "stop.hook.mjs", { stop_hook_active: false });
+  assert.match(first.stderr, /NUDGE/);
+  assert.equal(first.code, 0);
+  // Second Stop in the same day: the fact it recorded silences it.
+  assert.match(
+    runHook(dir, "stop.hook.mjs", { stop_hook_active: false }).stderr,
+    /QUIET/,
+  );
+});
+
+test("scope is the hook's DIRECTORY: siblings share a fact, a vendored plugin cannot see it", () => {
+  const dir = makeFixture({
+    "witness.hook.mjs": WITNESS,
+    "reader.hook.mjs": READER,
+  });
+  // A second hook set, shipped somewhere else in the same checkout — the shape a
+  // vendored plugin has.
+  mkdirSync(join(dir, "vendor", "plugin", "hooks"), { recursive: true });
+  writeFileSync(join(dir, "vendor", "plugin", "hooks", "reader.hook.mjs"), READER);
+
+  runHook(dir, "witness.hook.mjs", {
+    tool_name: "mcp__x__list_events",
+    tool_input: {},
+  });
+
+  // The sibling in the SAME directory sees it and goes quiet (the requirement).
+  assert.equal(injected(runHook(dir, "reader.hook.mjs", {}).stdout), "");
+
+  // The plugin's identically-named hook, reading an identically-named key, does
+  // NOT see it — so one plugin can neither read nor clobber another's facts.
+  const foreign = spawnSync(
+    process.execPath,
+    [CLI, "hook-runtime", "run-program", "vendor/plugin/hooks/reader.hook.mjs"],
+    { cwd: dir, encoding: "utf-8", input: "{}" },
+  );
+  assert.equal(
+    injected(foreign.stdout),
+    "FULL",
+    "a different directory is a different namespace",
+  );
+  assert.ok(
+    existsSync(
+      join(dir, ".vigiles", "state", "vendor", "plugin", "hooks", "calendar.nagged.json"),
+    ),
+    "the store MIRRORS the hook's directory, so a human can find the fact",
+  );
+});
+
+test("a corrupt store entry makes the hook SPEAK, not go quiet", () => {
+  const dir = makeFixture({ "reader.hook.mjs": READER });
+  mkdirSync(join(dir, ".vigiles", "state", ".claude", "hooks"), {
+    recursive: true,
+  });
+  // Both shapes of damage a real store can suffer: unparseable JSON, and valid
+  // JSON whose timestamp is not a time. Either one must fail toward noise.
+  writeFileSync(statePath(dir, "calendar.synced"), "{ this is not json");
+  assert.equal(injected(runHook(dir, "reader.hook.mjs", {}).stdout), "FULL");
+
+  writeFileSync(
+    statePath(dir, "calendar.synced"),
+    JSON.stringify({ value: "", at: "yesterday" }),
+  );
+  writeFileSync(
+    statePath(dir, "calendar.nagged"),
+    JSON.stringify({ value: "", at: new Date().toISOString() }),
+  );
+  assert.equal(injected(runHook(dir, "reader.hook.mjs", {}).stdout), "SHORT");
+
+  // Clean half: a well-formed fresh entry really does silence it, so the test
+  // above is measuring corruption handling and not a hook that always speaks.
+  writeFileSync(
+    statePath(dir, "calendar.synced"),
+    JSON.stringify({ value: "", at: new Date().toISOString() }),
+  );
+  assert.equal(injected(runHook(dir, "reader.hook.mjs", {}).stdout), "");
+});

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -81,6 +81,10 @@ export {
   dispatchKind,
   hookRouting,
   hookNeeds,
+  injectionOf,
+  outcomeWrites,
+  matchesTool,
+  invalidToolPatterns,
   // compile + integrity
   compileHookProgram,
   checkHookImports,
@@ -125,6 +129,28 @@ export {
   defineProvider,
   provider,
 } from "./core/hook-providers.js";
+
+// Runtime-owned named state: `state(k)` in `needs` reads a fact, `record(k)` in a
+// return value declares one. The whole design note lives in `core/hook-state.ts`.
+export {
+  state,
+  record,
+  stateFact,
+  isValidStateKey,
+  isStateNeed,
+  isStateWrite,
+  admissibleWrites,
+  durationSeconds,
+  HookStateError,
+} from "./core/hook-state.js";
+
+export type {
+  StateFact,
+  StateEntry,
+  StateNeed,
+  StateWrite,
+  Duration,
+} from "./core/hook-state.js";
 
 export type {
   ProviderName,


### PR DESCRIPTION
## What and why

A compiled hook could read state but had no way to **remember** a fact, so every nudge in a real consumer repo was written in shell instead — seven of seven. This adds runtime-owned named memory: a hook names a fact, the runtime stores it, and any hook in the same directory can declare that name in `needs` and read it back with its age.

```ts
e.ctx["retro.nagged"].fresherThan("1d") ? nothing() : notice(MSG, record("retro.nagged"))
```

**There is deliberately no `throttle:` field, and that is the load-bearing decision.** One was designed first and two measurements killed it:

1. **It changes behaviour the hooks depend on.** An automatic stamp can only be written where the runtime sees the hook emit. A real guard stamps *before* its threshold test — marks "I looked", then decides whether to speak — so an emit-triggered stamp silently converts "look hourly" into "look every turn until something is worth saying". The write site is a per-hook decision; a field takes it away.
2. **It re-manufactures the defect the feature retires.** The consumer repo ran a single automatic stamp for months: the heartbeat wrote it at print time, so an ignored reminder silenced itself and a skipped sync became indistinguishable from a completed one — 28 unclosed events and six blank days, undetected for twelve. A `throttle:` field would have recreated that stamp, given it no name, and made it the ergonomic default.

So both meanings of a stamp are named and neither is automatic: "I spoke at T" is `record("retro.nagged")` on the branch that speaks; "the work happened at T" is written by the hook that *watched* the work — a different hook, a different event. The framework never writes a fact on its own initiative, and every entry stores which hook claimed it.

**Failure direction, chosen by measurement:** `null < 3600` is `true` in JS, so with a nullable age the freshness test every author writes first reads a never-recorded fact as maximally fresh — a hook that never ran would never run. `ageSeconds` is `Infinity` instead, and so are corrupt timestamps and unreadable stores. Everything fails toward noise, never toward silence.

**What it subtracts:** seven bespoke stamp files (three of which re-implemented the same numeric clamp by hand), `run()`'s side career as a writer, and the `needs` asymmetry — injects and reacts could not declare context at all, and now the roles are uniform.

Two routing defects surfaced while building it and are fixed here: an empty tool list matched the empty tool name rather than nothing, and the react path could not emit a recorded fact at all.

## Safety impact

**Unrepresentable by construction, rather than discouraged:** filesystem access (`record()` returns a value; the runtime writes), naming another owner's store (namespaces are not in the vocabulary — the runtime derives them from the hook's path), escaping via the key (`[A-Za-z0-9][A-Za-z0-9._-]{0,63}`, and `record()` throws), and reading an undeclared fact (a `tsc` error).

**Still possible, stated rather than implied:** recording a fact under a name that misdescribes what happened. No runtime can decide that. Gates read state but cannot write it — deliberate.

One store file per key with an atomic rename, so distinct keys never interact; a single blob per namespace was rejected because read-modify-write loses concurrent writes.

## Checks

- [x] `npm test` passes locally, or CI is green — 2882 passed, 0 failed, 24 skipped
- [x] New behaviour has a test — 23 mutations, all caught. Two mattered: one exposed a real edge case (`^()$` matches the empty string) now fixed and tested, and one passed green because the assertion did not exist and was added
- [x] Docs updated if this changes a rule, a CLI surface, or a documented guarantee — `docs/compiled-hooks.md`; no new CLI verbs, the additions are API-only

Rebased onto current `main` by cherry-picking the three feature commits: the branch predated two squash merges, so merging produced 29 conflicted files of content arriving twice, while the cherry-pick produced two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Features**
- runtime-owned named state — record() + state(), and the two routing defects it exposed

**Fixes**
- an empty tool list must match nothing, not the empty tool name

**Chores**
- api surface report, lint and prettier for runtime-owned state
- regenerate the API surface after the rebase onto main
<!-- vigiles:pr-summary:end -->
