### PR TITLE
docs: два примера импортируют символ не из того сабпаса — оба падают на копипасте

### DIFF
--- a/docs/harness-testing-claude-code.md
+++ b/docs/harness-testing-claude-code.md
@@ -252,7 +252,8 @@ order and renders the Anthropic Messages SSE shape `claude` expects.
 
 ```ts
 import { test } from "node:test";
-import { withHarness, assertCreated, scriptModel } from "vigiles/testing";
+import { withHarness, assertCreated } from "vigiles/testing";
+import { scriptModel } from "vigiles/claude-code";
 
 test("Stop hook forces more work", async () => {
   await withHarness(

--- a/docs/testing-api.md
+++ b/docs/testing-api.md
@@ -133,8 +133,8 @@ import {
   assertHookAllows,
   assertHookNotices,
   assertHookSilent,
-  runHookProgram,
 } from "vigiles/testing";
+import { runHookProgram } from "vigiles/hook";
 
 // loadHook takes the hook's PATH — what a .harness.mjs file actually has. It is
 // the same loader the runtime uses, and it handles a .hook.ts under tsx / Node


### PR DESCRIPTION
Два примера в доках импортируют символ не из того subpath'а. Читатель копирует блок целиком — и оба падают на первой строке.

Подтверждено вызовом, не чтением:

```
scriptModel:     vigiles/testing → undefined,  vigiles/claude-code → function
runHookProgram:  vigiles/testing → undefined,  vigiles/hook        → function
```

| файл | было |
|---|---|
| `docs/harness-testing-claude-code.md:253` | `import { withHarness, assertCreated, scriptModel } from "vigiles/testing"` |
| `docs/testing-api.md:181` | `runHookProgram` в списке импорта из `vigiles/testing` |

## 🔴 Про `scriptModel` это третий раз

Тот же неверный импорт **дважды** записан в приватной базе знаний — один раз как найденный дефект, второй раз как починенный в скилле. Оба раза с пометкой, что **граница намеренная**: `scriptModel` живёт в адаптере Claude Code, а не в харнесс-агностичном барреле.

Правило было известно, задокументировано, процитировано — и третий экземпляр всё равно уехал в публичные доки.

Ровно тот класс, который проза не удерживает: граница верная, документация о границе верная, а конкретная строка импорта — нет.

Найдено ресёрчем по инструментам проверки фенсов (`vigiles/ideas/19`, приватно). Механическая проверка предложена там; **этот PR закрывает два известных экземпляра, а не класс.**

## Гейты

`npx prettier --check docs/` ✅ · `npm run lint` ✅ 0 errors. Правок кода нет — только две строки импорта в примерах.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Docs**
- два примера импортируют символ не из того сабпаса — оба падают на копипасте
<!-- vigiles:pr-summary:end -->
