### PR TITLE
fix(agent-result): закрывающая ограда обязана начинать свою строку — иначе фрагмент кода в результате рвёт блок

### DIFF
--- a/src/adapters/claude-code/agent-result.test.ts
+++ b/src/adapters/claude-code/agent-result.test.ts
@@ -130,3 +130,41 @@ test("contract validation runs against the err track too", () => {
   );
   assert.equal(good.kind, "err");
 });
+
+// --- a payload that carries a fenced code block --------------------------------
+//
+// MEASURED 2026-08-13 (spike, N=28 real sonnet runs): a contract whose `string`
+// field is asked to hold a code snippet made EVERY such answer `malformed` — not
+// because the model misbehaved (its JSON was valid, newlines correctly escaped)
+// but because the old closing-fence pattern matched the first ``` it saw, which
+// sat INSIDE the JSON string. The block below is a verbatim capture of one such
+// run. Raw records: mine `vigiles/repro/output-contract-2026-08-13/`.
+
+const REAL_MEASURED_ANSWER =
+  '```vigiles:ok\n' +
+  '{ "finding": "makeToken() uses Math.random(), not a CSPRNG.", ' +
+  '"snippet": "```javascript\\nfunction makeToken(userId) {\\n  return String(userId);\\n}\\n```", ' +
+  '"line": 4, "severity": "high" }\n' +
+  '```';
+
+test("a payload containing a fenced code block still parses", () => {
+  const r = parseAgentResult(REAL_MEASURED_ANSWER);
+  assert.equal(r.kind, "ok");
+  assert.match(
+    String(r.kind === "ok" && r.value.snippet),
+    /```javascript/,
+    "the snippet must survive the round trip with its fence intact",
+  );
+});
+
+test("a fence in the PROSE before the block was never the problem", () => {
+  const withProse =
+    "Here is the offending code:\n\n```js\nconst a = 1;\n```\n\n" +
+    okBlock('{ "summary": "done" }');
+  assert.equal(parseAgentResult(withProse).kind, "ok");
+});
+
+test("an indented closing fence still closes the block", () => {
+  const r = parseAgentResult('```vigiles:ok\n{ "summary": "done" }\n  ```');
+  assert.equal(r.kind, "ok");
+});

--- a/src/adapters/claude-code/agent-result.test.ts
+++ b/src/adapters/claude-code/agent-result.test.ts
@@ -133,19 +133,22 @@ test("contract validation runs against the err track too", () => {
 
 // --- a payload that carries a fenced code block --------------------------------
 //
-// MEASURED 2026-08-13 (spike, N=28 real sonnet runs): a contract whose `string`
-// field is asked to hold a code snippet made EVERY such answer `malformed` — not
-// because the model misbehaved (its JSON was valid, newlines correctly escaped)
-// but because the old closing-fence pattern matched the first ``` it saw, which
-// sat INSIDE the JSON string. The block below is a verbatim capture of one such
-// run. Raw records: mine `vigiles/repro/output-contract-2026-08-13/`.
+// MEASURED 2026-08-13 (spike, N=28 real sonnet runs, model=sonnet): across the
+// whole sample the old pattern returned `malformed` exactly 5 times, and the
+// correspondence was EXACT — it failed if and only if the model put a fence inside
+// the JSON payload (5 with a fence: 5 malformed; 23 without: 0 malformed). Never
+// because the model misbehaved: its JSON was valid, newlines correctly escaped.
+// The old closing-fence pattern simply matched the first ``` it saw, which sat
+// INSIDE the JSON string. A fence in the PROSE before the block was always fine.
+// The block below is a verbatim capture of one failing run.
+// Raw records: mine `vigiles/repro/output-contract-2026-08-13/`.
 
 const REAL_MEASURED_ANSWER =
-  '```vigiles:ok\n' +
+  "```vigiles:ok\n" +
   '{ "finding": "makeToken() uses Math.random(), not a CSPRNG.", ' +
   '"snippet": "```javascript\\nfunction makeToken(userId) {\\n  return String(userId);\\n}\\n```", ' +
   '"line": 4, "severity": "high" }\n' +
-  '```';
+  "```";
 
 test("a payload containing a fenced code block still parses", () => {
   const r = parseAgentResult(REAL_MEASURED_ANSWER);

--- a/src/adapters/claude-code/agent-result.ts
+++ b/src/adapters/claude-code/agent-result.ts
@@ -31,7 +31,12 @@ export type ParsedAgentResult<
 
 // Capture every vigiles:ok / vigiles:err fenced block; the LAST one is the
 // worker's final answer (earlier ones may be illustrative in its reasoning).
-const BLOCK_RE = /```vigiles:(ok|err)[ \t]*\r?\n([\s\S]*?)```/g;
+// The CLOSING fence must own its line: a ``` inside a JSON string value sits
+// mid-line, so it no longer terminates the block (measured 2026-08-13 — a
+// contract field carrying a code snippet made every such answer `malformed`
+// even though the model's JSON was valid).
+const BLOCK_RE =
+  /^[ \t]*```vigiles:(ok|err)[ \t]*\r?\n([\s\S]*?)\r?\n^[ \t]*```[ \t]*$/gm;
 
 /** Does a runtime value match a declared field type? */
 function fieldMatches(value: unknown, type: OutputFieldType): boolean {


### PR DESCRIPTION
Найдено спайком, который проверял **посылку** предложения «отдавать structured output вызовом инструмента», а не само предложение. Предложение отклонено, а дефект оказался в отгруженном парсере и чинится одной строкой.

## Дефект

`BLOCK_RE` в `src/adapters/claude-code/agent-result.ts` искал закрывающую ограду **где угодно**:

```ts
const BLOCK_RE = /```vigiles:(ok|err)[ \t]*\r?\n([\s\S]*?)```/g;
```

Нежадное тело останавливается на первом ``` ``` ```, а он сидит **внутри JSON-строки**, если результат несёт фрагмент кода. Блок обрывается посередине, `JSON.parse` падает, `parseAgentResult` возвращает `malformed` — при полностью корректном ответе модели.

Починка: закрывающая ограда обязана начинать свою строку. Ограда внутри JSON-строки экранирована (`\n`), то есть физически сидит в середине строки и больше блок не терминирует.

## Замер, на котором это стоит

28 реальных прогонов sonnet, $1,69, сырьё заморожено:

| ветвь | n | ok/err/**malformed** | после починки |
|---|---|---|---|
| plain | 7 | 7/0/**0** | 0 |
| long_prose | 7 | 7/0/**0** | 0 |
| code_payload | 7 | 2/0/**5** | **0** |
| err_track | 7 | 0/7/**0** | 0 |

**Это не доля, а класс, и соответствие точное:** нагрузка содержала вложенную ограду → 5 битых из 5; не содержала → 0 битых из 23. **Модель не нарушила контракт ни разу**, неверная ветка 0/28. То есть «хрупкость» механизма целиком объяснялась этим регэкспом.

## Тесты

Три регрессионных, включая **дословный записанный отказ** из замера. Мутация (вернуть незаякоренную ограду) прогнана с греп-доказательством, что патч лёг, и падает ровно на `a payload containing a fenced code block still parses` — воспроизведено независимо.

Гейты: `vitest` · `eslint` · `prettier --check` · `tsc --noEmit`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Other**
- spike: closing fence must own its line, so a payload can carry a code block
- spike: correct the measured-numbers comment (5/28, exact correspondence)
<!-- vigiles:pr-summary:end -->
