### PR TITLE
feat(testing): runMutations — prove a test can fail, by breaking what it watches

### DIFF
--- a/api-surface/vigiles-testing.api.md
+++ b/api-surface/vigiles-testing.api.md
@@ -473,6 +473,9 @@ export function formatContainment(v: ContainmentVerdict): string;
 export function formatEvalReport(report: EvalReport): string;
 
 // @public
+export function formatMutationReport(report: MutationReport): string;
+
+// @public
 export function formatTriggerRateReport(report: TriggerRateReport): string;
 
 // @public
@@ -699,6 +702,45 @@ export function mustInclude(fragment: string, why: string): Check<readonly DocCo
 export function mustNotInclude(fragment: string, why: string): Check<readonly DocCommand[]>;
 
 // @public
+export interface MutationCase {
+    readonly disables: string;
+    readonly edits: readonly MutationEdit[];
+    readonly expect: string;
+    readonly name: string;
+    readonly test: string;
+}
+
+// @public
+export type MutationEdit = readonly [
+file: string,
+find: string,
+replace: string
+];
+
+// @public
+export interface MutationOutcome {
+    readonly detail: string;
+    // (undocumented)
+    readonly disables: string;
+    // (undocumented)
+    readonly name: string;
+    // (undocumented)
+    readonly verdict: MutationVerdict;
+}
+
+// @public
+export interface MutationReport {
+    readonly alreadyRed: readonly string[];
+    readonly killed: number;
+    // (undocumented)
+    readonly outcomes: readonly MutationOutcome[];
+    readonly restored: boolean;
+}
+
+// @public
+export type MutationVerdict = "killed" | "wrong-assertion" | "survived" | "unjudgeable" | "not-applied";
+
+// @public
 export function notTool(name: string, args?: ArgMatcher): Check<Trace>;
 
 // @public
@@ -818,6 +860,17 @@ export function runHook(command: string, input: HookInput, opts?: RunHookOptions
 
 // @public
 export type RunHookOptions = Omit<RunScriptOptions, "stdin">;
+
+// @public
+export function runMutations(o: RunMutationsOptions): MutationReport;
+
+// @public (undocumented)
+export interface RunMutationsOptions {
+    // (undocumented)
+    readonly cases: readonly MutationCase[];
+    readonly cwd: string;
+    readonly env?: NodeJS.ProcessEnv;
+}
 
 // @public
 export interface RunOut {

--- a/docs/testing-api.md
+++ b/docs/testing-api.md
@@ -7,6 +7,7 @@ how-to; this is the reference you reach for when you need the exact name or knob
 ## Contents
 
 - [Picking a runner](#picking-a-runner)
+- [And one that asks about the tests themselves](#and-one-that-asks-about-the-tests-themselves)
 - [The `Trace` model](#the-trace-model)
 - [Predicates](#predicates)
 - [Assertions](#assertions)
@@ -37,6 +38,58 @@ model at that tier.
 **`runScript` is the primitive; `runHook` is it plus the hook protocol** (event →
 stdin, exit code → allow/deny). A **hook** has a _decision_; a **script** has
 _effects_ — so `ScriptRunResult` deliberately carries no `decision` field.
+
+### And one that asks about the tests themselves
+
+| Your question                                       | Runner         | Result           | Cost |
+| --------------------------------------------------- | -------------- | ---------------- | ---- |
+| **would my test notice if the check were deleted?** | `runMutations` | `MutationReport` | free |
+
+Every runner above reports that a check passed. None can tell a watched assertion
+from a vacuous one — both print `✓`. `runMutations` plants a defect in the thing a
+test watches, runs that test, and requires it to fail **with the message that
+names the defect**:
+
+```ts
+import { runMutations, formatMutationReport } from "vigiles/testing";
+
+const report = runMutations({
+  cwd: repoRoot,
+  cases: [
+    {
+      name: "year",
+      disables: "the year comparison",
+      edits: [[checker, "rec.year !== ourYear", "false"]],
+      test: harness,
+      expect: "a wrong year was not reported",
+    },
+  ],
+});
+console.log(formatMutationReport(report));
+```
+
+Five verdicts, and only the first is proof:
+
+| verdict           | what happened                                                                  |
+| ----------------- | ------------------------------------------------------------------------------ |
+| `killed`          | red, and it printed your `expect`                                              |
+| `wrong-assertion` | red, but a **neighbour** caught it — two defects share one assertion           |
+| `survived`        | green with the defect planted: the assertion is vacuous, or absent             |
+| `unjudgeable`     | the test was **already red** before the run, so "red" says nothing here        |
+| `not-applied`     | the edit did not land — `find` matched 0 or many, or the replacement was equal |
+
+🔴 **It rewrites the files in `edits` and restores them** — in a `finally` _and_ on
+SIGINT/SIGTERM, so an interrupted run cannot leave a neutered checker behind for
+the next run to measure and call healthy. Commit first. A named `test` file that
+does not exist, and an empty `cases` list, both **throw before anything is
+touched**: a runner with nothing to run would otherwise report success, which is
+the one claim this API exists to prevent.
+
+This is not Stryker/mutmut/PIT. Those generate mutants from operators over
+production code and score a suite by kill ratio; here the mutations are
+hand-authored and each names the assertion that must catch it — the right shape
+when the subject is a checker, a hook or an instruction file rather than
+general-purpose code. Use the generated-operator tools where they apply.
 
 **Both streams, always.** `ScriptRunResult`, `HookRunResult` and
 `HarnessTestResult` all carry `stdout` **and** `stderr`. That matters more than

--- a/src/mutations.test.ts
+++ b/src/mutations.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Tests for `runMutations` (src/mutations.ts).
+ *
+ * The subject here is a thing that judges tests, so every case builds a REAL checker and a REAL
+ * test in a temp dir and runs them — a mocked runner would be judging a mock. They are tiny (a
+ * dozen lines each) and there is no model, so the whole file is fast and free.
+ *
+ * Each property gets BOTH halves: it fires on the defect it is for, and it stays quiet otherwise.
+ * A guard proven only in the firing direction is indistinguishable from one that always fires.
+ */
+import { test, afterEach } from "vitest";
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  runMutations,
+  formatMutationReport,
+  type MutationCase,
+} from "./mutations.js";
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+/**
+ * A checker that reports two independent defects, and a test that names each one distinctly.
+ * `YEAR_RULE` and `TITLE_RULE` are the mutation targets.
+ */
+function fixture(): { cwd: string; checker: string; testFile: string } {
+  const cwd = mkdtempSync(join(tmpdir(), "vigiles-mut-"));
+  dirs.push(cwd);
+  mkdirSync(join(cwd, "src"), { recursive: true });
+
+  const checker = join(cwd, "src", "checker.mjs");
+  writeFileSync(
+    checker,
+    [
+      "export function check(rec) {",
+      "  const out = [];",
+      "  if (rec.year !== 2026) out.push('wrong year');",
+      "  if (rec.title !== 'ok') out.push('wrong title');",
+      "  return out;",
+      "}",
+    ].join("\n"),
+  );
+
+  const testFile = join(cwd, "src", "checker.harness.mjs");
+  writeFileSync(
+    testFile,
+    [
+      "import assert from 'node:assert/strict';",
+      "import { check } from './checker.mjs';",
+      "assert.ok(check({ year: 1999, title: 'ok' }).includes('wrong year'), 'the year rule is not watched');",
+      "assert.ok(check({ year: 2026, title: 'no' }).includes('wrong title'), 'the title rule is not watched');",
+      "console.log('ok');",
+    ].join("\n"),
+  );
+  return { cwd, checker, testFile };
+}
+
+const kase = (
+  over: Partial<MutationCase> & Pick<MutationCase, "edits" | "test" | "expect">,
+): MutationCase => ({
+  name: "case",
+  disables: "something",
+  ...over,
+});
+
+test("a planted defect the test names is KILLED, and the source is restored byte for byte", () => {
+  const { cwd, checker, testFile } = fixture();
+  const before = readFileSync(checker, "utf8");
+
+  const r = runMutations({
+    cwd,
+    cases: [
+      kase({
+        name: "year",
+        edits: [[checker, "rec.year !== 2026", "false"]],
+        test: testFile,
+        expect: "the year rule is not watched",
+      }),
+    ],
+  });
+
+  assert.equal(r.outcomes[0]?.verdict, "killed");
+  assert.equal(r.killed, 1);
+  assert.equal(r.restored, true);
+  assert.equal(
+    readFileSync(checker, "utf8"),
+    before,
+    "the checker was not restored",
+  );
+});
+
+test("a defect caught by a NEIGHBOUR's assertion is wrong-assertion, not a kill", () => {
+  // The mutation breaks the TITLE rule while the case claims the YEAR message. The test does go
+  // red — so a runner that only looked at the exit code would call this proven.
+  const { cwd, checker, testFile } = fixture();
+  const r = runMutations({
+    cwd,
+    cases: [
+      kase({
+        name: "mislabelled",
+        edits: [[checker, "rec.title !== 'ok'", "false"]],
+        test: testFile,
+        expect: "the year rule is not watched",
+      }),
+    ],
+  });
+  assert.equal(r.outcomes[0]?.verdict, "wrong-assertion");
+  assert.equal(r.killed, 0);
+  assert.match(r.outcomes[0]?.detail ?? "", /never printed/);
+});
+
+test("a defect nothing watches SURVIVES", () => {
+  const { cwd, checker, testFile } = fixture();
+  writeFileSync(
+    checker,
+    `${readFileSync(checker, "utf8")}\nexport const UNWATCHED = 1;\n`,
+  );
+  const r = runMutations({
+    cwd,
+    cases: [
+      kase({
+        name: "unwatched",
+        edits: [
+          [
+            checker,
+            "export const UNWATCHED = 1;",
+            "export const UNWATCHED = 2;",
+          ],
+        ],
+        test: testFile,
+        expect: "anything",
+      }),
+    ],
+  });
+  assert.equal(r.outcomes[0]?.verdict, "survived");
+});
+
+test("a replacement equal to the original is NOT-APPLIED, never a kill", () => {
+  // The no-op mutation: it leaves a green test that reads exactly like a passing one. Four of ten
+  // hand-written copies of this driver lacked the guard.
+  const { cwd, checker, testFile } = fixture();
+  const r = runMutations({
+    cwd,
+    cases: [
+      kase({
+        name: "noop",
+        edits: [[checker, "rec.year !== 2026", "rec.year !== 2026"]],
+        test: testFile,
+        expect: "the year rule is not watched",
+      }),
+    ],
+  });
+  assert.equal(r.outcomes[0]?.verdict, "not-applied");
+  assert.match(r.outcomes[0]?.detail ?? "", /replacement equals the original/);
+});
+
+test("a `find` that matches zero or several times is NOT-APPLIED, and says which", () => {
+  const { cwd, checker, testFile } = fixture();
+  const zero = runMutations({
+    cwd,
+    cases: [
+      kase({
+        name: "gone",
+        edits: [[checker, "moved away", "x"]],
+        test: testFile,
+        expect: "x",
+      }),
+    ],
+  });
+  assert.equal(zero.outcomes[0]?.verdict, "not-applied");
+  assert.match(zero.outcomes[0]?.detail ?? "", /matched nothing/);
+
+  const many = runMutations({
+    cwd,
+    cases: [
+      kase({
+        name: "ambiguous",
+        edits: [[checker, "out.push", "x"]],
+        test: testFile,
+        expect: "x",
+      }),
+    ],
+  });
+  assert.equal(many.outcomes[0]?.verdict, "not-applied");
+  assert.match(many.outcomes[0]?.detail ?? "", /matched 2 times/);
+});
+
+test("a test file that does not exist is REFUSED before any file is touched", () => {
+  // The defect this API was extracted to make impossible: a runner that exits 0 on a path matching
+  // nothing turns every case naming it into a silent SURVIVED.
+  const { cwd, checker } = fixture();
+  const before = readFileSync(checker, "utf8");
+  assert.throws(
+    () =>
+      runMutations({
+        cwd,
+        cases: [
+          kase({
+            edits: [[checker, "rec.year !== 2026", "false"]],
+            test: join(cwd, "gone.mjs"),
+            expect: "x",
+          }),
+        ],
+      }),
+    /test file\(s\) do not exist/,
+  );
+  assert.equal(
+    readFileSync(checker, "utf8"),
+    before,
+    "a refused run must not have touched anything",
+  );
+});
+
+test("an empty case list throws rather than reporting success", () => {
+  const { cwd } = fixture();
+  assert.throws(() => runMutations({ cwd, cases: [] }), /no cases/);
+});
+
+test("a test that was ALREADY red judges nothing, and is excluded from the restore check", () => {
+  // A test can be red on purpose — an open finding it exists to report. Counting it made a real
+  // runner announce "the restore failed" about a working restore on every single run.
+  const { cwd, checker, testFile } = fixture();
+  writeFileSync(
+    testFile,
+    "import assert from 'node:assert/strict';\nassert.fail('an open finding');\n",
+  );
+  const r = runMutations({
+    cwd,
+    cases: [
+      kase({
+        name: "against-a-red-test",
+        edits: [[checker, "rec.year !== 2026", "false"]],
+        test: testFile,
+        expect: "the year rule is not watched",
+      }),
+    ],
+  });
+  assert.equal(r.outcomes[0]?.verdict, "unjudgeable");
+  assert.deepEqual(r.alreadyRed, [testFile]);
+  assert.equal(
+    r.restored,
+    true,
+    "a test that was red before must not be read as a failed restore",
+  );
+});
+
+test("multi-file cases: every edit lands, and all of them are restored", () => {
+  const { cwd, checker, testFile } = fixture();
+  const second = join(cwd, "src", "other.mjs");
+  writeFileSync(second, "export const GUARD = true;\n");
+  const beforeChecker = readFileSync(checker, "utf8");
+
+  const r = runMutations({
+    cwd,
+    cases: [
+      kase({
+        name: "both",
+        edits: [
+          [checker, "rec.year !== 2026", "false"],
+          [second, "export const GUARD = true;", "export const GUARD = false;"],
+        ],
+        test: testFile,
+        expect: "the year rule is not watched",
+      }),
+    ],
+  });
+  assert.equal(r.outcomes[0]?.verdict, "killed");
+  assert.equal(readFileSync(checker, "utf8"), beforeChecker);
+  assert.equal(readFileSync(second, "utf8"), "export const GUARD = true;\n");
+});
+
+test("formatMutationReport names every non-kill and states the restore in words", () => {
+  const { cwd, checker, testFile } = fixture();
+  const r = runMutations({
+    cwd,
+    cases: [
+      kase({
+        name: "kills",
+        edits: [[checker, "rec.year !== 2026", "false"]],
+        test: testFile,
+        expect: "the year rule is not watched",
+      }),
+      kase({
+        name: "noop",
+        edits: [[checker, "rec.title !== 'ok'", "rec.title !== 'ok'"]],
+        test: testFile,
+        expect: "x",
+      }),
+    ],
+  });
+  const text = formatMutationReport(r);
+  assert.match(text, /kills.*✓ killed/);
+  assert.match(text, /noop.*not applied/s);
+  assert.match(text, /1 of 2 not killed as named: noop/);
+  assert.match(text, /restored: every test that was green/);
+});

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -1,0 +1,343 @@
+/**
+ * `runMutations` — prove a test can FAIL, by breaking the thing it watches.
+ *
+ * A green test says the checker passed. It does not say the test would notice if the check were
+ * deleted: an assertion can be vacuous, a fixture can be wrong in the same direction as the code,
+ * and both look exactly like a pass. The only way to tell is to plant a defect and require the
+ * test to go red — with the message that NAMES that defect, not merely with something red.
+ *
+ * ## Why this is in vigiles rather than in a repo's own scripts
+ *
+ * It arrived as ten hand-written copies of one driver in a dogfooding repo (1799 lines), and the
+ * copies had DRIFTED. Counted against the committed versions on 2026-08-14:
+ *
+ *   - the NO-OP guard (a replacement equal to the original leaves a green test proving nothing)
+ *     was in 4 of 10;
+ *   - the RETRY (a non-kill re-run once before it is believed) was in 1 of 10;
+ *   - the strict rule — killed by its OWN named assertion, not merely by something going red —
+ *     was in 1 of 10.
+ *
+ * Every one of those was written AFTER it caught something, in whichever copy happened to catch
+ * it, and never travelled to the other nine. Two copies also named a test file that a refactor had
+ * deleted; the runner they used exits 0 on a path matching nothing, so those cases reported
+ * SURVIVED on every run for three days. That is the argument for one engine: not less code, but
+ * one place where each of those becomes impossible again.
+ *
+ * ## What this is NOT
+ *
+ * Not Stryker/mutmut/PIT. Those GENERATE mutants from operators (flip a `<`, drop a `return`) over
+ * production code and score a suite by kill ratio. Here the mutations are HAND-AUTHORED and each
+ * one names the assertion that must catch it, because the subject is usually not general-purpose
+ * code — it is a checker, a hook, an instruction file — where "flip an operator" produces mostly
+ * unreachable nonsense and a kill ratio measures nothing. The generated-operator approach is the
+ * better tool when it applies; reach for it there.
+ *
+ * ## The contract, in one sentence
+ *
+ * Plant one defect, run the test that owns it, and require the test to fail with the message that
+ * names it — anything else is reported as a finding, never as a pass.
+ *
+ * @module
+ */
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { basename } from "node:path";
+
+import {
+  detectNodeCaps,
+  interpreterArgs,
+} from "./adapters/claude-code/run-scripts.js";
+
+/** One edit: the file, the exact substring to find, and what replaces it. */
+export type MutationEdit = readonly [
+  file: string,
+  find: string,
+  replace: string,
+];
+
+/** One planted defect and the assertion that must catch it. */
+export interface MutationCase {
+  /** Short id, printed in the report. */
+  readonly name: string;
+  /** What the mutation takes away, in words — the column a reader scans. */
+  readonly disables: string;
+  /**
+   * The edits that plant it. A LIST, because some defects are only expressible as more than one:
+   * removing a guard AND the vocabulary check that would otherwise throw for an unrelated reason.
+   * Every edit must match its `find` EXACTLY ONCE, or the case is reported `not-applied`.
+   */
+  readonly edits: readonly MutationEdit[];
+  /** The test file that must go red. Its absence is refused, loudly, before anything is touched. */
+  readonly test: string;
+  /** A substring the test's complaint must contain, so a kill by a NEIGHBOUR is not counted. */
+  readonly expect: string;
+}
+
+/**
+ * - `killed` — the test went red AND printed `expect`. The only outcome that counts as proof.
+ * - `wrong-assertion` — red, but not with this case's message: two defects share one assertion and
+ *   neither is really watched.
+ * - `survived` — the test stayed green. The assertion is vacuous, or absent.
+ * - `unjudgeable` — the test was ALREADY red before the run, and `expect` never printed, so "red"
+ *   carries no information about this mutation. Not a pass and not a failure of the assertion.
+ * - `not-applied` — the edit did not land: `find` matched zero or several times, or the
+ *   replacement equalled the original.
+ */
+export type MutationVerdict =
+  | "killed"
+  | "wrong-assertion"
+  | "survived"
+  | "unjudgeable"
+  | "not-applied";
+
+/** What one case did. */
+export interface MutationOutcome {
+  readonly name: string;
+  readonly disables: string;
+  readonly verdict: MutationVerdict;
+  /** Human-readable specifics — which file, how many matches, whether a retry was needed. */
+  readonly detail: string;
+}
+
+/** What a whole run did. */
+export interface MutationReport {
+  readonly outcomes: readonly MutationOutcome[];
+  /** Cases with verdict `killed`. */
+  readonly killed: number;
+  /** Test files that were red BEFORE any mutation, so they can testify about nothing. */
+  readonly alreadyRed: readonly string[];
+  /**
+   * Whether every test that was green before the run is green again after it. `false` means the
+   * restore failed and the working tree is not what it was — the one outcome worth interrupting for.
+   */
+  readonly restored: boolean;
+}
+
+export interface RunMutationsOptions {
+  /** Working directory for the test runs; every path in `edits` and `test` is absolute. */
+  readonly cwd: string;
+  readonly cases: readonly MutationCase[];
+  /**
+   * Extra environment for each test run, merged over `process.env`.
+   * Use it to hand the test the same variables its normal runner would.
+   */
+  readonly env?: NodeJS.ProcessEnv;
+}
+
+interface RunResult {
+  readonly failed: boolean;
+  readonly out: string;
+}
+
+function runTest(file: string, o: RunMutationsOptions): RunResult {
+  const argv = interpreterArgs(file, detectNodeCaps(o.cwd));
+  const r = spawnSync("node", argv, {
+    cwd: o.cwd,
+    encoding: "utf8",
+    env: { ...process.env, ...o.env },
+  });
+  return { failed: r.status !== 0, out: (r.stdout ?? "") + (r.stderr ?? "") };
+}
+
+/**
+ * Plant each case's defect, run the test that owns it, restore, and report what happened.
+ *
+ * ```ts
+ * const report = runMutations({
+ *   cwd: repoRoot,
+ *   cases: [{
+ *     name: "year",
+ *     disables: "the year comparison",
+ *     edits: [[checker, "rec.year !== ourYear", "false"]],
+ *     test: harness,
+ *     expect: "a wrong year was not reported",
+ *   }],
+ * });
+ * console.log(formatMutationReport(report));
+ * process.exit(report.killed === report.outcomes.length && report.restored ? 0 : 1);
+ * ```
+ *
+ * 🔴 THIS REWRITES THE FILES NAMED IN `edits` AND RESTORES THEM. The restore runs in a `finally`
+ * AND on SIGINT/SIGTERM, because a run killed midway would otherwise leave a neutered checker on
+ * disk — and the next run would then measure an already-broken repo and call it healthy. Commit
+ * before running. (Do not reach for `git stash` to clear the tree: the stash is repository-global,
+ * so a second agent working in another worktree of the same repo will pop your entries.)
+ *
+ * @throws if `cases` is empty, or if any named test file does not exist — both BEFORE any file is
+ * touched, so the message arrives with a clean working tree.
+ */
+export function runMutations(o: RunMutationsOptions): MutationReport {
+  if (o.cases.length === 0) {
+    throw new Error(
+      "runMutations: no cases. A mutation run with nothing to run reports success, which is the exact claim this API exists to make impossible.",
+    );
+  }
+
+  const tests = [...new Set(o.cases.map((c) => c.test))];
+  // A test path that resolves to nothing is the defect that hid for three days in the corpus this
+  // came from: the runner exits 0 on "no files matched", so every case naming it reported SURVIVED
+  // and sent the reader hunting for an assertion that was never reached.
+  const missing = tests.filter((t) => !existsSync(t));
+  if (missing.length > 0) {
+    throw new Error(
+      `runMutations: test file(s) do not exist, so no case naming them could ever be judged:\n  ${missing.join("\n  ")}`,
+    );
+  }
+
+  // Baselined BEFORE anything is touched. Without this, a test that is red on purpose (an open
+  // finding it is meant to report) makes every run announce "the restore failed" about a working
+  // restore, and makes every case against it look killed.
+  const alreadyRed = tests.filter((t) => runTest(t, o).failed);
+  const redBefore = new Set(alreadyRed);
+
+  const targets = [...new Set(o.cases.flatMap((c) => c.edits.map(([f]) => f)))];
+  const originals = new Map(targets.map((f) => [f, readFileSync(f, "utf8")]));
+  const restore = (): void => {
+    for (const [f, text] of originals) writeFileSync(f, text);
+  };
+  const onSignal = (sig: NodeJS.Signals): never => {
+    restore();
+    process.exit(sig === "SIGINT" ? 130 : 143);
+  };
+  process.on("SIGINT", onSignal);
+  process.on("SIGTERM", onSignal);
+
+  const outcomes: MutationOutcome[] = [];
+  try {
+    for (const c of o.cases) {
+      const applied = apply(c);
+      if (applied) {
+        outcomes.push({
+          name: c.name,
+          disables: c.disables,
+          verdict: "not-applied",
+          detail: applied,
+        });
+        restore();
+        continue;
+      }
+
+      // A non-kill is retried ONCE before it is believed. Observed on a real corpus: a row killed
+      // as named came back as a neighbour's assertion in a later full run and reproduced as a clean
+      // kill when replayed alone. Reporting a flake as a survivor sends the next reader to rewrite
+      // a working assertion, which is worse than one extra run.
+      let judged = judge(c, o, redBefore);
+      if (judged.verdict !== "killed") {
+        const second = judge(c, o, redBefore);
+        if (second.verdict === "killed")
+          judged = {
+            verdict: "killed",
+            detail: "killed on retry (the first run was a flake)",
+          };
+        else judged = second;
+      }
+      outcomes.push({ name: c.name, disables: c.disables, ...judged });
+      restore();
+    }
+  } finally {
+    restore();
+    process.off("SIGINT", onSignal);
+    process.off("SIGTERM", onSignal);
+  }
+
+  // Only a test that was GREEN before can testify about the restore.
+  const restored = tests
+    .filter((t) => !redBefore.has(t))
+    .every((t) => !runTest(t, o).failed);
+
+  return {
+    outcomes,
+    killed: outcomes.filter((r) => r.verdict === "killed").length,
+    alreadyRed,
+    restored,
+  };
+}
+
+/** Plants one case's edits. Returns a reason string when it could not be planted, else null. */
+function apply(c: MutationCase): string | null {
+  for (const [file, find, replace] of c.edits) {
+    const src = readFileSync(file, "utf8");
+    const n = src.split(find).length - 1;
+    if (n !== 1) {
+      return n === 0
+        ? `"find" matched nothing in ${basename(file)} — the source moved under the case`
+        : `"find" matched ${String(n)} times in ${basename(file)}; an edit must be unambiguous`;
+    }
+    const next = src.replace(find, replace);
+    // The mutation-that-does-not-mutate, caught against the BYTES rather than the intent: a
+    // replacement equal to the original leaves a green test that reads exactly like a kill.
+    if (next === src)
+      return `the replacement equals the original in ${basename(file)}`;
+    writeFileSync(file, next);
+  }
+  return null;
+}
+
+function judge(
+  c: MutationCase,
+  o: RunMutationsOptions,
+  redBefore: ReadonlySet<string>,
+): { verdict: MutationVerdict; detail: string } {
+  const { failed, out } = runTest(c.test, o);
+  if (!failed)
+    return {
+      verdict: "survived",
+      detail: `${basename(c.test)} stayed green with the defect planted`,
+    };
+  if (out.includes(c.expect))
+    return { verdict: "killed", detail: `named by "${c.expect}"` };
+  // When the test was ALREADY red, "red" carries no information — but the MESSAGE still does,
+  // because a runner that aborts at the first failure never reaches a later assertion. Absent it,
+  // the two causes are indistinguishable, and calling it a wrong assertion would be a guess.
+  return redBefore.has(c.test)
+    ? {
+        verdict: "unjudgeable",
+        detail: `${basename(c.test)} was red before the run and "${c.expect}" never printed`,
+      }
+    : {
+        verdict: "wrong-assertion",
+        detail: `red, but "${c.expect}" never printed — a neighbour's assertion caught it`,
+      };
+}
+
+/** Render a report the way the CLI-style runners in this package render theirs. */
+export function formatMutationReport(report: MutationReport): string {
+  const lines: string[] = [];
+  if (report.alreadyRed.length > 0) {
+    lines.push(
+      `ℹ️  already red before any mutation: ${report.alreadyRed.map((t) => basename(t)).join(", ")} — excluded from the restore check; a case naming one is reported unjudgeable.`,
+      "",
+    );
+  }
+  const width = Math.max(...report.outcomes.map((r) => r.name.length));
+  const mark: Record<MutationVerdict, string> = {
+    killed: "✓ killed",
+    "wrong-assertion": "🔴 wrong assertion",
+    survived: "🔴 SURVIVED",
+    unjudgeable: "🔴 unjudgeable",
+    "not-applied": "🔴 not applied",
+  };
+  for (const r of report.outcomes) {
+    lines.push(
+      `${r.name.padEnd(width)}  ${mark[r.verdict].padEnd(20)} ${r.disables}`,
+    );
+    if (r.verdict !== "killed")
+      lines.push(`${" ".repeat(width + 2)}  ${r.detail}`);
+  }
+  lines.push("");
+  lines.push(
+    report.restored
+      ? "restored: every test that was green before the run is green again"
+      : "🔴 RESTORE FAILED — a test that was green before the run is red now. The working tree is not what it was.",
+  );
+  const bad = report.outcomes.length - report.killed;
+  lines.push(
+    bad === 0
+      ? `✓ all ${String(report.outcomes.length)} mutations killed, each at its own assertion`
+      : `🔴 ${String(bad)} of ${String(report.outcomes.length)} not killed as named: ${report.outcomes
+          .filter((r) => r.verdict !== "killed")
+          .map((r) => r.name)
+          .join(", ")}`,
+  );
+  return lines.join("\n");
+}

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -23,6 +23,22 @@
 // vitest's `expect` — so those are visible to the runner too. See check-count.ts.
 export { recordCheck } from "./check-count.js";
 
+// --- the tier above the tiers: is a passing test PROVING anything? ---
+// Every tier below reports that a check passed. None can tell a watched assertion
+// from a vacuous one — both print `✓`. `runMutations` plants a defect, runs the
+// test that owns it, and requires the test to fail with the message that NAMES
+// it, so "green" stops being the strongest claim a suite can make about itself.
+export {
+  runMutations,
+  formatMutationReport,
+  type MutationCase,
+  type MutationEdit,
+  type MutationOutcome,
+  type MutationReport,
+  type MutationVerdict,
+  type RunMutationsOptions,
+} from "./mutations.js";
+
 // --- unit tier: runScript (the primitive) + runHook (it, plus a decision) ---
 // `runScript` runs any program and reports what it DID (exit, both streams,
 // writes, egress). `runHook` is that plus the hook protocol: event to stdin,


### PR DESCRIPTION
A green test says the checker passed. It does not say the test would notice if the check were **deleted** — an assertion can be vacuous, a fixture can be wrong in the same direction as the code, and both look exactly like a pass.

`runMutations` plants a defect, runs the test that owns it, and requires that test to go red **with the message that names the defect**.

```ts
import { runMutations, formatMutationReport } from "vigiles/testing";

const report = runMutations({
  cwd: repoRoot,
  cases: [{
    name: "year",
    disables: "the year comparison",
    edits: [[checker, "rec.year !== ourYear", "false"]],
    test: harness,
    expect: "a wrong year was not reported",
  }],
});
console.log(formatMutationReport(report));
```

## Why it belongs in the package rather than in a repo's scripts

It arrived as **ten hand-written copies of one driver** in a dogfooding repo (1799 lines), and the copies had drifted. Counted against the committed versions:

| protection | had it |
|---|---|
| no-op guard (a replacement equal to the original leaves a green test proving nothing) | **4 of 10** |
| retry on a non-kill (a flake reported as a survivor sends the next reader to rewrite a working assertion) | **1 of 10** |
| strict rule: killed by its OWN named assertion, not merely by something going red | **1 of 10** |

Each was written *after* it caught something, in whichever copy happened to catch it, and never travelled to the other nine. Two copies also named a test file a refactor had deleted — and the runner they used exits 0 on a path matching nothing, so those cases reported `SURVIVED` on every run for three days.

## Five verdicts, one of which is proof

`killed` · `wrong-assertion` (a neighbour caught it — two defects share one assertion) · `survived` · `unjudgeable` · `not-applied`.

The **baseline** matters more than it looks. A test can be red *on purpose* — an open finding it exists to report. Without measuring which tests were red before the run, every run announces a failed restore about a working one, and every case against such a test looks killed. That was live, not hypothetical.

## What refuses rather than reports

An empty `cases` list, and a named `test` file that does not exist, both **throw before any file is touched**. A runner with nothing to run reports success, and that is the one claim this API exists to prevent.

It rewrites the files in `edits` and restores them in a `finally` **and** on SIGINT/SIGTERM — an interrupted run must not leave a neutered checker for the next run to measure and call healthy.

## Not Stryker/mutmut/PIT

Those generate mutants from operators over production code and score a suite by kill ratio. Here the mutations are hand-authored and each names the assertion that must catch it — the right shape when the subject is a checker, a hook or an instruction file, where "flip an operator" produces mostly unreachable nonsense. The docs say so explicitly and point at the generated-operator tools for the cases they fit.

## Verification

Gates, in order: `npx vitest run` (2924 passed, 25 skipped) · `npm run lint` (0 errors) · `npx prettier --check .` · `npm run api:check` (additive only — +53 lines to `vigiles-testing`, nothing removed) · `npm run build`.

Ten new tests, each building a real checker and a real test in a temp dir and running them — a mocked runner would be judging a mock. And the runner is mutation-tested against itself: removing the strict-kill rule, the no-op guard, or the existence check each turns the suite red on its own assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Features**
- runMutations — prove a test can fail, by breaking what it watches
<!-- vigiles:pr-summary:end -->
