### PR TITLE
docs: surface the docs from the landing page

### DIFF
--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -5,6 +5,7 @@ import { Wedge } from "@/components/sections/Wedge";
 import { VerbMap } from "@/components/sections/VerbMap";
 import { Adoption } from "@/components/sections/Adoption";
 import { FAQ } from "@/components/sections/FAQ";
+import { Docs } from "@/components/sections/Docs";
 import { CTA } from "@/components/sections/CTA";
 import { Footer } from "@/components/Footer";
 
@@ -18,6 +19,7 @@ export function App() {
         <VerbMap />
         <Adoption />
         <FAQ />
+        <Docs />
         <CTA />
         <Footer />
       </main>

--- a/site/src/components/sections/Docs.tsx
+++ b/site/src/components/sections/Docs.tsx
@@ -1,0 +1,107 @@
+import { ArrowUpRight, ArrowRight } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+
+/** The docs are plain markdown in the repo — there is no separate docs site, so
+ *  every link here points at GitHub's rendered blob. Deliberately NOT the whole
+ *  index (31 files): a list of everything is as useless to a first-time reader as
+ *  no list at all. These six are the entry points — the ones the README leans on
+ *  most, one per thing the landing page has already promised (grade it, run it,
+ *  measure it, set it up). "Browse all docs" below carries the rest. */
+const DOCS = "https://github.com/zernie/vigiles/blob/main/docs";
+
+const LINKS: { title: string; file: string; blurb: string }[] = [
+  {
+    title: "What it catches",
+    file: "what-vigiles-catches.md",
+    blurb:
+      "The full list of harness problems, biggest first — and which of them a typed spec makes impossible to write in the first place.",
+  },
+  {
+    title: "Which command to run",
+    file: "commands-and-how-they-relate.md",
+    blurb:
+      "The map behind the four verbs above: when to reach for audit, lint, test or eval, and why measuring skills starts with init.",
+  },
+  {
+    title: "Verify your instructions",
+    file: "verifying-instruction-files.md",
+    blurb:
+      "The lint layer end to end — how every file, script, symbol and rule your CLAUDE.md names gets checked against your real config.",
+  },
+  {
+    title: "Test hooks and skills",
+    file: "harness-testing.md",
+    blurb:
+      "Pick what you want to prove — a hook really blocks, a skill really fires — and copy the first test for it. No API key.",
+  },
+  {
+    title: "Measure whether it helps",
+    file: "measuring-skills.md",
+    blurb:
+      "A/B a skill, plugin, rule or model change on real coding tasks and get the number, on your own subscription instead of a metered API.",
+  },
+  {
+    title: "Set it up in your repo",
+    file: "agent-setup.md",
+    blurb:
+      "What npx vigiles init writes, the per-agent recipes (Claude Code, Codex, Cursor), and wiring the CI gate.",
+  },
+];
+
+export function Docs() {
+  return (
+    <section id="docs" className="scroll-mt-8 border-t border-border">
+      <div className="mx-auto w-full max-w-4xl px-6 py-20 sm:py-28">
+        <div className="mx-auto max-w-2xl text-center">
+          <Badge className="mb-5">Docs</Badge>
+          <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
+            The rest is written down.
+          </h2>
+          <p className="mt-4 text-lg leading-relaxed text-muted-foreground">
+            The documentation is markdown in the repo — one source of truth, no
+            second site to drift out of sync. Start with the line that matches
+            what you&apos;re trying to do.
+          </p>
+        </div>
+
+        {/* Type + dividers, same as the verb map — a link list, not six cards. */}
+        <div className="mx-auto mt-12 max-w-3xl divide-y divide-border border-y border-border">
+          {LINKS.map((d) => (
+            <a
+              key={d.file}
+              href={`${DOCS}/${d.file}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group grid gap-1 py-4 no-underline sm:grid-cols-[13rem_1fr] sm:gap-x-6"
+            >
+              {/* The arrow rides the last word (inline, not a flex sibling) so a
+                  title that wraps at a narrow width doesn't strand it mid-block. */}
+              <span className="text-sm font-semibold text-foreground transition-colors group-hover:text-accent">
+                {d.title}
+                <ArrowUpRight
+                  className="ml-1 inline-block h-3.5 w-3.5 align-[-0.1em] text-muted-foreground transition-colors group-hover:text-accent"
+                  aria-hidden
+                />
+              </span>
+              <span className="text-sm leading-relaxed text-muted-foreground">
+                {d.blurb}
+              </span>
+            </a>
+          ))}
+        </div>
+
+        <div className="mt-10 text-center">
+          <a
+            href={`${DOCS}/README.md`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 text-base font-semibold text-accent no-underline transition-colors hover:text-accent/80"
+          >
+            Browse all docs
+            <ArrowRight className="h-4 w-4" aria-hidden />
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/site/src/components/sections/Hero.tsx
+++ b/site/src/components/sections/Hero.tsx
@@ -25,6 +25,14 @@ export function Hero() {
           >
             Grade a repo
           </a>
+          {/* The docs are a directory away and used to be unreachable from the
+              top of the page — a visitor who wanted detail had to guess. */}
+          <a
+            href="#docs"
+            className="hidden text-sm font-medium text-muted-foreground no-underline transition-colors hover:text-foreground sm:inline"
+          >
+            Docs
+          </a>
           <a
             href={REPO}
             target="_blank"


### PR DESCRIPTION
## What and why

The repo ships **31 markdown docs / 7240 lines**. The landing page reached two of them, both below the fold (`Footer.tsx`, `FAQ.tsx`), so a visitor arriving at the top had no path into the documentation at all.

Adds a `Docs` section between FAQ and CTA plus a top-nav entry, linking six entry-point docs and a "browse all". Which six was decided from evidence, not taste — link counts from `README.md` plus the role each doc plays in `docs/README.md`, weighted toward the verbs the headline promises (*audit, test and measure*):

| Doc | Why |
|---|---|
| `what-vigiles-catches.md` | 3 README links; the docs index's "Explanation" entry point |
| `verifying-instruction-files.md` | 3 links; the docs index calls it the lint layer's master guide |
| `harness-testing.md` | 2 links; serves *test* |
| `measuring-skills.md` | 2 links; serves *measure*, and the only doc for the eval tier |
| `agent-setup.md` | the only doc for what `npx vigiles init` writes — what the Adoption section leaves the reader wanting |
| `commands-and-how-they-relate.md` | the mental model behind VerbMap's "One tool. Four questions." |

Deliberately excluded: `faq.md` (already linked from the FAQ tail), `comparison.md` (answered inline in the FAQ), `harnesses.md` / `for-plugin-authors.md` (audience-specific, not entry points). A "Browse all docs" link carries the other 25.

Links target GitHub's rendered markdown, checked against the alternatives first: no `gh-pages` branch, `homepage` points at the README, and `pages.yml` publishes only the landing at `/` and TypeDoc at `/api/` — the prose docs are published nowhere else. All seven targets verified to exist on disk.

No new design tokens and no new CSS: reuses `Badge`, the existing section shell, and VerbMap's divider list. The site is dark-only by declaration (`site/src/index.css`), so there is no light palette to preserve.

## Safety impact

None. Static links in the marketing site.

## Checks

- [x] `npm test` passes locally — 2928 passed, 24 skipped
- [x] Verified in the **built** output, since none of the repo-root gates touch the landing bundle: the six filenames and the base URL are present in `site/dist/assets/index-*.js`, and a headless render of the built page returned exactly the seven expected hrefs
- [x] `site/e2e/mobile.spec.ts` (390px, the repo's own no-horizontal-overflow gate) passes
- [x] Docs updated — n/a, this only links existing docs

`npx vitest run` ✓ · `npm run lint` 0 errors · `npx prettier --check .` ✓ · `npm run api:check` no drift · `npm run build` ✓ · `npm run docs:check` 0 · `npm run build --workspace @vigiles/site` ✓

Note for future work: the `og:image:alt` "Truthful refs" defect was confirmed real but **already fixed** on `main` in #144 — nothing left to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Features**
- give the landing page a way into the docs
<!-- vigiles:pr-summary:end -->
