### PR TITLE
fix(core): `..` зажимается на корне Windows, а не съедает его

### DIFF
--- a/src/core/hook-program.test.ts
+++ b/src/core/hook-program.test.ts
@@ -1842,3 +1842,176 @@ test("projectRootOf: an ABSOLUTE env root still wins, and unusable pairs give no
     undefined,
   );
 });
+
+// ---------------------------------------------------------------------------
+// Round 39: `..` CLAMPED AT THE ROOT INSTEAD OF EATING IT. `resolveRef`
+// collapsed dot segments with an unconditional `out.pop()`, so a `..` sitting at
+// the top of a Windows path popped the ROOT out of the segment list —
+// `C:/../repo/src/x.ts` lost its drive letter and came back as the
+// relative-looking `repo/src/x.ts`, which no longer resolved against `C:/repo`.
+// A UNC share went one worse: two `..` ate `share` and then `server`.
+//
+// POSIX was already right BY ACCIDENT, not by design: its leader `/` is held
+// outside the segment list, so popping an empty array is already the clamp. The
+// Windows forms broke precisely because their root lives INSIDE that list.
+// ---------------------------------------------------------------------------
+test("`..` clamps at a DRIVE root — the drive letter is not poppable", () => {
+  // `C:/../repo/src/x.ts` IS `C:/repo/src/x.ts`: on Windows `..` at a drive root
+  // stays at the drive root. Both spellings of the prefix must see it, because
+  // each takes a different arm of `prefixVerdict`.
+  assert.equal(pathView("C:/../repo/src/x.ts", "C:/repo").under(["src"]), true);
+  assert.equal(
+    pathView("C:/../repo/src/x.ts", "C:/repo").under(["C:/repo/src"]),
+    true,
+  );
+  // Two of them, and a `.` in the way, still land on the same place.
+  assert.equal(
+    pathView("C:/../../repo/./src/x.ts", "C:/repo").under(["src"]),
+    true,
+  );
+  // Clamping is not "everything absolute is inside": a path that really is
+  // elsewhere on the same drive stays outside.
+  assert.equal(
+    pathView("C:/../other/src/x.ts", "C:/repo").under(["C:/repo/src"]),
+    false,
+  );
+  // The ROOT is resolved by the same helper (`relativeToRoot` resolves it
+  // against `"."` to get the comparison base), so a `..` in the ROOT ate the
+  // drive too — leaving the base `repo`, which nothing absolute starts with.
+  assert.equal(pathView("C:/repo/src/x.ts", "C:/../repo").under(["src"]), true);
+  assert.equal(
+    pathView("//server/share/repo/src/x.ts", "//server/share/../repo").under([
+      "src",
+    ]),
+    true,
+  );
+});
+
+test("`..` clamps at a UNC SHARE — it eats neither the share nor the server", () => {
+  const root = "//server/share/repo";
+  assert.equal(
+    pathView("//server/share/../repo/src/x.ts", root).under(["src"]),
+    true,
+  );
+  // The second `..` is the one that used to eat `server`, leaving `//repo/…`.
+  assert.equal(
+    pathView("//server/share/../../repo/src/x.ts", root).under(["src"]),
+    true,
+  );
+  assert.equal(
+    pathView("//server/share/../../repo/src/x.ts", root).under([
+      "//server/share/repo/src",
+    ]),
+    true,
+  );
+  // Backslashes are a spelling of the same path, and the root's own spelling
+  // must not change the answer.
+  assert.equal(
+    pathView(String.raw`\\server\share\..\repo\src\x.ts`, String.raw`\\server\share\repo`).under(["src"]), // prettier-ignore
+    true,
+  );
+  // Still not a licence: a DIFFERENT share on the same server is outside.
+  assert.equal(
+    pathView("//server/other/../other/repo/src/x.ts", root).under(["src"]),
+    false,
+  );
+});
+
+test("the clamp leaves ORDINARY `..` collapsing, on every root", () => {
+  // The quiet half, and the one a too-large floor would break: `..` in the
+  // middle of a path is not a root `..` and must still remove a segment.
+  assert.equal(
+    pathView("C:/repo/a/b/../c/x.ts", "C:/repo").under(["a/c"]),
+    true,
+  );
+  assert.equal(pathView("C:/repo/a/b/../c/x.ts", "C:/repo").under(["a/b"]), false); // prettier-ignore
+  assert.equal(
+    pathView("//server/share/repo/a/b/../c/x.ts", "//server/share/repo").under([
+      "a/c",
+    ]),
+    true,
+  );
+  assert.equal(pathView("/repo/a/b/../c/x.ts", "/repo").under(["a/c"]), true);
+  // POSIX `/..` behaves as it always did — the leader lives outside the segment
+  // list, so there was never anything there to pop.
+  assert.equal(pathView("/../repo/src/x.ts", "/repo").under(["src"]), true);
+  assert.equal(pathView("/../../repo/src/x.ts", "/repo").under(["src"]), true);
+});
+
+test("whether a `//` leader is a SHARE is the ROOT's answer, not the path's", () => {
+  // 🔴 THE ROUND-37 LESSON, AT A THIRD SITE. Read off the operand,
+  // `//repo/a/../src/x.ts` looks share-rooted (`//repo/a`), so a floor taken
+  // from the string would refuse to pop `a` and resolve to `/repo/a/src/x.ts`.
+  // Under a POSIX root that doubled slash is a stutter: the `..` must collapse.
+  assert.equal(pathView("//repo/a/../src/x.ts", "/repo").under(["src"]), true);
+  assert.equal(pathView("//repo/a/../src/x.ts", "/repo").under(["a"]), false);
+  // And the converse arm: a POSIX-absolute ref under a WINDOWS root has no
+  // Windows root of its own to clamp at, and is simply not in the repo.
+  assert.equal(pathView("/etc/passwd", "C:/repo").under(["etc"]), false);
+  assert.equal(pathView("/../etc/passwd", "C:/repo").under(["etc"]), false);
+});
+
+test("a DRIVE clamps with NO root at all — the sibling call site", () => {
+  // 🔴 THE CALL SITE A FIX WRITTEN ONLY AT THE DEFECT WOULD HAVE MISSED.
+  // `absoluteSpelling` resolves a ROOTLESS absolute path against the literal
+  // `"/"`, so a floor gated on the root would read POSIX there and eat `C:`
+  // anyway. A drive letter names its filesystem by itself — `C:/x` has no POSIX
+  // reading — which is why `isAtOrUnder` already folds case on a drive-rooted
+  // BASE with no root in hand.
+  assert.equal(pathView("C:/../repo/src/x.ts").under(["C:/repo/src"]), true);
+  assert.equal(pathView("C:/../other/x.ts").under(["C:/repo/src"]), false);
+  // The `//` half stays gated, because `//a/b` DOES have a POSIX reading and
+  // only a root settles it (round 37). Rootless it resolves as POSIX, which is
+  // a quiet miss for an allowlist — never a grant.
+  assert.equal(
+    pathView("//server/share/../repo/src/x.ts").under([
+      "//server/share/repo/src",
+    ]),
+    false,
+  );
+});
+
+test("a UNC path with no `..` resolves exactly as it did before", () => {
+  assert.equal(
+    pathView("//server/share/repo/src/x.ts", "//server/share/repo").under([
+      "src",
+    ]),
+    true,
+  );
+  assert.equal(
+    pathView("//server/share/repo/other/x.ts", "//server/share/repo").under([
+      "src",
+    ]),
+    false,
+  );
+});
+
+test("the clamp reaches BOTH repair doors, and grants nothing new", () => {
+  // The sibling call sites. `C:/../repo/a.hook.mjs` names this repo's own hook;
+  // with the drive letter eaten it resolved to `repo/a.hook.mjs`, matched
+  // nothing, and the door refused the write that unwedges the repo.
+  const hook = "a.hook.mjs";
+  const repo = { root: "C:/repo", loadPathFiles: ["C:/repo/package.json"] };
+  assert.equal(
+    isLoadPathRepairEvent(writeEvent("C:/../repo/package.json"), hook, repo),
+    true,
+  );
+  assert.equal(
+    isLoadPathRepairEvent(writeEvent("C:/other/package.json"), hook, repo),
+    false,
+  );
+  assert.equal(
+    isStampRepairEvent(writeEvent("C:/../repo/a.hook.mjs"), hook, "C:/repo"),
+    true,
+  );
+  // …and the clamp grants nothing new: climbing out of the repo is still refused,
+  // it just stops at the drive instead of falling off it.
+  assert.equal(
+    isStampRepairEvent(
+      writeEvent("C:/repo/a.hook.mjs/../../../elsewhere/a.hook.mjs"),
+      hook,
+      "C:/repo",
+    ),
+    false,
+  );
+});

--- a/src/core/hook-program.ts
+++ b/src/core/hook-program.ts
@@ -1900,6 +1900,49 @@ function isAbsoluteRef(ref: string): boolean {
 }
 
 /**
+ * Does this ROOT name a Windows filesystem? One predicate, because the two
+ * questions that ask it — how many segments `..` may not pop through, and
+ * whether a `//` leader is a share or a stutter — must never disagree about the
+ * same root. `//x` is caught by the second arm: too short to be a share, but
+ * still not something to read as POSIX.
+ */
+const namesWindowsFs = (root: string): boolean =>
+  WINDOWS_ROOT.test(root) || root.startsWith("//");
+
+/**
+ * How many leading segments of a resolved path ARE its root — the floor a `..`
+ * must not pop through. `0` on POSIX, `1` for a drive (`C:`), `2` for a UNC
+ * share (`//server/share`), and 2/4 for the `//?/` spellings of those two.
+ *
+ * 🔴 A `//` LEADER IS THE ROOT'S ANSWER, NEVER THE OPERAND'S — the round-37
+ * lesson at a third site (after the case fold in {@link caseInsensitiveFs} and
+ * the UNC leader in {@link resolveRef}). Read from the string alone,
+ * `//repo/a/../src/x.ts` looks share-rooted, so a count taken off the operand
+ * would guard `repo/a` and stop `..` collapsing at all — under a POSIX root that
+ * doubled slash is a stutter, not a share. The `//` forms are therefore gated on
+ * the root, exactly as the leader is.
+ *
+ * ⚠️ A DRIVE LETTER IS THE ONE THING THAT NAMES A WINDOWS FILESYSTEM BY ITSELF,
+ * and that is not a second rule — {@link isAtOrUnder} already says it about a
+ * base (`WINDOWS_ROOT.test(rawBase)`), because `C:/x` has no POSIX reading the
+ * way `//x` does. It earns its place at a real call site rather than in the
+ * abstract: {@link absoluteSpelling} resolves a ROOTLESS absolute path against
+ * the literal `"/"`, so gating the drive on the root too would leave
+ * `C:/../repo/x` still losing its drive right there — the sibling call site a
+ * fix written only where the defect was found would have missed.
+ *
+ * The count itself is read off {@link WINDOWS_ROOT} rather than re-derived,
+ * because that regex already IS this file's single answer to "what is a Windows
+ * root"; the two forms and the `//?/` spelling are enumerated there, once.
+ */
+const rootSegmentCount = (joined: string, root: string): number => {
+  const matched = WINDOWS_ROOT.exec(joined)?.[0];
+  if (matched === undefined) return 0; // POSIX, or relative: no root inside `out`
+  if (/^[/\\]/.test(matched) && !namesWindowsFs(root)) return 0; // stutter, not share
+  return matched.split(/[/\\]+/).filter((s) => s !== "").length;
+};
+
+/**
  * Resolve a path reference against a root, without node:path (core stays
  * dependency-free). Mirrors `resolve(root, ref)`: an absolute ref wins, a
  * relative one hangs off the root, and `.` / `..` / `//` collapse.
@@ -1920,11 +1963,25 @@ function resolveRef(root: string, ref: string): string {
   const joined = isAbsoluteRef(r)
     ? r
     : `${slashes(root).replace(/\/+$/, "")}/${r}`;
+  // 🔴 `..` CLAMPS AT THE ROOT, IT DOES NOT EAT IT. A real filesystem holds
+  // still at the top: on Windows `C:/..` is `C:/`, on POSIX `/..` is `/`. An
+  // unconditional `out.pop()` popped the DRIVE LETTER out of `C:/../repo/src/x`,
+  // leaving the relative-looking `repo/src/x` — which then failed to resolve
+  // against `C:/repo`, so a gate stopped recognising a path naming its own
+  // repository. A UNC share went one worse: two `..` ate `share` and then
+  // `server`.
+  //
+  // ⚠️ POSIX WAS ALREADY CORRECT BY ACCIDENT, and the accident is worth naming
+  // so nobody "simplifies" it back: its leader `/` is held OUTSIDE `out` (see
+  // the leader below), so popping an empty array is already the clamp. The
+  // Windows forms broke precisely because their root lives INSIDE `out` —
+  // exactly the segments the loop treats as ordinary directories.
+  const floor = rootSegmentCount(joined, root);
   const out: string[] = [];
   for (const seg of joined.split("/")) {
     if (seg === "" || seg === ".") continue;
     if (seg === "..") {
-      out.pop();
+      if (out.length > floor) out.pop();
       continue;
     }
     out.push(seg);
@@ -1942,9 +1999,7 @@ function resolveRef(root: string, ref: string): string {
   // stutter, so preserving the pair unconditionally made it stop resolving
   // against a POSIX root and an allowlist gate denied a valid edit. Semantics
   // belong to the filesystem, and only the root knows which one that is.
-  const unc =
-    joined.startsWith("//") &&
-    (WINDOWS_ROOT.test(root) || root.startsWith("//"));
+  const unc = joined.startsWith("//") && namesWindowsFs(root);
   const leader = unc ? "//" : joined.startsWith("/") ? "/" : "";
   return leader + out.join("/");
 }


### PR DESCRIPTION
`resolveRef` схлопывает `.`/`..` сам (ядро без `node:path`), и `out.pop()` был безусловным — то есть `..` мог съесть сам корень.

- `C:/../repo/src/x.ts` → сегменты `["C:", "..", "repo", …]` → **буква диска съедена**;
- UNC: `//server/share/../x` должен зажиматься на share, а не съедать `share`, потом `server`.

POSIX вёл себя правильно **случайно**: его ведущий `/` лежит отдельно от `out`, и pop по пустому массиву безвреден. Windows-формы ломались потому, что их корень лежит ВНУТРИ `out`.

## Решение

Число сегментов корня — свойство КОРНЯ, а не строки-операнда: та же развязка, что уже записана в этом файле для регистра и для UNC-ведущего. Счётчик читается с `WINDOWS_ROOT`, а не выводится заново, поэтому понятие «что такое корень» остаётся одно.

Одно место, где корень и операнд намеренно разведены: **диск не гейтится корнем**, потому что у `C:/x` нет POSIX-прочтения, а `absoluteSpelling` резолвит безкорневой абсолютный путь против литерального `"/"` — полностью гейтованный пол оставил бы `C:/../repo/x` без буквы диска ровно на этом соседнем вызове.

## Таблица вызывающих — колонка «не относится» ПУСТАЯ

Шесть мест вызывают `resolveRef`; ни одно не оказалось исключением, потому что все берут либо корень, который может быть Windows, либо операнд с буквой диска. **Два из них правка, написанная только там, куда указывал дефект, оставила бы на старом поведении** — `absoluteSpelling` L1178 (безкорневой) и `relativeToRoot` L1197, который **тоже был сломан**: `..` внутри корня съедал букву диска и в базе сравнения.

## Тесты

Семь: четыре «срабатывает» (зажим на диске · зажим на UNC-share, где второй `..` раньше съедал `server` · соседний вызов без корня · обе двери починки), три «молчит» (обычный `..` схлопывается на любом корне · «share или заикание» решает корень, а не путь · UNC без `..` не тронут). Каждый ассерт закрепляет, **признан ли путь внутри корня**, а не сравнение строк, которое могло бы разойтись по другой причине.

Две мутации, обе с греп-доказательством, что патч лёг, обе против всего набора (2 913 тестов): вернуть безусловный `pop()` → 4 падения; снять гейт по корню → ровно 1 падение. Воспроизведено независимо.

## Гейты

`npx vitest run` · `npm run lint` (0 ошибок, число варнингов побайтово как на чистом `main`) · `npx prettier --check .` · `npm run api:check` · `npm run build` — все пять.

Покрытие: `Statements 99.94%` — **но идентично на чистом `origin/main`**, проверено отдельным baseline-деревом; `src/core/` не инструментируется, добавленное в знаменатель не входит.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Fixes**
- `..` clamps at a Windows root instead of eating it
<!-- vigiles:pr-summary:end -->
