### PR TITLE
fix(sidecar): классифицировать записи обхода через entryOf, а не голый statSync

### DIFF
--- a/src/core/sidecar.test.ts
+++ b/src/core/sidecar.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, beforeAll as before, afterAll as after } from "vitest";
 import assert from "node:assert/strict";
-import { writeFileSync, mkdirSync } from "node:fs";
+import { writeFileSync, mkdirSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 
 import {
@@ -119,6 +119,103 @@ describe("iterateSidecars", () => {
     iterateSidecars(empty, () => count++);
     assert.equal(count, 0);
     cleanupTmpDir(empty);
+  });
+});
+
+/**
+ * The walk classified entries with a bare `statSync().isDirectory()`, which
+ * FOLLOWS a symlink — third instance of that class in this repo, and the reason
+ * `entryOf` exists. Both halves per shape: the symlinked DIRECTORY is refused,
+ * and everything else still resolves exactly as before. A fix that skipped every
+ * symlink, or every entry, would pass the first half alone and silently stop the
+ * audit from seeing manifests it used to see.
+ */
+describe("iterateSidecars and symlinks", () => {
+  it("does not descend into a directory symlink inside .vigiles/", () => {
+    const tmp = makeTmpDir("sidecar-symlink-dir");
+    writeSidecarManifest(tmp, {
+      specFile: "Real.md.spec.ts",
+      target: "Real.md",
+      compiledAt: new Date().toISOString(),
+      files: {},
+    });
+    // A tree OUTSIDE .vigiles/ holding something that looks like a manifest.
+    const outside = join(tmp, "outside");
+    mkdirSync(outside, { recursive: true });
+    writeFileSync(
+      join(outside, "Foreign.md.inputs.json"),
+      JSON.stringify({
+        specFile: "Foreign.md.spec.ts",
+        target: "Foreign.md",
+        compiledAt: new Date().toISOString(),
+        files: {},
+      }),
+    );
+    symlinkSync(outside, join(tmp, ".vigiles", "linked"), "dir");
+
+    const seen: string[] = [];
+    iterateSidecars(tmp, (target) => seen.push(target));
+    // FIRES: following the link pulled a foreign tree's manifests into the audit
+    // under a reconstructed target name (`linked/Foreign.md`).
+    assert.deepEqual(seen, ["Real.md"]);
+    cleanupTmpDir(tmp);
+  });
+
+  it("reports a manifest once under a symlink cycle, not once per lap", () => {
+    const tmp = makeTmpDir("sidecar-symlink-cycle");
+    writeSidecarManifest(tmp, {
+      specFile: "Real.md.spec.ts",
+      target: "Real.md",
+      compiledAt: new Date().toISOString(),
+      files: {},
+    });
+    // `.vigiles/loop -> .vigiles`: statSync says "directory" on every lap.
+    symlinkSync(join(tmp, ".vigiles"), join(tmp, ".vigiles", "loop"), "dir");
+
+    const seen: string[] = [];
+    // FIRES: reverting the fix reported this ONE manifest 41 times — `Real.md`,
+    // `loop/Real.md`, `loop/loop/Real.md` … until the kernel's link limit ended
+    // it. Note it did NOT throw the way the loader's uncaught walk did: the
+    // `catch` inside walk() swallowed the ELOOP, so the only visible symptom was
+    // a multiplied audit. So the assertion is on the LIST, not on "it didn't
+    // throw" — the no-throw half stays green under the defect and would prove
+    // nothing. (A throw still fails this test: it escapes the call below.)
+    iterateSidecars(tmp, (target) => seen.push(target));
+    assert.deepEqual(seen, ["Real.md"]);
+    cleanupTmpDir(tmp);
+  });
+
+  it("still finds nested sidecars and follows a symlinked manifest FILE", () => {
+    const tmp = makeTmpDir("sidecar-symlink-quiet");
+    writeSidecarManifest(tmp, {
+      specFile: "CLAUDE.md.spec.ts",
+      target: "CLAUDE.md",
+      compiledAt: new Date().toISOString(),
+      files: {},
+    });
+    // The nested case the recursion exists for, in a real directory.
+    writeSidecarManifest(tmp, {
+      specFile: "copilot.spec.ts",
+      target: ".github/copilot-instructions.md",
+      compiledAt: new Date().toISOString(),
+      files: {},
+    });
+    // A symlink to a manifest FILE cannot recurse and is a real manifest, so it
+    // is read like any other — dropping it would lose findings.
+    symlinkSync(
+      sidecarPath(tmp, "CLAUDE.md"),
+      sidecarPath(tmp, "Linked.md"),
+      "file",
+    );
+
+    const seen: string[] = [];
+    iterateSidecars(tmp, (target) => seen.push(target));
+    assert.deepEqual(seen.sort(), [
+      ".github/copilot-instructions.md",
+      "CLAUDE.md",
+      "Linked.md",
+    ]);
+    cleanupTmpDir(tmp);
   });
 });
 

--- a/src/core/sidecar.ts
+++ b/src/core/sidecar.ts
@@ -16,10 +16,10 @@ import {
   writeFileSync,
   mkdirSync,
   readdirSync,
-  statSync,
 } from "node:fs";
 import { dirname, relative, resolve } from "node:path";
 
+import { entryOf } from "../fs-walk.js";
 import { sha256short } from "./hash.js";
 
 const SIDECAR_ROOT = ".vigiles";
@@ -86,6 +86,22 @@ export function computePerFileHashes(
  * Recurses so that nested targets (e.g. `.github/copilot-instructions.md`,
  * which lives at `.vigiles/.github/copilot-instructions.md.inputs.json`)
  * are not silently skipped.
+ *
+ * 🔴 A DIRECTORY SYMLINK IS NOT DESCENDED INTO — this walk classified entries
+ * with a bare `statSync().isDirectory()`, which FOLLOWS a link, so a link inside
+ * `.vigiles/` pointing at a directory OUTSIDE it was walked (manifests from a
+ * foreign tree entering the audit under reconstructed target names), and a cycle
+ * — `.vigiles/loop -> .vigiles`, or a link to any ancestor — re-walked the same
+ * tree once per lap. Measured 2026-08-13 by reverting this call: ONE manifest was
+ * reported FORTY-ONE times, as `Real.md`, `loop/Real.md`, `loop/loop/Real.md` …
+ * until the kernel's link limit stopped it. Unlike the loader's walk it did not
+ * throw, and that is not a mitigation: the `catch` below swallowed the `ELOOP` and
+ * turned a crash into a silently multiplied audit. Third instance of the class in
+ * this repo; the decision is {@link entryOf} in `fs-walk.ts`, which carries the
+ * full rationale: a symlinked FILE is still read (it cannot recurse, and a
+ * manifest reached through one is a real manifest), termination is by
+ * construction rather than a visited-set, and an unreadable entry is `"skip"`
+ * rather than a throw — which is exactly what the `try`/`continue` here did.
  */
 export function iterateSidecars(
   basePath: string,
@@ -111,17 +127,15 @@ function walk(
 
   for (const entry of entries) {
     const fullPath = resolve(dir, entry);
-    let isDir: boolean;
-    try {
-      isDir = statSync(fullPath).isDirectory();
-    } catch {
-      continue;
-    }
+    const { kind } = entryOf(fullPath);
 
-    if (isDir) {
+    if (kind === "dir") {
       walk(fullPath, root, basePath, fn);
       continue;
     }
+    // "skip" covers what the old bare `statSync` handled by throwing (a dangling
+    // link, an unreadable entry) AND the symlinked directory it silently followed.
+    if (kind === "skip") continue;
     if (!entry.endsWith(MANIFEST_SUFFIX)) continue;
 
     // Reconstruct the target name from the path relative to .vigiles/


### PR DESCRIPTION
Третий экземпляр класса «рекурсивный обход классифицирует записи через `statSync`, который ходит по симлинкам». Два предыдущих закрыты тем же способом — каноническим `entryOf` из `src/fs-walk.ts`, который несёт всё обоснование: почему нужны и `lstat`, и `stat`, почему симлинк на ФАЙЛ остаётся файлом, и почему цикл убирается конструкцией, а не visited-множеством.

## Что было

`walk` в `src/core/sidecar.ts` использовал голый `statSync(fullPath).isDirectory()`. Симлинк внутри `.vigiles/` на каталог снаружи уводил обход в чужое дерево; симлинк на предка перечитывал то же дерево на каждом круге.

## Замер, поправивший формулировку задачи

Задача была поставлена как «цикл рекурсирует, пока не бросит». Мутация показала другое: собственный `catch` этого обхода глотал `ELOOP`, поэтому падения не было — был **один манифест, посчитанный 41 раз** (`Real.md`, `loop/Real.md`, `loop/loop/Real.md`…). Из-за этого переписан комментарий и **выброшен ассерт `doesNotThrow`**: он оставался зелёным при дефекте, то есть не доказывал ничего.

## Тесты

Три, по обеим половинам:

- **срабатывает** — `does not descend into a directory symlink inside .vigiles/`
- **срабатывает** — `reports a manifest once under a symlink cycle, not once per lap`
- **молчит** — `still finds nested sidecars and follows a symlinked manifest FILE`

Мутация (вернуть голый `statSync`) прогнана с греп-доказательством, что патч лёг; падают ровно два «срабатывающих» теста. Воспроизведено независимо второй раз.

## Гейты

`npx vitest run` · `npm run lint` · `npx prettier --check .` · `npm run api:check` · `npm run build` — все пять пройдены.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Fixes**
- classify walk entries through entryOf, not raw statSync

**Tests**
- pin the symlink policy at the walk — both halves per shape
<!-- vigiles:pr-summary:end -->
