### PR TITLE
ci: проверять, что примеры в доках импортируют существующее

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,6 +348,33 @@ jobs:
       - name: Check generated types compile
         run: node dist/cli.js generate types && npx tsc --noEmit
 
+      # Do the TypeScript examples in the docs still import things that exist?
+      #
+      # Nothing checked this before 2026-08-16, and on that day the docs carried SIX package
+      # subpaths that raise ERR_PACKAGE_PATH_NOT_EXPORTED, plus two examples importing a real
+      # symbol from the wrong barrel — `scriptModel` (it lives in `vigiles/claude-code`) and
+      # `runHookProgram` (`vigiles/hook`). All copy-pasteable, all broken on the reader's first
+      # line. `scriptModel` was the THIRD occurrence of the same wrong import, twice previously
+      # written down as a known boundary. Prose did not hold it; this does.
+      #
+      # 🔴 IT REPORTS ONLY THIS PACKAGE'S OWN MODULE SURFACE, AND THAT NARROWNESS IS THE WHOLE
+      # DESIGN. Measured over this repo's 102 ts/js blocks: full `tsc` on every block — the
+      # DEFAULT of all three off-the-shelf tools — yields 234 findings, 2 real and 232 false,
+      # because only 36.3% of blocks are self-contained; the rest are illustrative fragments with
+      # free variables. This gate yields 2 of 2, with no suppression markers anywhere. A checker
+      # that fires on legitimate input is muted within a week, so a tool with a 1:24 noise ratio
+      # is not a stricter version of this one — it is a dead one.
+      #
+      # Rust's doctests take the opposite route (compile everything, opt OUT with `ignore`); here
+      # that would mean ~65 suppression markers on day one, visible to every reader on GitHub.
+      # Inverting it costs nothing and makes the false positive unrepresentable rather than filtered.
+      # Opt IN to a full type-check per block with `<!-- vigiles:check -->` above the fence.
+      #
+      # Resolution needs no path rewriting: TypeScript resolves the package to itself through the
+      # `exports` map (self-reference), so a phantom subpath is an ordinary TS2307.
+      - name: Check doc imports
+        run: npm run docs:check
+
       - name: Lint
         run: npm run lint
 

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "test:types": "npm run build && tsc --noEmit -p test/types/tsconfig.json",
     "api:report": "npm run build && node scripts/api-extractor.mjs --local",
     "api:check": "npm run build && node scripts/api-extractor.mjs",
+    "docs:check": "npm run build && node scripts/check-doc-imports.mjs . docs README.md",
     "docs:api": "typedoc"
   },
   "devDependencies": {

--- a/scripts/check-doc-imports.mjs
+++ b/scripts/check-doc-imports.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * check-docs.mjs — type-check the TypeScript examples in the docs against THIS
+ * repo's own build, with two tiers:
+ *
+ *   GATE 1 (always, every ts block): report ONLY diagnostics about this package's
+ *           own module surface — a subpath that is not in the exports map, or a
+ *           named import the built package does not export. Free variables,
+ *           partial snippets and deliberate type errors are invisible to it, so
+ *           an illustrative fragment cannot make it fire.
+ *   GATE 2 (opt-in, block marked `<!-- vigiles:check -->`): full tsc diagnostics.
+ *
+ * No network. No new CLI verb. Resolution is TypeScript's own package
+ * self-reference: `import ... from "vigiles/testing"` resolves through this
+ * package.json's `exports` map to the local ./dist.
+ */
+import {
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { createRequire } from "node:module";
+
+const ROOT = resolve(process.argv[2] ?? ".");
+const req = createRequire(join(ROOT, "package.json"));
+const ts = req("typescript");
+const MarkdownIt = req("markdown-it");
+const md = new MarkdownIt();
+const PKG = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8")).name;
+
+const LANGS = new Set(["ts", "typescript", "tsx"]);
+const IGNORE_FILE = /<!--\s*vigiles:ignore-file\s*-->/;
+const IGNORE = /<!--\s*vigiles:ignore\s*-->/;
+const CHECK = /<!--\s*vigiles:check\s*-->/;
+
+function mdFiles(dir, out = []) {
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    if (["node_modules", ".git", "dist"].includes(e.name)) continue;
+    const p = join(dir, e.name);
+    if (e.isDirectory()) mdFiles(p, out);
+    else if (e.name.endsWith(".md")) out.push(p);
+  }
+  return out;
+}
+
+const targets = [];
+for (const arg of process.argv.slice(3).length
+  ? process.argv.slice(3)
+  : ["docs", "README.md"]) {
+  const p = join(ROOT, arg);
+  try {
+    statSync(p).isDirectory() ? mdFiles(p, targets) : targets.push(p);
+  } catch {}
+}
+targets.sort();
+
+const WORK = join(ROOT, ".doccheck-tmp");
+rmSync(WORK, { recursive: true, force: true });
+mkdirSync(WORK, { recursive: true });
+
+const blocks = [];
+for (const f of targets) {
+  const src = readFileSync(f, "utf8");
+  if (IGNORE_FILE.test(src)) continue;
+  const lines = src.split("\n");
+  for (const t of md.parse(src, {})) {
+    if (t.type !== "fence") continue;
+    if (!LANGS.has((t.info || "").trim().split(/\s+/)[0])) continue;
+    // look at the two source lines above the fence for a marker
+    const above = lines.slice(Math.max(0, t.map[0] - 3), t.map[0]).join("\n");
+    if (IGNORE.test(above)) continue;
+    const full = CHECK.test(above);
+    const id = `b${String(blocks.length).padStart(3, "0")}`;
+    const file = join(WORK, `${id}.ts`);
+    writeFileSync(
+      file,
+      t.content.endsWith("\n") ? t.content : t.content + "\n",
+    );
+    blocks.push({ file, doc: relative(ROOT, f), line: t.map[0] + 1, full });
+  }
+}
+
+const program = ts.createProgram(
+  blocks.map((b) => b.file),
+  {
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.Node16,
+    moduleResolution: ts.ModuleResolutionKind.Node16,
+    strict: true,
+    skipLibCheck: true,
+    noEmit: true,
+    esModuleInterop: true,
+    noUnusedLocals: false,
+    noUnusedParameters: false,
+    types: ["node"],
+    typeRoots: [join(ROOT, "node_modules", "@types")],
+  },
+);
+
+// Gate-1 codes: the module surface of THIS package only.
+const OWN_MODULE = new RegExp(`['"\`]${PKG}(/[^'"\`]*)?['"\`]`);
+const SURFACE = new Set([
+  2307, // Cannot find module 'X' or its corresponding type declarations
+  2305, // Module 'X' has no exported member 'Y'
+  2724, // 'X' has no exported member named 'Y'. Did you mean 'Z'?
+  2614, // Module 'X' has no exported member 'Y'. Did you mean to use 'import Y from'?
+]);
+
+let findings = 0;
+for (const b of blocks) {
+  const sf = program.getSourceFile(b.file);
+  const diags = b.full
+    ? [
+        ...program.getSyntacticDiagnostics(sf),
+        ...program.getSemanticDiagnostics(sf),
+      ]
+    : program.getSemanticDiagnostics(sf).filter((d) => {
+        if (!SURFACE.has(d.code)) return false;
+        const msg = ts.flattenDiagnosticMessageText(d.messageText, " ");
+        return OWN_MODULE.test(msg);
+      });
+  for (const d of diags) {
+    const { line, character } = sf.getLineAndCharacterOfPosition(d.start ?? 0);
+    console.log(
+      `${b.doc}:${b.line} (block line ${line + 1}:${character + 1}) TS${d.code}: ` +
+        ts.flattenDiagnosticMessageText(d.messageText, " ") +
+        (b.full ? "  [vigiles:check]" : ""),
+    );
+    findings++;
+  }
+}
+rmSync(WORK, { recursive: true, force: true });
+console.log(
+  `\nblocks scanned: ${blocks.length}  (full-check: ${blocks.filter((b) => b.full).length})`,
+);
+console.log(`findings: ${findings}`);
+process.exit(findings ? 1 : 0);

--- a/scripts/check-doc-imports.test.ts
+++ b/scripts/check-doc-imports.test.ts
@@ -1,0 +1,218 @@
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { execFileSync } from "node:child_process";
+import { describe, it, expect, afterAll } from "vitest";
+
+/**
+ * Tests for `scripts/check-doc-imports.mjs` — the gate that reads TypeScript examples in the
+ * docs and reports imports of this package's own module surface that do not resolve.
+ *
+ * 🔴 EVERY CASE HERE HAS BOTH HALVES: it fires on a planted defect AND it is silent on the
+ * legitimate input next door. A gate whose success looks like silence cannot be noticed broken,
+ * so "silent" alone is indistinguishable from dead — this repository has shipped three checks
+ * that were dead on arrival, and each was found by accident.
+ *
+ * The false-positive cases are the load-bearing ones. The measured reason this gate exists in
+ * this narrow shape rather than as a full type-check is that only 36.3% of the real corpus is
+ * self-contained; the illustrative fragments below are what a full `tsc` would fire on, 232
+ * times, and what mutes a checker within a week.
+ */
+
+const REPO = resolve(import.meta.dirname, "..");
+const SCRIPT = join(REPO, "scripts", "check-doc-imports.mjs");
+const roots: string[] = [];
+
+/** A throwaway package that self-references through its own `exports` map, like vigiles does. */
+function fixture(docBody: string): string {
+  const root = mkdtempSync(join(tmpdir(), "doc-import-check-"));
+  roots.push(root);
+  mkdirSync(join(root, "dist"), { recursive: true });
+  mkdirSync(join(root, "docs"), { recursive: true });
+  writeFileSync(
+    join(root, "package.json"),
+    JSON.stringify({
+      name: "demo-pkg",
+      version: "0.0.0",
+      type: "commonjs",
+      exports: { "./real": "./dist/real.js" },
+    }),
+  );
+  writeFileSync(join(root, "dist", "real.js"), "exports.greet = () => {};\n");
+  writeFileSync(
+    join(root, "dist", "real.d.ts"),
+    "export declare function greet(name: string): void;\n",
+  );
+  // The script resolves `typescript` and `markdown-it` from the target package, so borrow ours.
+  symlinkSync(join(REPO, "node_modules"), join(root, "node_modules"), "dir");
+  writeFileSync(join(root, "docs", "guide.md"), docBody);
+  return root;
+}
+
+function run(root: string): { code: number; out: string } {
+  try {
+    return {
+      code: 0,
+      out: execFileSync("node", [SCRIPT, root, "docs"], { encoding: "utf8" }),
+    };
+  } catch (e) {
+    const err = e as { status?: number; stdout?: string };
+    return { code: err.status ?? 1, out: err.stdout ?? "" };
+  }
+}
+
+const fence = (body: string, marker = "") =>
+  `${marker}\n\`\`\`ts\n${body}\n\`\`\`\n`;
+
+afterAll(() => {
+  for (const r of roots) rmSync(r, { recursive: true, force: true });
+});
+
+describe("check-doc-imports", () => {
+  it("FIRES on a subpath the exports map does not serve", () => {
+    const { code, out } = run(
+      fixture(fence(`import { greet } from "demo-pkg/phantom";\ngreet("x");`)),
+    );
+    expect(out).toContain("TS2307");
+    expect(out).toContain("demo-pkg/phantom");
+    expect(code).toBe(1);
+  });
+
+  it("FIRES on a named import the package does not export", () => {
+    const { code, out } = run(
+      fixture(
+        fence(
+          `import { greet, nope } from "demo-pkg/real";\ngreet("x");\nnope();`,
+        ),
+      ),
+    );
+    expect(out).toContain("TS2305");
+    expect(out).toContain("nope");
+    expect(code).toBe(1);
+  });
+
+  it("is SILENT on an import that resolves", () => {
+    const { code, out } = run(
+      fixture(fence(`import { greet } from "demo-pkg/real";\ngreet("x");`)),
+    );
+    expect(out).toContain("findings: 0");
+    expect(code).toBe(0);
+  });
+
+  // ── the false-positive half: what a full type-check would fire on and this must not ──
+
+  it("is SILENT on an illustrative fragment with free variables", () => {
+    // Two thirds of the real corpus looks like this. A gate that fires here is muted in a week.
+    const { code } = run(
+      fixture(
+        fence(`const report = runEval(config);\nconsole.log(report.mean);`),
+      ),
+    );
+    expect(code).toBe(0);
+  });
+
+  it("is SILENT on a deliberate type error in a non-own-surface call", () => {
+    const { code } = run(
+      fixture(fence(`import { greet } from "demo-pkg/real";\ngreet(42);`)),
+    );
+    expect(code).toBe(0);
+  });
+
+  // 🔴 THE TWO CASES BELOW PIN THE TWO FILTER HALVES, ONE EACH, AND THEY EXIST BECAUSE THE FIRST
+  // VERSION OF THIS SUITE DID NOT. Mutating either half — dropping the diagnostic-code allowlist,
+  // or dropping the "message names OUR package" test — left all ten tests GREEN, because the
+  // fragments above trip BOTH filters independently and so cannot tell them apart. A green
+  // mutation is a finding about the test, not a verdict on the checker.
+  //
+  // Both cases are transcribed from what the real corpus actually contains, measured by turning
+  // each half off and reading what came through:
+  //   own-package filter off → 3 findings, all `import … from "./my-harness-adapter.js"`
+  //   diagnostic-code filter off → 1 finding, TS2664 in a `declare module` augmentation
+
+  it("is SILENT on a RELATIVE import the doc invents for the example", () => {
+    // TS2307 — the same code a phantom subpath produces — but about someone else's module.
+    // Three real blocks in docs/adapter-api.md and docs/authoring-an-adapter.md do exactly this.
+    // Pins: the "message names our package" half. Dropping it turns these three into findings.
+    const { code, out } = run(
+      fixture(
+        fence(
+          `import { adapter } from "./my-harness-adapter.js";\nvoid adapter;`,
+        ),
+      ),
+    );
+    expect(out).toContain("findings: 0");
+    expect(code).toBe(0);
+  });
+
+  it("is SILENT on a module augmentation naming a generated module", () => {
+    // TS2664, which NAMES our package and so passes the own-package half — only the
+    // diagnostic-code allowlist stops it. `docs/linter-support.md` documents exactly this
+    // augmentation against `vigiles/generated`, a module that exists only after codegen.
+    // Pins: the allowlist half. Dropping it turns that block into a finding.
+    const { code, out } = run(
+      fixture(
+        fence(
+          `declare module "demo-pkg/generated" {\n  export const x: number;\n}`,
+        ),
+      ),
+    );
+    expect(out).toContain("findings: 0");
+    expect(code).toBe(0);
+  });
+
+  it("is SILENT on a block that is not TypeScript", () => {
+    const root = fixture("```sh\nnpm install demo-pkg/phantom\n```\n");
+    expect(run(root).code).toBe(0);
+  });
+
+  // ── the markers ──
+
+  it("`vigiles:check` OPTS IN to the full type-check, catching what gate 1 ignores", () => {
+    const { code, out } = run(
+      fixture(
+        fence(
+          `import { greet } from "demo-pkg/real";\ngreet(42);`,
+          "<!-- vigiles:check -->",
+        ),
+      ),
+    );
+    expect(out).toContain("TS2345"); // Argument of type 'number' is not assignable to 'string'
+    expect(out).toContain("[vigiles:check]");
+    expect(code).toBe(1);
+  });
+
+  it("`vigiles:ignore` exempts ONE block and nothing after it", () => {
+    const body =
+      fence(
+        `import { greet } from "demo-pkg/phantom";`,
+        "<!-- vigiles:ignore -->",
+      ) + fence(`import { greet } from "demo-pkg/gone";`);
+    const { out } = run(fixture(body));
+    expect(out).not.toContain("demo-pkg/phantom");
+    expect(out).toContain("demo-pkg/gone"); // the exemption did not leak to the next block
+  });
+
+  it("`vigiles:ignore-file` exempts the whole file", () => {
+    const body =
+      "<!-- vigiles:ignore-file -->\n" +
+      fence(`import { greet } from "demo-pkg/phantom";`);
+    expect(run(fixture(body)).code).toBe(0);
+  });
+
+  // ── the failure mode that would make it green and dead ──
+
+  it("counts the blocks it scanned, so a glob that matches nothing is VISIBLE", () => {
+    // A run over zero blocks exits 0 — identical to a clean run. The count is the only thing
+    // that tells the two apart, which is why it is printed rather than kept internal.
+    const { out } = run(
+      fixture(fence(`import { greet } from "demo-pkg/real";`)),
+    );
+    expect(out).toMatch(/blocks scanned: [1-9]/);
+  });
+});

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -26,7 +26,10 @@ export default defineConfig({
         test: {
           ...sourceTier.test,
           name: "unit",
-          include: ["src/**/*.test.ts"],
+          // `scripts/` is in scope on purpose: `check-doc-imports.mjs` is a CI gate, and a gate
+          // with no test is the shape this repo has shipped dead three times. Its test lives
+          // beside it (colocation), so the glob has to reach outside `src/`.
+          include: ["src/**/*.test.ts", "scripts/**/*.test.ts"],
           exclude: [
             ...configDefaults.exclude,
             "src/**/*.integration.test.ts",


### PR DESCRIPTION
Примеры в доках никто не проверял. 16.08 они несли **шесть** subpath'ов, дающих `ERR_PACKAGE_PATH_NOT_EXPORTED`, плюс два примера с настоящим символом не из того барреля — `scriptModel` (живёт в `vigiles/claude-code`) и `runHookProgram` (`vigiles/hook`). Всё копипастится целиком и падает на первой строке читателя.

Про `scriptModel` это был **третий** экземпляр одного и того же неверного импорта, дважды до того записанного как известная граница. Проза не удержала.

## 🔴 Докладывает только собственную модульную поверхность — и эта узость есть весь дизайн

Замер по **102** ts/js-блокам этого репо:

| режим | находок | настоящих | ложных |
|---|---:|---:|---:|
| полный `tsc` на каждом блоке — **дефолт всех трёх готовых инструментов** | **234** | 2 | **232** |
| только модульная поверхность своего пакета — **этот шаг** | **2** | **2** | **0** |

Причина: самодостаточны лишь **36,3%** блоков, остальные — иллюстративные фрагменты со свободными переменными. Инструмент с шумом **1:24** — не более строгая версия этого, а **мёртвая**: проверку, срабатывающую на нормальном входе, глушат за неделю.

Rust идёт обратным путём (компилировать всё, отписываться `ignore`) — у нас это **~65 маркеров подавления в первый же день**, видимых каждому читателю на GitHub. Инверсия стоит ноль и делает ложное срабатывание **невыразимым**, а не отфильтрованным. Сейчас в репозитории **ни одного** маркера подавления.

Полный тайпчек блока — opt-in через `<!-- vigiles:check -->` над фенсом.

Резолвинг бесплатный: TypeScript резолвит пакет **сам на себя** через `exports`, поэтому фантомный subpath — обычный `TS2307`. Ни переписывания путей, ни сети.

## Мутационный прогон вскрыл дефект в самих тестах — это важнее самой проверки

Первая версия: 10 тестов, все зелёные. Снял одну половину фильтра — **зелёные**. Снял вторую — **зелёные**. Патч при этом ложился (проверено грепом).

Находка **о тесте**, а не вывод о проверке: иллюстративные фрагменты спотыкались об **обе** половины независимо и различить их не могли. Замерил, что каждая держит на реальном корпусе:

| выключен фильтр | что прорывается |
|---|---|
| «сообщение называет наш пакет» | 3× `import … from "./my-harness-adapter.js"` — придуманный для примера **относительный** путь |
| «коды модульной поверхности» | 1× `TS2664` в `declare module "vigiles/generated"` — модуль, существующий только после кодогенерации |

Оба случая переписаны в тесты **дословно с корпуса**. Теперь каждая мутация падает на **своём** ассерте:

```
мутация SURFACE     → × is SILENT on a module augmentation naming a generated module
мутация OWN_MODULE  → × is SILENT on a RELATIVE import the doc invents for the example
чистый прогон       → 12 passed
```

## Что ещё изменено

`vitest.config.mjs` — include расширён на `scripts/**`. Без этого тест самого гейта **не запускался бы вообще** — ровно та форма, которой в этом проекте уже трижды были мёртвые проверки.

## Гейты, поимённо и в порядке

| # | команда | результат |
|---|---|---|
| 1 | `npx vitest run` | ✅ 2928 passed, 173 файла |
| 2 | `npm run lint` | ✅ 0 errors |
| 3 | `npx prettier --check .` | ✅ |
| 4 | `npm run api:check` | ✅ no drift |
| 5 | `npm run build` | ✅ |

Новых CLI-глаголов нет — `npm run docs:check` + шаг в существующем джобе.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**CI**
- проверять, что примеры в доках импортируют существующее
<!-- vigiles:pr-summary:end -->
