### PR TITLE
docs: четыре утверждения о собственной публичной поверхности были ложными

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -2,6 +2,15 @@
 
 <!-- vigiles:ignore-file -->
 
+> 🔴 **The import paths below do not exist yet.** Measured 2026-08-16 against the
+> published package: `vigiles/skill` and `vigiles/skill-test` both raise
+> `ERR_PACKAGE_PATH_NOT_EXPORTED`, and `genSkill` / `act` / `checkpoint` /
+> `finish` / `runSkill` are reachable from **no** subpath at all — the generator
+> API is compiled from source by `vigiles compile`, and was never given an entry
+> point. Everything about the SHAPE of a skill below is accurate; the `import`
+> lines are aspirational. Read them as the intended surface, not as working code,
+> until an entry point ships.
+
 vigiles treats an agent **skill** (a `SKILL.md` procedure) the way it treats a `CLAUDE.md`: verify the deterministic parts at author time, enforce them at run time, and leave prose as prose.
 
 A skill has two kinds of content:

--- a/examples/harness/hook-unit.harness.mjs
+++ b/examples/harness/hook-unit.harness.mjs
@@ -15,8 +15,8 @@
  *   npx vigiles test examples/harness/hook-unit.harness.mjs
  *   node examples/harness/hook-unit.harness.mjs        # standalone
  *
- * External users import from the package: `from "vigiles/run-hook"` and
- * `from "vigiles/harness-assert"`.
+ * External users import from the package: `from "vigiles/unit"` and
+ * `from "vigiles/testing"`.
  */
 import { runHook } from "../../dist/run-hook.js";
 import {

--- a/examples/harness/intercept-tools.eval.mjs
+++ b/examples/harness/intercept-tools.eval.mjs
@@ -22,7 +22,7 @@
  *   node examples/harness/intercept-tools.eval.mjs 5     # trials
  *
  * Real model → real cost. Needs the `claude` CLI + model auth and a built dist/.
- * External users import from the package: `from "vigiles/eval"`.
+ * External users import from the package: `from "vigiles/testing"`.
  */
 import { measure, formatCheckReport, assertRates } from "../../dist/eval.js";
 import { toolWith } from "../../dist/check.js";

--- a/examples/harness/oh-my-claudecode-deterministic.harness.mjs
+++ b/examples/harness/oh-my-claudecode-deterministic.harness.mjs
@@ -19,7 +19,7 @@
  *   node examples/harness/oh-my-claudecode-deterministic.harness.mjs   # standalone
  *
  * Needs the `claude` CLI (no API key) and a built dist/. External users import
- * from the package: `from "vigiles/harness-test"`.
+ * from the package: `from "vigiles/integration"`.
  */
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/examples/harness/oh-my-claudecode-egress.harness.mjs
+++ b/examples/harness/oh-my-claudecode-egress.harness.mjs
@@ -14,7 +14,7 @@
  *
  * Needs Linux + bubblewrap (and working user namespaces). Self-skips otherwise —
  * you can't record egress where you can't confine. External users import from the
- * package: `from "vigiles/run-hook"` + `from "vigiles/harness-assert"`.
+ * package: `from "vigiles/unit"` + `from "vigiles/testing"`.
  */
 import { join } from "node:path";
 import { tmpdir } from "node:os";

--- a/examples/harness/oh-my-claudecode-eval.eval.mjs
+++ b/examples/harness/oh-my-claudecode-eval.eval.mjs
@@ -14,7 +14,7 @@
  *
  * Real model → real cost. This is the ONE tier that needs model auth, so it is
  * NOT run in CI (unlike the unit/deterministic tiers above). External users
- * import from the package: `from "vigiles/eval"`.
+ * import from the package: `from "vigiles/testing"`.
  */
 import { fileURLToPath } from "node:url";
 
@@ -49,6 +49,6 @@ const report = await measureTriggerRate({
 console.log(formatTriggerRateReport(report));
 
 // A trigger-rate eval is a measurement; gate it in CI (where auth exists) with
-// assertTriggerRate(report, { min: 0.6 }) from vigiles/harness-assert.
+// assertTriggerRate(report, { min: 0.6 }) from vigiles/testing.
 if (report.n === 0) throw new Error("no runs executed");
 console.log(`\n✓ measured ${report.n} run(s).`);

--- a/examples/harness/oh-my-claudecode-unit.harness.mjs
+++ b/examples/harness/oh-my-claudecode-unit.harness.mjs
@@ -15,7 +15,7 @@
  *   node examples/harness/oh-my-claudecode-unit.harness.mjs        # standalone
  *
  * No `claude` needed. External users import from the package:
- * `from "vigiles/run-hook"`.
+ * `from "vigiles/unit"`.
  */
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/examples/harness/plugin-cohesion.harness.mjs
+++ b/examples/harness/plugin-cohesion.harness.mjs
@@ -15,7 +15,7 @@
  *   node examples/harness/plugin-cohesion.harness.mjs        # standalone
  *
  * Needs the `claude` CLI and a built dist/. External users import from the
- * package: `from "vigiles/harness-test"` and `from "vigiles/harness-assert"`.
+ * package: `from "vigiles/integration"` and `from "vigiles/testing"`.
  */
 import { fileURLToPath } from "node:url";
 import { scriptModel, claudeAvailable } from "../../dist/harness-test.js";

--- a/examples/harness/policy-gate.harness.mjs
+++ b/examples/harness/policy-gate.harness.mjs
@@ -17,7 +17,7 @@
  *   node examples/harness/policy-gate.harness.mjs        # standalone
  *
  * Needs the `claude` CLI and a built dist/ (`npm run build`). External users
- * import from the package instead: `from "vigiles/harness-test"`.
+ * import from the package instead: `from "vigiles/integration"`.
  */
 import {
   runHarnessTest,

--- a/examples/harness/skill-compression.eval.mjs
+++ b/examples/harness/skill-compression.eval.mjs
@@ -34,7 +34,7 @@
  *   node examples/harness/skill-compression.eval.mjs 6      # standalone
  *
  * Real model → real cost. Needs the `claude` CLI + model auth and a built dist/.
- * External users import from the package: `from "vigiles/eval"`.
+ * External users import from the package: `from "vigiles/testing"`.
  *
  * FINDING (2026-06-17, real haiku, 3 trials/arm, on the Pro/Max subscription —
  * apiKeySource:"none", $0.1057 total). The cost-metric capture works end-to-end:

--- a/examples/harness/skill-outcome.eval.mjs
+++ b/examples/harness/skill-outcome.eval.mjs
@@ -17,7 +17,7 @@
  *   node examples/harness/skill-outcome.eval.mjs 6      # standalone
  *
  * Real model → real cost. Needs the `claude` CLI + model auth and a built
- * dist/. External users import from the package: `from "vigiles/eval"`.
+ * dist/. External users import from the package: `from "vigiles/testing"`.
  *
  * Note: this example delivers the arm difference by telling the agent to read a
  * working-dir SKILL.md — the simplest illustration for a prose-only skill. To

--- a/examples/harness/skill-trigger-rate.eval.mjs
+++ b/examples/harness/skill-trigger-rate.eval.mjs
@@ -12,7 +12,7 @@
  *   node examples/harness/skill-trigger-rate.eval.mjs 2     # trials per prompt
  *
  * Real model → real cost. Needs the `claude` CLI + model auth and a built dist/.
- * External users import from the package: `from "vigiles/eval"`.
+ * External users import from the package: `from "vigiles/testing"`.
  */
 import {
   measureTriggerRate,
@@ -56,7 +56,7 @@ const report = await measureTriggerRate({
 console.log(formatTriggerRateReport(report));
 
 // A trigger-rate eval is a measurement, not a hard gate by default — but you can
-// gate in CI with assertTriggerRate(report, { min: 0.6 }) from vigiles/harness-assert.
+// gate in CI with assertTriggerRate(report, { min: 0.6 }) from vigiles/testing.
 if (report.n === 0) {
   throw new Error("no runs executed");
 }

--- a/site/index.html
+++ b/site/index.html
@@ -32,7 +32,7 @@
     <meta property="og:image:height" content="1260" />
     <meta
       property="og:image:alt"
-      content="vigiles — grade your agent harness. A harness report card grading Truthful refs, Triggering, Structure, and Safety."
+      content="vigiles — audit, test and measure your agent harness. A report card grading Truthfulness, Triggering, Structure, Safety and Tested."
     />
     <meta name="twitter:card" content="summary_large_image" />
     <meta

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -10,6 +10,8 @@
  * four tiers). Prefer `vigiles/integration`.
  *
  * NOT here: **evals** (`runEval` / `measure` / `measureTriggerRate` / `judge`) —
- * those are non-deterministic measurement (`vigiles/eval`), a different axis.
+ * those are non-deterministic measurement, a different axis. (They live on
+ * `vigiles/testing`; `vigiles/eval` is named here in the original comment and does
+ * not exist as an entry point.)
  */
 export * from "./integration.js";

--- a/src/harness-assert.ts
+++ b/src/harness-assert.ts
@@ -43,7 +43,8 @@ import {
 } from "./eval-baseline.js";
 
 // Re-export the significance primitives so the whole eval-analysis surface lives
-// behind `vigiles/harness-assert` (no separate entry point).
+// re-exported from `vigiles/testing` (there is no `vigiles/harness-assert` entry
+// point — it was advertised in this very comment and never existed).
 export { compareArms } from "./stats.js";
 export type { Comparison } from "./stats.js";
 export {
@@ -935,7 +936,7 @@ interface MatcherOutput {
  * Custom matchers compatible with both vitest and jest. Register once:
  *
  *   import { expect } from "vitest"; // or "@jest/globals"
- *   import { vigilesMatchers } from "vigiles/harness-assert";
+ *   import { vigilesMatchers } from "vigiles/testing";
  *   expect.extend(vigilesMatchers);
  *
  *   expect(result).toHaveCreated("RESULT");

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -3,7 +3,14 @@
  * the three tiers — `runHook` (unit), `runHarnessTest` (deterministic), `runEval`
  * (eval) — plus the runner-agnostic predicates/assertions. Kept deliberately
  * separate from `vigiles/claude-code` so this surface can stay harness-agnostic as
- * more harnesses are added. Granular paths (`vigiles/run-hook`, etc.) still work.
+ * more harnesses are added.
+ *
+ * 🔴 THIS LINE USED TO SAY the granular paths (`vigiles/run-hook`, etc.) «still
+ * work». MEASURED 2026-08-16: they do not. `vigiles/run-hook`, `vigiles/eval`,
+ * `vigiles/harness-test`, `vigiles/harness-assert`, `vigiles/skill` and
+ * `vigiles/skill-test` all raise ERR_PACKAGE_PATH_NOT_EXPORTED — six paths this
+ * package advertised to its own readers and does not serve. A promise that an
+ * import keeps working is exactly the kind a reader has no reason to re-check.
  *
  * It re-exports the composition-root runner modules (which do the Claude-Code
  * default-wiring), never an adapter directly — the `agnostic-surface` eslint

--- a/src/unit.ts
+++ b/src/unit.ts
@@ -1,8 +1,23 @@
 /**
  * `vigiles/unit` — the **no-capability** harness-testing surface.
  *
- * Importing from here is a contract: this test needs **no `claude`, no model, no
- * bubblewrap, no network** — only a process. It is the cheap base of the pyramid:
+ * Importing from here is MOSTLY a contract: this test needs no `claude`, no
+ * bubblewrap and no network — only a process. It is the cheap base of the pyramid:
+ *
+ * 🔴 «NO MODEL» IS NOT TRUE TODAY, AND SAYING SO WAS THE WORST OF THE FOUR
+ * MISSTATEMENTS ON THIS SURFACE, because it reads as a guarantee rather than a
+ * description. `judged` is re-exported here and its default judge is a REAL model
+ * call — `check.ts` resolves `opts.judge ?? ((o) => runJudge(o))`. So a test that
+ * imports only from this barrel can still spend money, and the one line a reader
+ * would rely on to know it cannot is this one.
+ *
+ * The honest fix is to MOVE `judged` off this barrel, not to reword the sentence —
+ * but that changes the public surface, and the surface is being reorganised
+ * separately (the measured proposal splits by COST: everything free on one path,
+ * everything that spends money on another, where this defect becomes unexpressible
+ * rather than merely documented). Until that lands, the claim is corrected here
+ * rather than left standing.
+ *
  * `runHook` (pipe a synthesized event to a hook and read the block/allow
  * decision), the bare `Trace` predicates, the `assert*` helpers, and the pure
  * parsers. A `*.test.ts` should import **only** from here (enforced by lint).


### PR DESCRIPTION
Четыре утверждения пакета о **собственной** публичной поверхности оказались ложными. Все четыре проверены командой, не чтением.

## 1. Шесть subpath'ов, которые пакет рекламирует сам себе и не обслуживает

```
vigiles/eval             ERR_PACKAGE_PATH_NOT_EXPORTED
vigiles/run-hook         ERR_PACKAGE_PATH_NOT_EXPORTED
vigiles/harness-test     ERR_PACKAGE_PATH_NOT_EXPORTED
vigiles/harness-assert   ERR_PACKAGE_PATH_NOT_EXPORTED
vigiles/skill            ERR_PACKAGE_PATH_NOT_EXPORTED
vigiles/skill-test       ERR_PACKAGE_PATH_NOT_EXPORTED
```

Они стояли в комментариях **одиннадцати** файлов `examples/` (в форме «External users import from the package: …»), в докстринге `harness-assert.ts` как готовый пример импорта, и в `e2e.ts` — который сам объясняет депрекейт и по дороге называет несуществующий путь.

## 2. `src/testing.ts` утверждал, что эти пути «still work»

Обещание, что импорт **продолжает** работать, — ровно то, что читатель не станет перепроверять.

## 3. `vigiles/unit` обещает «no `claude`, no model, no bubblewrap, no network»

Из четырёх верны три. `judged` ре-экспортируется отсюда, а его судья по умолчанию — реальный вызов модели:

```ts
// check.ts:571
const judgeFn: JudgeFn = opts.judge ?? ((o) => runJudge(o));
```

Тест, импортирующий **только** из этого барреля, может тратить деньги — и единственная строка, по которой читатель заключил бы обратное, это она. Опаснее прочих трёх, потому что читается как **гарантия**, а не как описание.

Честная починка — увезти `judged` с барреля. Но это правка публичной поверхности, а она пересматривается отдельно (замеренное предложение режет по **стоимости**, и там этот дефект становится невыразимым, а не задокументированным). До тех пор утверждение исправлено, а не оставлено стоять.

## 4. `docs/skills.md` учит импортировать то, чего нет нигде

```ts
import { act, checkpoint, finish } from "vigiles/skill";
import { runSkill, scriptModel } from "vigiles/skill-test";
```

`genSkill` / `act` / `checkpoint` / `finish` / `runSkill` не экспортируются **ни из одного** subpath — проверено перебором всех. Генераторный API компилируется из исходника командой `vigiles compile`, и точки входа ему не завели.

Форма скилла в документе описана **верно** — неверны строки `import`. Документ теперь говорит это сам, вместо того чтобы молча не работать.

## Плюс превью сайта

`site/index.html` — alt-текст og-карточки называл показатель **«Truthful refs»**, которого у продукта нет (`src/audit-score.ts`: `Truthfulness · Triggering · Structure · Safety · Tested`). Инструмент, ловящий расхождение прозы с механикой, показывал в собственном превью несуществующее имя своего же показателя.

⚠️ Сама картинка `og.png` несёт то же неверное кольцо и **этим PR не перерисована** — нужен ре-рендер.

## Гейты, поимённо и в порядке

| # | команда | результат |
|---|---|---|
| 1 | `npx vitest run` | ✅ 2926 passed, 173 файла |
| 2 | `npm run lint` | ✅ 0 errors |
| 3 | `npx prettier --check .` | ✅ |
| 4 | `npm run api:check` | ✅ no drift |
| 5 | `npm run build` | ✅ |

Правок публичного API нет — только правдивость того, что о нём написано.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Docs**
- четыре утверждения о собственной публичной поверхности были ложными
<!-- vigiles:pr-summary:end -->
