### PR TITLE
feat(hook): writeTargets(prefixes) — API перестаёт выбрасывать, какой файл пишется

### DIFF
--- a/api-surface/vigiles-hook.api.md
+++ b/api-surface/vigiles-hook.api.md
@@ -44,6 +44,7 @@ export interface CommandView {
     }): boolean;
     touches(prefixes: readonly string[]): boolean;
     writesTo(prefixes: readonly string[]): boolean;
+    writeTargets(prefixes: readonly string[]): readonly string[];
 }
 
 // @public
@@ -333,6 +334,7 @@ export interface NormalizedLeaf {
     readonly args: readonly string[];
     readonly argv: readonly string[];
     readonly assigns: ReadonlyMap<string, string | null>;
+    readonly chdir: string | null;
     readonly flags: ReadonlySet<string>;
     hasAssign(...names: readonly string[]): boolean;
     hasFlag(...names: readonly string[]): boolean;

--- a/docs/compiled-hooks.md
+++ b/docs/compiled-hooks.md
@@ -67,6 +67,7 @@ export default defineHook({
   - `runs(program, { force? })` — a leaf runs `program` (e.g. `"git reset --hard"`), optionally forced.
   - `touches(prefixes)` — a leaf **mentions** a path under one of `prefixes` (e.g. `["~/.ssh", ".env"]`) — secret reads.
   - `writesTo(prefixes)` — a leaf **creates or modifies** a file under one of `prefixes`: redirection targets (`cmd > f`, `>>`, `>|`, `&>`) plus the writing argv position of `sed -i`, `cp` / `mv` / `install` (destination), `tee`, `dd of=`, `truncate`, `shred`.
+  - `writeTargets(prefixes)` — the same write targets as the **list of files** rather than a boolean, for a gate that has to tell _which_ file (`writeTargets(PAPER_SOURCES).some(isPaperSource)`); `writesTo` is exactly `writeTargets(prefixes).length > 0`. Spelling is as-written after normalization (quotes removed by the parser, `$HOME` canonicalized, a leaf's own `env -C` / `sudo -D` directory resolved), duplicates collapsed — so filter by basename or suffix. `prefixes` is required and there is no unfiltered form: a consumer holding the raw list has to re-implement prefix matching by hand, which is where every measured gate bypass came from.
   - `pipesToShell()` — pipes into a bare shell (`curl … | sh`) — remote-code execution. A shell _with_ a script file (`sh deploy.sh`) is **not** flagged.
   - `isSideEffecting()` — the deterministic Bash-effect classifier's verdict.
 

--- a/src/core/bash-effects.ts
+++ b/src/core/bash-effects.ts
@@ -609,6 +609,26 @@ export interface NormalizedLeaf {
    * {@link LeafRedirect}. Empty for a command with no redirection.
    */
   readonly redirects: readonly LeafRedirect[];
+  /**
+   * The directory a chdir WRAPPER moved this leaf into before exec'ing it —
+   * `env -C dir`, `env --chdir=dir`, `sudo -D dir` — or `null` when there was
+   * none. Nested wrappers accumulate (`sudo -D a env -C b cmd` → `a/b`).
+   *
+   * The parser already READ this token in order to skip past it, then threw the
+   * value away — so every relative operand of the wrapped command resolved
+   * against the wrong directory for every consumer. Same shape as the
+   * redirection targets the leaf used to drop: the parser knew, the leaf did
+   * not carry it. `git -C` is deliberately NOT here — `git` is not a wrapper
+   * (it does not exec the rest of its argv as a command).
+   *
+   * ⚠️ ONE LEAF'S OWN WRAPPER, NOT A CWD MODEL. A directory changed by a
+   * PRECEDING statement (`cd x && …`, `pushd`, a subshell) is not reported:
+   * connectors do not survive leaf extraction, and `cd x; cmd` writes into the
+   * OLD directory when the `cd` fails — that is a model with failure semantics,
+   * not a field. A dynamic value (`env -C "$DIR" …`) is not resolvable and the
+   * whole leaf is already unnormalizable in that case.
+   */
+  readonly chdir: string | null;
 }
 
 /**
@@ -770,6 +790,46 @@ const WRAPPER_VALUE_OPTS: Readonly<Record<string, ReadonlySet<string>>> = {
   nohup: new Set(),
 };
 
+/**
+ * Per-wrapper options whose value is a DIRECTORY the wrapper chdirs into before
+ * exec'ing the command. A subset of {@link WRAPPER_VALUE_OPTS}, and keyed by head
+ * for a reason: `-C` is `--chdir` for `env` but `--close-from` (a file
+ * descriptor) for `sudo`, whose chdir is `-D`. One shared set would read a
+ * number as a directory.
+ */
+const WRAPPER_CHDIR_OPTS: Readonly<Record<string, ReadonlySet<string>>> = {
+  env: new Set(["-C", "--chdir"]),
+  sudo: new Set(["-D", "--chdir"]),
+};
+
+/**
+ * The directory carried by an option WORD, when that word is one of this
+ * wrapper's chdir options — covering both spellings, since `--chdir=dir` is a
+ * single token that never reaches the separate-value table.
+ */
+function chdirValue(
+  word: string,
+  next: string | undefined,
+  chdirOpts: ReadonlySet<string>,
+): string | undefined {
+  if (chdirOpts.has(word)) return next; // `-C dir`, `--chdir dir`
+  const eq = word.indexOf("=");
+  return eq > 0 && chdirOpts.has(word.slice(0, eq))
+    ? word.slice(eq + 1) // `--chdir=dir`
+    : undefined;
+}
+
+/** Layer a wrapper's chdir onto the one an outer wrapper already applied. */
+function nestChdir(
+  outer: string | null,
+  inner: string | undefined,
+): string | null {
+  if (inner === undefined || inner === "") return outer;
+  if (outer === null || inner.startsWith("/") || /^[A-Za-z]:\//.test(inner))
+    return inner;
+  return `${outer.replace(/\/+$/, "")}/${inner}`;
+}
+
 /** Count of leading NON-option positionals a wrapper consumes before the command (timeout DURATION). */
 const WRAPPER_SKIP_POSITIONALS: Readonly<Record<string, number>> = {
   timeout: 1,
@@ -797,13 +857,16 @@ function splitAssignmentWord(word: string): [string, string] {
 function stripWrappers(argv: readonly string[]): {
   argv: readonly string[];
   envAssigns: Map<string, string | null>;
+  chdir: string | null;
 } {
   const envAssigns = new Map<string, string | null>();
+  let chdir: string | null = null;
   let cur: readonly string[] = argv;
   for (let guard = 0; guard < 8; guard++) {
     const head = cur[0];
     if (head === undefined || !WRAPPER_HEADS.has(head)) break;
     const valueOpts = WRAPPER_VALUE_OPTS[head] ?? new Set<string>();
+    const chdirOpts = WRAPPER_CHDIR_OPTS[head] ?? new Set<string>();
     let positionalsToSkip = WRAPPER_SKIP_POSITIONALS[head] ?? 0;
     let i = 1; // start after the wrapper head
     let ended = false;
@@ -816,6 +879,11 @@ function stripWrappers(argv: readonly string[]): {
         break;
       }
       if (a.length > 1 && a.startsWith("-")) {
+        // The chdir value is CAPTURED before it is skipped. It was always read
+        // here — reading it is how the loop knows to skip past it — and then
+        // discarded, so every relative operand of the wrapped command resolved
+        // against the wrong directory downstream.
+        chdir = nestChdir(chdir, chdirValue(a, cur[i + 1], chdirOpts));
         if (valueOpts.has(a)) i++; // skip this option's separate value too
         continue;
       }
@@ -836,7 +904,7 @@ function stripWrappers(argv: readonly string[]): {
     if (next.length === cur.length) break; // no progress → stop
     cur = next;
   }
-  return { argv: cur, envAssigns };
+  return { argv: cur, envAssigns, chdir };
 }
 
 /**
@@ -1200,5 +1268,6 @@ function normalizeCallExpr(
     assigns,
     hasAssign: (...names) => names.some((n) => assigns.has(n)),
     redirects: normalizeRedirects(redirs),
+    chdir: stripped.chdir,
   };
 }

--- a/src/core/hook-program.test.ts
+++ b/src/core/hook-program.test.ts
@@ -483,6 +483,192 @@ test("commandView.writesTo: file-writing programs, at the position that writes",
 });
 
 // ---------------------------------------------------------------------------
+// writeTargets() — WHICH file, not just whether. The list was already computed
+// here and collapsed to a boolean on the way out, so every consumer that needed
+// a filename rebuilt it from the raw string: the shipped paper guard carried a
+// 69-line character scan with its own quote tracking, and that scan had THREE
+// documented silent bypasses (a quoted path, an absolute path, a path eaten by a
+// wrapper) plus a fourth found while designing this — `env sed -i <full path>`,
+// where the guard's `runs()` conjunct read raw leaves while `writesTo` read
+// normalized ones and the two disagreed.
+// ---------------------------------------------------------------------------
+test("commandView.writeTargets: names the file, from both write sources", () => {
+  // Redirection target.
+  assert.deepEqual(
+    commandView("echo x > papers/x/paper.md").writeTargets(["papers"]),
+    ["papers/x/paper.md"],
+  );
+  // File-writing program, at the argv position that writes.
+  assert.deepEqual(
+    commandView("sed -i s/a/b/ papers/x/paper.tex").writeTargets(["papers"]),
+    ["papers/x/paper.tex"],
+  );
+  // cp/mv report the DESTINATION only — the source is read, and the list is
+  // where that distinction becomes visible rather than merely true.
+  assert.deepEqual(
+    commandView("cp papers/draft.md papers/final.md").writeTargets(["papers"]),
+    ["papers/final.md"],
+  );
+  // Several leaves, in order of appearance, exact duplicates collapsed.
+  assert.deepEqual(
+    commandView(
+      "sed -i s/a/b/ papers/b.md && echo x > papers/a.md && tee papers/b.md",
+    ).writeTargets(["papers"]),
+    ["papers/b.md", "papers/a.md"],
+  );
+  // Spelling is as-written after normalization: the parser removed the quotes,
+  // so the consumer never sees them and never needs an `unquote` of its own.
+  assert.deepEqual(
+    commandView('sed -i s/a/b/ "papers/x/paper.tex"').writeTargets(["papers"]),
+    ["papers/x/paper.tex"],
+  );
+});
+
+test("commandView.writeTargets: empty on a read, a quoted mention, or a path outside the prefixes", () => {
+  // A READ is not a write — the false-block regression, asked the other way.
+  assert.deepEqual(commandView("cat papers/x.md").writeTargets(["papers"]), []);
+  assert.deepEqual(
+    commandView("grep -c x papers/x.md 2>/dev/null").writeTargets(["papers"]),
+    [],
+  );
+  assert.deepEqual(
+    commandView("cp papers/x.md /tmp/y").writeTargets(["papers"]),
+    [],
+  );
+  // A write QUOTED inside another command is data, not a redirection.
+  const quoted = commandView("echo 'echo y > papers/x.md' > /tmp/note.txt");
+  assert.deepEqual(quoted.writeTargets(["papers"]), []);
+  assert.deepEqual(quoted.writeTargets(["/tmp"]), ["/tmp/note.txt"]);
+  // A real write, outside the prefixes asked about: the filter is the API, and
+  // handing back the unfiltered list is what this signature refuses to do.
+  assert.deepEqual(
+    commandView("sed -i s/a/b/ src/x.ts", MINE_ROOT).writeTargets(["papers"]),
+    [],
+  );
+  assert.deepEqual(
+    commandView("echo x > /etc/hosts", MINE_ROOT).writeTargets(["papers"]),
+    [],
+  );
+  // An unresolvable target is never guessed at, so it cannot appear.
+  assert.deepEqual(
+    commandView('echo x > "$OUT"', MINE_ROOT).writeTargets(["papers"]),
+    [],
+  );
+});
+
+test("commandView.writeTargets: a leaf's own chdir wrapper resolves; a preceding `cd` does NOT", () => {
+  // MEASURED before this change (root set, prefix `migratsiya/papers`):
+  //   sed -i s/a/b/ migratsiya/papers/x/paper.tex          → true
+  //   env -C migratsiya sed -i s/a/b/ papers/x/paper.tex   → FALSE, silently
+  // `stripWrappers` read the `-C` value in order to skip past it and then threw
+  // it away, so the operand resolved against the wrong directory and a denylist
+  // built on `writesTo` waved the write through.
+  for (const cmd of [
+    "env -C migratsiya sed -i s/a/b/ papers/x/paper.tex",
+    "env --chdir=migratsiya sed -i s/a/b/ papers/x/paper.tex",
+    "sudo -D migratsiya sed -i s/a/b/ papers/x/paper.tex",
+    // The live guard's own shape: the wrapper carries the whole directory.
+    "env -C migratsiya/papers/x sed -i s/a/b/ paper.tex",
+  ]) {
+    assert.deepEqual(
+      commandView(cmd, MINE_ROOT).writeTargets(PAPER_DIR),
+      ["migratsiya/papers/x/paper.tex"],
+      cmd,
+    );
+    assert.equal(commandView(cmd, MINE_ROOT).writesTo(PAPER_DIR), true, cmd);
+  }
+  // Nested wrappers layer, rather than the innermost one winning.
+  assert.deepEqual(
+    commandView(
+      "sudo -D migratsiya env -C papers sed -i s/a/b/ x/paper.tex",
+      MINE_ROOT,
+    ).writeTargets(PAPER_DIR),
+    ["migratsiya/papers/x/paper.tex"],
+  );
+  // 🔴 `-C` IS `--chdir` FOR env AND `--close-from` FOR sudo, so the option
+  // table is keyed by head. Read as one shared set, this reports `5/papers/x.tex`
+  // — a directory that does not exist, from a file descriptor.
+  assert.deepEqual(
+    commandView("sudo -C 5 sed -i s/a/b/ papers/x.tex").writeTargets([
+      "papers",
+    ]),
+    ["papers/x.tex"],
+  );
+  // A REDIRECTION is opened by the SHELL, in the shell's directory — `-C` moves
+  // only the process `env` execs. Joining it would name a file nothing writes.
+  assert.deepEqual(
+    commandView(
+      "env -C migratsiya echo hi > papers/x/paper.md",
+      MINE_ROOT,
+    ).writeTargets(PAPER_DIR),
+    [],
+  );
+  assert.deepEqual(
+    commandView("env -C migratsiya echo hi > papers/x/paper.md").writeTargets([
+      "papers",
+    ]),
+    ["papers/x/paper.md"],
+  );
+  // ⚠️ CHARACTERIZATION, NOT AN ENDORSEMENT. A cwd changed by a PRECEDING
+  // statement is explicitly out of scope: connectors do not survive leaf
+  // extraction, and `cd x; cmd` writes into the OLD directory when the `cd`
+  // fails — a model with failure semantics, not a field on a leaf. The error
+  // direction is ALLOW, which is the wrong one for a denylist, so it is pinned
+  // here to make the day it closes loud instead of silent.
+  assert.deepEqual(
+    commandView(
+      "cd migratsiya && sed -i s/a/b/ papers/x/paper.tex",
+      MINE_ROOT,
+    ).writeTargets(PAPER_DIR),
+    [],
+  );
+});
+
+test("commandView.writesTo is DERIVED from writeTargets — one code path, no drift", () => {
+  // The boolean is `writeTargets(p).length > 0` and nothing else. Two
+  // implementations of one rule is how `runs()` (raw leaves) and `writesTo`
+  // (normalized leaves) came to disagree inside a single gate, so the agreement
+  // is asserted across the whole grid rather than assumed from the source.
+  //
+  // ⚠️ WHAT THIS CAN AND CANNOT CATCH, measured by mutation rather than assumed.
+  // Restoring `writesTo` as its own EXTRACTION (re-walking the leaves, which is
+  // what the code did before this list existed) fails here on `env -C` — the
+  // second path misses the chdir the first one resolves, which is exactly the
+  // drift the derivation removes. Rewriting only the MATCHING half over the same
+  // shared list (`targets.some(...)` instead of `filter(...).length > 0`) passes,
+  // and no test can do better: that is the same function written twice, not a
+  // second answer. So the grid is deliberately stocked with the shapes where a
+  // second extraction diverges — a chdir wrapper, a wrapper with a full path, a
+  // redirection, a dynamic target, a read — rather than with more commands.
+  for (const cmd of [
+    "sed -i s/a/b/ migratsiya/papers/x/paper.tex",
+    "env -C migratsiya sed -i s/a/b/ papers/x/paper.tex",
+    "env sed -i s/a/b/ migratsiya/papers/x/paper.tex",
+    "echo x > migratsiya/papers/x/paper.md",
+    'echo x > "$OUT"',
+    "cat migratsiya/papers/x/paper.tex",
+    "cd migratsiya && sed -i s/a/b/ papers/x/paper.tex",
+    "git status",
+  ]) {
+    for (const root of [MINE_ROOT, undefined]) {
+      const v = commandView(cmd, root);
+      assert.equal(
+        v.writesTo(PAPER_DIR),
+        v.writeTargets(PAPER_DIR).length > 0,
+        `${cmd} (root=${String(root)})`,
+      );
+    }
+  }
+  // The denylist bias reaches the list too: an undecidable placement is INCLUDED,
+  // so a sibling checkout's copy comes back as a target rather than as silence.
+  const foreign = "/somewhere/else/migratsiya/papers/x/paper.tex";
+  assert.deepEqual(
+    commandView(`sed -i s/a/b/ ${foreign}`, MINE_ROOT).writeTargets(PAPER_DIR),
+    [foreign],
+  );
+});
+
+// ---------------------------------------------------------------------------
 // MULTI-HARNESS EMIT — one typed program, the settings block is per-harness.
 // The dogfood is NON-CC-shaped (TOML + regex matcher) so it can't pass by
 // accident on a Claude-Code-hardcoded path (the adapter-aware-lint discipline).

--- a/src/core/hook-program.ts
+++ b/src/core/hook-program.ts
@@ -232,8 +232,33 @@ export interface CommandView {
    *
    * Deletion is a different question and is deliberately NOT reported here —
    * pair with `runs("rm")` if a gate cares about removal too.
+   *
+   * Exactly `writeTargets(prefixes).length > 0`, and implemented as that — reach
+   * for {@link writeTargets} when the gate needs to know WHICH file.
    */
   writesTo(prefixes: readonly string[]): boolean;
+  /**
+   * The write targets of this command that fall under one of the prefixes — the
+   * "WHICH file is written" counterpart to {@link writesTo}. Same two AST-backed
+   * sources (redirection targets + file-writing programs' argv positions), same
+   * denylist bias (an undecidable placement is INCLUDED).
+   *
+   * Spelling is as-written after normalization — quote-unwrapped,
+   * `$HOME`-canonicalized, and resolved against the leaf's own chdir wrapper
+   * (`env -C dir sed -i x` reports `dir/x`) — in order of appearance, exact
+   * duplicates collapsed. Filter by basename/suffix; never re-match the prefixes
+   * by hand, because hand-rolled prefix matching is the exact source of the
+   * trailing-slash, absolute-path and root-blindness defects this vocabulary
+   * exists to remove.
+   *
+   * An empty array ⇔ `writesTo(prefixes) === false`, so the natural
+   * `writeTargets(P).some(pred)` needs no emptiness check to behave correctly.
+   *
+   * `prefixes` is REQUIRED and there is no unfiltered overload: the raw list
+   * does not cross the API boundary, because a consumer holding it has to
+   * re-implement the matching that {@link prefixVerdict} exists to own.
+   */
+  writeTargets(prefixes: readonly string[]): readonly string[];
   /**
    * True iff the command pipes into a BARE shell interpreter (`curl … | sh`,
    * `… | bash -s`) — the remote-code-execution shape. High-signal: a shell leaf
@@ -604,6 +629,20 @@ function writeTargetsOf(leaf: NormalizedLeaf): string[] {
 }
 
 /**
+ * A write target as it lands on disk, given the chdir wrapper the leaf ran under
+ * (`env -C migratsiya sed -i s/a/b/ papers/x.tex` writes `migratsiya/papers/x.tex`).
+ *
+ * Absolute targets and `~`-rooted ones already name their directory and are
+ * returned untouched. The join itself is {@link resolveRef} rather than a fresh
+ * `a + "/" + b`, because two functions normalising the same string differently is
+ * the defect class this file keeps finding.
+ */
+const underChdir = (target: string, chdir: string | null): string =>
+  chdir === null || target === "" || target.startsWith("~")
+    ? target
+    : resolveRef(chdir, target);
+
+/**
  * An AST-backed view of a Bash command.
  *
  * @param raw - the command line as the tool event carried it.
@@ -620,12 +659,28 @@ export function commandView(raw: string, root?: string): CommandView {
   // The operation-normalized leaves carry the redirections (and quote-unwrapped,
   // wrapper-resolved argv) that `writesTo` needs; `leafCommands` cannot see them.
   const normalized = leafCommandsNormalized(raw);
-  const writeTargets = normalized.flatMap((leaf) => [
+  const allWriteTargets = normalized.flatMap((leaf) => [
+    // 🔴 A REDIRECTION IS NOT JOINED ONTO THE LEAF'S CHDIR, AND THAT IS THE
+    // SHELL'S RULE, NOT A SHORTCUT. `env -C dir cmd > out.txt` opens `out.txt`
+    // in the SHELL's directory — the redirection happens before `env` ever runs
+    // and `-C` only moves the process `env` execs. Joining here would report a
+    // file the command never writes.
     ...leaf.redirects.flatMap((r) =>
       r.writes && r.target !== null ? [r.target] : [],
     ),
-    ...writeTargetsOf(leaf),
+    // The wrapped program's own operands DO resolve against it — see
+    // `NormalizedLeaf.chdir` for why the value was being read and discarded.
+    ...writeTargetsOf(leaf).map((t) => underChdir(t, leaf.chdir)),
   ]);
+  const matchedWriteTargets = (
+    prefixes: readonly string[],
+  ): readonly string[] => [
+    ...new Set(
+      allWriteTargets.filter((t) =>
+        prefixes.some((p) => matchesPrefix(prefixVerdict(t, p, root), "match")),
+      ),
+    ),
+  ];
   return {
     raw,
     runs(program, opts) {
@@ -675,10 +730,13 @@ export function commandView(raw: string, root?: string): CommandView {
             matchesPrefix(prefixVerdict(tok, p, root), "match"),
           ),
         ),
-    writesTo: (prefixes) =>
-      writeTargets.some((t) =>
-        prefixes.some((p) => matchesPrefix(prefixVerdict(t, p, root), "match")),
-      ),
+    // DERIVED, not a second implementation of the same rule. The boolean stays
+    // because `writesTo(secrets) ? deny() : allow()` is the common gate shape,
+    // but it is a PROJECTION of the list — one code path, so the two can never
+    // drift the way `runs()` and `writesTo` did (one reads raw leaves, the other
+    // normalized ones, and a gate built on both had a silent hole).
+    writesTo: (prefixes) => matchedWriteTargets(prefixes).length > 0,
+    writeTargets: matchedWriteTargets,
     pipesToShell: () => leaves.some(isBareShellLeaf),
   };
 }


### PR DESCRIPTION
`writesTo(prefixes)` отвечает да/нет, поэтому потребителю, которому нужно знать КАКОЙ файл пишется, приходится восстанавливать имена самому. В `mine` такой самописный скан уже дал **четыре** отдельных обхода гейта — путь в кавычках, путь абсолютный, путь, съеденный обёрткой, и обёртка, спрятавшая саму команду. Каждый раз это тихо пропущенная запись.

При этом список целей **уже вычисляется** внутри `commandView` и схлопывается в булево. API просто перестаёт выбрасывать посчитанное:

```ts
const matchedWriteTargets = (prefixes: readonly string[]): readonly string[] => [
  ...new Set(allWriteTargets.filter((t) =>
    prefixes.some((p) => matchesPrefix(prefixVerdict(t, p, root), "match")))),
];
…
writesTo: (prefixes) => matchedWriteTargets(prefixes).length > 0,
writeTargets: matchedWriteTargets,
```

`prefixes` обязателен и безфильтрового варианта нет: сырой список, перешедший границу API, заставляет потребителя переисполнять матчинг, которым владеет `prefixVerdict` — это и есть источник всех четырёх обходов.

## В скоупе и вне

**В скоупе — chdir-обёртка ОДНОГО листа.** Парсер уже читал значение `-C`, чтобы его пропустить; теперь оно сохраняется (`readonly chdir` на `NormalizedLeaf`). `env -C dir sed -i x` начинает резолвиться.

**Вне скоупа — межстейтментная cwd** (`cd x && …`, `pushd`, сабшеллы): это модель cwd, а не предикат. Остаток честно падает в тишину, то есть в неправильную для денилиста сторону — записано, а не замято.

## Три решения, которых в дизайне не было

- **Таблица ключей chdir должна быть по ГОЛОВЕ команды.** `-C` у `env` это `--chdir`, а у `sudo` — `--close-from` (chdir у него `-D`). Одним набором `sudo -C 5 sed -i papers/x.tex` даёт каталог `5/`, собранный из файлового дескриптора. Есть ассерт.
- **Редирект НЕ приклеивается к chdir.** В `env -C dir cmd > out.txt` шелл открывает `out.txt` в своём каталоге до запуска `env`; приклеивание назвало бы файл, в который никто не пишет. Закреплены обе половины.
- **Вложенные обёртки слоятся** (`sudo -D a env -C b cmd` → `a/b`), а не «внутренняя побеждает».

## Мутации

(a) вернуть нефильтрованный список → 6 падений.
(b) сделать `writesTo` независимым — прогнано **дважды**, и первый прогон сам по себе находка. Слабый вариант (свой цикл матчинга над тем же списком) прошёл ЗЕЛЁНЫМ: набор не узкий (весь unit-проект), тест не недокрепляет — это **эквивалентный мутант**, `some(pred)` и `filter(pred).length > 0` суть одна функция, записанная дважды, разделяющего входа не существует. Измеренная граница записана прямо в тест. Настоящий вариант (перестроить список заново) → 2 падения.

Обе мутации с греп-доказательством, что патч лёг.

## Гейты

`npx vitest run` (2 902) · `npm run lint` · `npx prettier --check .` · `npm run api:check` («no drift», поверхность обновлена) · `npm run build` — все пять.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Features**
- writeTargets(prefixes) — the API stops throwing away which file is written
<!-- vigiles:pr-summary:end -->
