### PR TITLE
fix(ci): main is red — the rename never reached `test/types/`

### DIFF
--- a/.vigiles/generated.d.ts
+++ b/.vigiles/generated.d.ts
@@ -75,7 +75,7 @@ declare module "vigiles/generated" {
   /** All enabled linter rules across all detected linters. */
   export type LinterRule = EslintRule;
 
-  /** 21 npm scripts from package.json. */
+  /** 22 npm scripts from package.json. */
   export type NpmScript = 
     | "build"
     | "build:core"
@@ -97,6 +97,7 @@ declare module "vigiles/generated" {
     | "api:check"
     | "docs:check"
     | "exports:check"
+    | "experimental:check"
     | "docs:api";
 
   /** 371 project files. */
@@ -938,6 +939,7 @@ declare module "vigiles/spec" {
       | "api:check"
       | "docs:check"
       | "exports:check"
+      | "experimental:check"
       | "docs:api";
   }
 }

--- a/test/types/composition.ts
+++ b/test/types/composition.ts
@@ -2,8 +2,8 @@
  * Type-level constraint: TYPED COMPOSITION — "your multi-agent pipeline doesn't
  * compile if the handoffs don't line up." The SHIPPED `agent()` / `result()`
  * builders now carry each agent's `result()` ok/err SHAPE at the type level (a
- * `TypedAgentSpec`), so a typed `pipe`/`then` cross-references one step's `ok`
- * against the next step's `needs` AT `tsc` TIME — a missing field, a wrong field
+ * `TypedAgentSpec`), so a typed `experimental_pipe`/`then` cross-references one step's `ok`
+ * against the next step's `experimental_needs` AT `tsc` TIME — a missing field, a wrong field
  * type, or an out-of-order step is a compile error.
  *
  * Compiled with `tsc --noEmit` (npm run test:types); it asserts types, it is not
@@ -13,11 +13,11 @@
 import {
   agent,
   result,
-  start,
-  andThen,
-  pipe,
-  pipeStep,
-  needs,
+  experimental_start,
+  experimental_andThen,
+  experimental_pipe,
+  experimental_pipeStep,
+  experimental_needs,
 } from "../../dist/core/spec.js";
 
 // ---------------------------------------------------------------------------
@@ -53,10 +53,13 @@ const reviewer = agent({
 //   planner.ok ⊇ implementer.needs, implementer.ok ⊇ reviewer.needs.
 // ---------------------------------------------------------------------------
 
-const good = pipe(
+const good = experimental_pipe(
   planner,
-  pipeStep(implementer, needs({ plan: "string", files: "string[]" })),
-  pipeStep(reviewer, needs({ diff: "string" })),
+  experimental_pipeStep(
+    implementer,
+    experimental_needs({ plan: "string", files: "string[]" }),
+  ),
+  experimental_pipeStep(reviewer, experimental_needs({ diff: "string" })),
 );
 
 // The carried final type is precise — the pipeline's `ok` is reviewer's `ok`.
@@ -64,12 +67,15 @@ const _approved: "boolean" = good.ok.approved;
 void _approved;
 
 // The same chain via the explicit start/andThen fold MUST also compile.
-const goodFold = andThen(
-  andThen(
-    start(planner),
-    pipeStep(implementer, needs({ plan: "string", files: "string[]" })),
+const goodFold = experimental_andThen(
+  experimental_andThen(
+    experimental_start(planner),
+    experimental_pipeStep(
+      implementer,
+      experimental_needs({ plan: "string", files: "string[]" }),
+    ),
   ),
-  pipeStep(reviewer, needs({ diff: "string" })),
+  experimental_pipeStep(reviewer, experimental_needs({ diff: "string" })),
 );
 void goodFold;
 
@@ -84,11 +90,17 @@ const reviewerNeedsScan = agent({
   output: result({ approved: "boolean" }, { reason: "string" }),
 });
 
-void pipe(
+void experimental_pipe(
   planner,
-  pipeStep(implementer, needs({ plan: "string", files: "string[]" })),
+  experimental_pipeStep(
+    implementer,
+    experimental_needs({ plan: "string", files: "string[]" }),
+  ),
   // @ts-expect-error MISSING FIELD: implementer.ok has no `securityScan`.
-  pipeStep(reviewerNeedsScan, needs({ securityScan: "string" })),
+  experimental_pipeStep(
+    reviewerNeedsScan,
+    experimental_needs({ securityScan: "string" }),
+  ),
 );
 
 // ---------------------------------------------------------------------------
@@ -96,11 +108,14 @@ void pipe(
 // (`string[]`, but implementer produces `diff: "string"`).
 // ---------------------------------------------------------------------------
 
-void pipe(
+void experimental_pipe(
   planner,
-  pipeStep(implementer, needs({ plan: "string", files: "string[]" })),
+  experimental_pipeStep(
+    implementer,
+    experimental_needs({ plan: "string", files: "string[]" }),
+  ),
   // @ts-expect-error TYPE MISMATCH: implementer produces diff:"string", reviewer needs diff:"string[]".
-  pipeStep(reviewer, needs({ diff: "string[]" })),
+  experimental_pipeStep(reviewer, experimental_needs({ diff: "string[]" })),
 );
 
 // ---------------------------------------------------------------------------
@@ -109,10 +124,10 @@ void pipe(
 // typed pipe rejects the inverted handoff.
 // ---------------------------------------------------------------------------
 
-void pipe(
+void experimental_pipe(
   planner,
   // @ts-expect-error ORDER ERROR: reviewer needs `diff`, but planner.ok has none (implementer hasn't run).
-  pipeStep(reviewer, needs({ diff: "string" })),
+  experimental_pipeStep(reviewer, experimental_needs({ diff: "string" })),
 );
 
 // ---------------------------------------------------------------------------
@@ -122,4 +137,4 @@ void pipe(
 // ---------------------------------------------------------------------------
 
 const bare = agent({ name: "bare", description: "no result contract" });
-void start(bare);
+void experimental_start(bare);

--- a/test/types/purity.ts
+++ b/test/types/purity.ts
@@ -1,6 +1,6 @@
 /**
  * Type-level constraint: typed purity. The `vigiles/claude-code` `agent` /
- * `skill` builders enforce the `purity` floor AGAINST the Claude Code tool
+ * `experimental_skill` builders enforce the `purity` floor AGAINST the Claude Code tool
  * catalog at `tsc` time — a strict addition to the runtime/compile purity
  * checks. Compiled with `tsc --noEmit` (npm run test:types); it asserts types,
  * it is not executed. `// @ts-expect-error` marks the must-NOT-compile cases.
@@ -9,10 +9,10 @@
  * bounded = read-only ∪ Write/Edit/NotebookEdit ∪ Bash; no purity / dangerous =
  * open. The core (harness-agnostic) `agent()` is unconstrained by default.
  */
-import { agent, skill } from "../../dist/claude-code.js";
+import { agent, experimental_skill } from "../../dist/claude-code.js";
 import {
   agent as coreAgent,
-  skill as coreSkill,
+  experimental_skill as coreSkill,
 } from "../../dist/core/spec.js";
 
 // ---------------------------------------------------------------------------
@@ -79,17 +79,17 @@ agent({
 });
 
 // ---------------------------------------------------------------------------
-// CC-bound `skill` — the same constraint applies.
+// CC-bound `experimental_skill` — the same constraint applies.
 // ---------------------------------------------------------------------------
 
-skill({
+experimental_skill({
   name: "pure-skill",
   description: "read-only skill",
   purity: "pure",
   tools: ["Read", "Grep"],
 });
 
-skill({
+experimental_skill({
   name: "bad-pure-skill",
   description: "pure skill cannot take Bash",
   purity: "pure",
@@ -97,14 +97,14 @@ skill({
   tools: ["Read", "Bash"],
 });
 
-skill({
+experimental_skill({
   name: "open-skill",
   description: "no purity → open",
   tools: ["Bash", "mcp__server__tool"],
 });
 
 // ---------------------------------------------------------------------------
-// Core (harness-agnostic) `agent` / `skill` — UNCONSTRAINED by default, so even
+// Core (harness-agnostic) `agent` / `experimental_skill` — UNCONSTRAINED by default, so even
 // `purity: "pure"` + a side-effecting tool COMPILES (the runtime/compile checks
 // are the backstop for the untyped import). Backwards compatibility.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What and why

`main` has been red since #147. Four of five CI jobs pass; **one step** fails — "Matcher type augmentation compiles" — and everything after it is skipped, which is why the whole run reads red.

**Cause:** `test/types/` lives in a **separate tsconfig**, excluded from the root one. The renames (`skill` → `experimental_skill`, and `pipe`/`pipeStep`/`needs`/`start`/`andThen` → `experimental_*`) were driven off `npx tsc --noEmit -p tsconfig.json`, which cannot see those files. 11 errors in `composition.ts` + `purity.ts`, three of them `Unused '@ts-expect-error'` — meaning checks that are supposed to fail had quietly stopped failing.

**The real cause is one level up, and it is a class already documented in this repo:** adjacent gates look overlapping and overlap nowhere. The gate list I ran covered **5 commands out of the 13** CI actually runs. Never executed: `npx jest` · `tsc -p test/types/tsconfig.json` · `tsc -p site/tsconfig.json` · `node dist/cli.js lint` · `generate types` + the drift diff · `npx typedoc` · `fmt:check` (which is not the same as `prettier --check .`).

Also closes a `.vigiles/generated.d.ts` drift: the `experimental:check` script was added in #147, the file derives from `package.json`, and it was never regenerated.

🔑 Worth noting which gate caught that: the `git diff --exit-code .vigiles/generated.d.ts` step shipped in **#149**, and it fired on **#147's** omission the first day both were on `main`. It did exactly the job it was written for.

## Safety impact

None. Test-only type declarations and a regenerated types file.

## Checks

- [x] `npm test` passes locally — vitest 2953 passed, 25 skipped
- [x] New behaviour has a test — n/a; this restores three `@ts-expect-error` assertions that had stopped being checked
- [x] Docs updated — n/a

**All 13 CI commands run locally: 13/13 ✓** (not the 5 that let this through).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Fixes**
- main был красным — переименование не дошло до test/types
<!-- vigiles:pr-summary:end -->
