### PR TITLE
fix(experimental-emit): unsupported field type throws; the example finds a numbered heading

### DIFF
--- a/examples/experimental-emit/run-emit.mjs
+++ b/examples/experimental-emit/run-emit.mjs
@@ -11,8 +11,9 @@
  * What it does:
  *  1. reads `<skill-dir>/SKILL.md` and asserts it has NO `context: fork` — the
  *     whole question is about the skills that cannot carry an `output:` today;
- *  2. replaces exactly ONE section, `## Record the verdict` (which today shells
- *     out to a ledger script), with `experimental_emitTool(contract).instruction`;
+ *  2. replaces exactly ONE section — the h2 whose heading reads "Record the verdict",
+ *     numbered or not (which today shells out to a ledger script) — with
+ *     `experimental_emitTool(contract).instruction`;
  *  3. serves `experimental_emitTool(contract).tool` from `emit-server.mjs` over a
  *     cwd `.mcp.json`, so no approval prompt and no global config are involved;
  *  4. runs the skill through the real CLI and reads the result back out of
@@ -31,6 +32,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { basename, resolve } from "node:path";
+import MarkdownIt from "markdown-it";
 
 import { result } from "../../dist/core/spec.js";
 import {
@@ -71,17 +73,64 @@ const CONTRACT = result(
 const emit = experimental_emitTool(CONTRACT);
 writeFileSync(TOOL_JSON, JSON.stringify(emit.tool, null, 2));
 
-const MARKER = "## Record the verdict";
-if (!original.includes(MARKER)) {
+// 🔴 The matcher used to be `original.includes("## Record the verdict")`, and it
+// REFUSED 5 of the 22 recording skills in the dogfood corpus — 4 of them wrongly.
+// Their heading is numbered or reworded, which is a formatting choice, not a
+// different section:
+//
+//   ## 6. Record the verdict          (camera-ready, submit-paper, verify-citations)
+//   ## 5. Record the verdict          (plan-paper-timeline)
+//   ## Step 8 — record the verdict    (map-prior-work — and lowercase `record`)
+//
+// So the heading is read as a HEADING, through the parser, not as a substring of
+// the file. A string search cannot tell a heading from the same words inside a
+// fenced block or a sentence, and has no notion of heading LEVEL; markdown-it
+// gives both. (Same call this repo's own linters make — see the four times a
+// regex over markdown structure silently matched the wrong thing.)
+const md = new MarkdownIt();
+
+// ⚠️ Frontmatter must go before parsing. A `---` fence is SETEXT syntax: markdown-it
+// reads the whole YAML block as an <h2> whose text is `name: … description: …`.
+// Measured on this corpus — every skill produced one such phantom heading, and a
+// description containing the words "record the verdict" would have matched it and
+// spliced the emit into the frontmatter. Blank lines, not deletion, so every
+// remaining heading keeps its original line number.
+const fm = original.match(/^---\n[\s\S]*?\n---\n/);
+const body = fm
+  ? "\n".repeat(fm[0].split("\n").length - 1) + original.slice(fm[0].length)
+  : original;
+const tokens = md.parse(body, {});
+
+/**
+ * "## 6. Record the verdict" and "## Step 8 — record the verdict" are the same section.
+ * The separator class includes WHITESPACE: without it `Step 8 — record` fails, because
+ * the dash is a space away from the digit. Caught by running this over the real 22, not
+ * over an example I made up — the invented case had no space.
+ */
+const isVerdictHeading = (text) =>
+  /^(?:step\s*)?\d*[\s.)—–-]*record the verdict\b/i.test(text.trim());
+
+const headings = tokens
+  .map((t, i) => ({ t, inline: tokens[i + 1] }))
+  .filter(({ t }) => t.type === "heading_open" && t.tag === "h2" && t.map)
+  .map(({ t, inline }) => ({ line: t.map[0], text: inline?.content ?? "" }));
+
+const target = headings.find((h) => isVerdictHeading(h.text));
+if (!target) {
   throw new Error(
-    `${skillName} has no "${MARKER}" section to swap for an emit.`,
+    `${skillName} has no "Record the verdict" section to swap for an emit. ` +
+      `Its h2 headings are: ${headings.map((h) => JSON.stringify(h.text)).join(", ") || "none"}.`,
   );
 }
-const before = original.slice(0, original.indexOf(MARKER));
-const rest = original.slice(original.indexOf(MARKER) + MARKER.length);
-const nextHeading = rest.indexOf("\n## ");
-const after = nextHeading === -1 ? "" : rest.slice(nextHeading + 1);
-const patched = `${before}${emit.instruction}\n\n${after}`;
+
+// The section ends at the NEXT h2, not at end-of-file: in all 22 recorders this
+// section is followed by `## Rules` / `## Compose` / `## Provenance`, so cutting
+// to the end would silently delete the rest of the skill.
+const lines = original.split("\n");
+const nextH2 = headings.find((h) => h.line > target.line);
+const before = lines.slice(0, target.line).join("\n");
+const after = nextH2 === undefined ? "" : lines.slice(nextH2.line).join("\n");
+const patched = `${before}\n${emit.instruction}\n\n${after}`;
 
 // --- 2. the fixture: a tiny paper the skill has something real to say about --
 

--- a/src/experimental-emit.test.ts
+++ b/src/experimental-emit.test.ts
@@ -213,3 +213,41 @@ test("assertEmittedOk returns the value, and names the tools called when it thro
     /tools called: none/,
   );
 });
+
+/**
+ * 🔴 REGRESSION — the schema was UNSATISFIABLE and silent, found by dogfooding this
+ * surface across five real skills (2026-08-14). A type outside the ceiling fell
+ * through `fieldSchema`'s switch to `undefined`; `"actions" in properties` stayed
+ * TRUE, so no guard noticed; `JSON.stringify` then dropped the key while `required`
+ * kept it and `additionalProperties: false` forbade it. The served schema demanded
+ * a property it also banned, and `.instruction` still told the model to send it.
+ *
+ * TypeScript rejects this call, which is exactly why it needed a runtime test: the
+ * one shipped example of this API is `.mjs`, where the compiler is not present.
+ */
+test("a field type outside the ceiling THROWS rather than serving an unsatisfiable schema", () => {
+  const outOfCeiling = result(
+    // @ts-expect-error — unreachable from TS, reachable from the .mjs example
+    { verdict: "string", actions: "object[]" },
+    { reason: "string" },
+  );
+
+  assert.throws(
+    () => experimental_emitTool(outOfCeiling),
+    /unsupported field type "object\[\]".*Supported: "string", "number", "boolean", "string\[\]"/s,
+  );
+
+  // The half that made it silent: an undefined value is still an `in` hit, so any
+  // check written that way would have passed the broken schema through. Pinned so
+  // a future "cheap validation" cannot reintroduce the same blind spot.
+  const properties: Record<string, unknown> = {
+    verdict: { type: "string" },
+    actions: undefined,
+  };
+  assert.equal("actions" in properties, true);
+  const roundTripped = JSON.parse(JSON.stringify({ properties })) as {
+    properties: Record<string, unknown>;
+  };
+  assert.equal("actions" in roundTripped.properties, false);
+  assert.deepEqual(Object.keys(roundTripped.properties), ["verdict"]);
+});

--- a/src/experimental-emit.ts
+++ b/src/experimental-emit.ts
@@ -119,6 +119,25 @@ function fieldSchema(type: OutputFieldType): EmitFieldSchema {
       return { type: "boolean" };
     case "string[]":
       return { type: "array", items: { type: "string" } };
+    default:
+      // 🔴 Unreachable from TypeScript, reachable from JavaScript — and the one
+      // shipped example of this API (examples/experimental-emit/run-emit.mjs) is
+      // .mjs, so this is the path a real author takes.
+      //
+      // Without this arm the switch fell through to `undefined`, and every later
+      // step read that as a field: `"actions" in properties` is TRUE for an
+      // undefined value, so nothing noticed; `JSON.stringify` then DROPPED the
+      // key while `required` kept it and `additionalProperties: false` forbade
+      // it. The served schema demanded a property it also banned — unsatisfiable,
+      // silent, and contradicted by `.instruction`, which still asked the model
+      // to send it. Throwing here makes the contradiction impossible to construct
+      // instead of merely unlikely.
+      throw new TypeError(
+        `experimental_emitTool: unsupported field type ${JSON.stringify(type)}. ` +
+          `Supported: "string", "number", "boolean", "string[]". ` +
+          `Nested objects and enums are outside this surface's ceiling — flatten the field, ` +
+          `or use the fenced fork rail if the shape cannot be flattened.`,
+      );
   }
 }
 


### PR DESCRIPTION
Two defects found by dogfooding the emit surface across five real pipeline skills. Both are the same shape: they do not fail, they answer confidently and wrongly.

## 1. A type outside the ceiling served an unsatisfiable schema, silently

`fieldSchema` was a `switch` over four literals with no `default`, so a fifth type became `undefined` — and every later step read that as a field:

```
in memory   properties.actions = undefined
            "actions" in properties  = true     <- key present, value undefined:
                                                   any `in` guard reads this as fine

serialized (what actually reaches the model):
{"type":"object","properties":{"tooLong":{"type":"boolean"}},
 "required":["verdict","actions"],"additionalProperties":false}
        ^^^^^^^^^^^^ still required        ^^^^^^^^^^ and forbidden
```

The served schema demanded a property it also banned, while `.instruction` from the same call still told the model to send it. That matters because the only argument for returning both halves from one call is that a second copy of the contract would drift — returning them together is necessary but not sufficient, since the halves are built by different code paths and one of them lost the field.

Unreachable from TypeScript (`TS2322`), reachable from JavaScript — and the one shipped example of this API is `.mjs`, which is why a runtime test was the right place for it. Verified by mutation: deleting the new `default:` arm turns the regression test red on its own assertion.

## 2. The example refused a section for its formatting

The target section was matched with `original.includes("## Record the verdict")`. Measured on the corpus: **11 of 15 eligible recorders reached**, 4 refused purely because the heading is numbered (`## 6. Record the verdict`, `## 5. …`, `## 7. …`). A heading is now read as a heading through `markdown-it`, which is already a dependency — a substring search has no notion of heading level and cannot distinguish a heading from the same words inside a fence. **15 of 15 after.**

Two defects inside that fix, both caught by running it over the real corpus rather than an invented example:

- the separator class needed whitespace — `Step 8 — record the verdict` has a space before the dash, and my invented test case did not;
- `markdown-it` reads YAML frontmatter as a **setext h2**, so every skill produced a phantom heading whose text is the description. A description containing these words would have spliced the emit into the frontmatter.

The section end is bounded by the next h2 rather than end-of-file: in all 22 recorders this section is followed by `## Rules` / `## Compose` / `## Provenance`, so cutting to the end would silently delete the rest of the skill.

## Gates

Run in this order, all clean:

- `npx vitest run` — 2915 passed, 25 skipped
- `npm run lint` — 0 errors
- `npx prettier --check .`
- `npm run api:check` — no drift

Note for anyone hitting red locally: six failures in `hook-state-runtime.test.ts` are a **stale `dist/`**, not a regression — they reproduce on clean `origin/main` and go green after `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Fixes**
- unsupported field type throws; the example finds a numbered heading
<!-- vigiles:pr-summary:end -->
