### PR TITLE
ci: one list of commands instead of two — CI now calls `npm run check`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,13 +265,15 @@ jobs:
           fi
           echo "vigiles action output: valid=$got"
 
-      - name: Lint compiled files (direct CLI — redundant safety)
-        run: node dist/cli.js lint
-
       # Dogfood the eval staleness gate via the composite Action. This repo's
       # real-model evals run locally (`npm run test:eval`), so no lock is
       # committed yet — `eval-check` is a green no-op here, but it proves the
       # action's `command: eval-check` → `eval --check` path works in CI.
+      #
+      # 🔴 Kept OUT of `npm run check` on purpose, and nearly lost by accident when
+      # the consolidation below was written: it sat between two command-steps, so a
+      # span-based edit swallowed it. Like the lint step above it, it exercises the
+      # ACTION WRAPPER, which has no shell equivalent.
       - name: Dogfood the eval staleness gate (eval-check)
         uses: ./
         with:
@@ -279,147 +281,24 @@ jobs:
           version: local
           comment: "false"
 
-      # Public-API surface gate: API Extractor compares the live .d.ts surface of
-      # every public entry point against the committed api-surface/*.api.md reports. A PR
-      # that adds/removes/changes a public export (or leaks a Claude-Code symbol
-      # back onto the agnostic surface) fails here until `npm run api:report` is
-      # run and the report diff is reviewed + committed. dist/ is built above.
-      - name: API surface gate
-        run: node scripts/api-extractor.mjs
-
-      # Smoke-check the API reference GENERATOR (TypeDoc) on every PR — proves
-      # `npm run docs:api` / typedoc.json still build, so the api-docs.yml Pages
-      # deploy (push to main) can't silently rot. Output is gitignored, not
-      # published here.
-      - name: API reference generates (smoke, no publish)
-        run: npx typedoc
-
-      # Dogfood-corpus guards (deterministic, no model, no key). The benchmark
-      # corpus's own correctness-oracle self-checks: a check that stopped
-      # discriminating good-from-bad would silently void every downstream
-      # benchmark/optimizer claim. See research/dogfood-corpus.md.
-      - name: Dogfood corpus guards (bench self-checks)
-        run: |
-          node bench/corpus/verify.mjs
-          node bench/corpus/verify-headroom.mjs
-
-      # The @vigiles/rule-enforcer trust gate — prove the two-stage soundness gate
-      # still ABSTAINS the leaky synthesized checkers (its whole reason to
-      # exist). gate.js asserts the known-correct kept/abstain verdicts and
-      # exits non-zero on drift. Its own package + lockfile, so install in place.
-      # Deterministic, no model. See research/dogfood-corpus.md.
-      - name: Rule-enforcer trust gate (soundness dogfood)
-        run: |
-          npm ci --prefix rule-enforcer
-          node rule-enforcer/gate.js
-
-      # ── Moved here from `test` (2026-08-12) ─────────────────────────────────
-      # Not one of these needs python/ruby/java/go, bubblewrap, or the
-      # claude/codex CLIs — they were simply queued behind ~96 s of toolchain
-      # install and ~6 min of tests in the job that was CI's long pole, while
-      # this job finished in ~90 s and idled. 63 s measured, moved wholesale.
-      # Relative ORDER is preserved: `generate types` writes
-      # .vigiles/generated.d.ts before lint and prettier see the tree, exactly
-      # as it did in `test`. dist/ comes from the Build step above.
-
-      # Jest is the half of the old "cross-runner matcher tests (vitest + jest)"
-      # step that was worth keeping — a genuinely different runner, 1.4 s. The
-      # vitest half was deleted rather than moved: it re-ran the whole suite the
-      # coverage gate had just run (see the note in `test`).
-      - name: Cross-runner matcher tests (jest)
-        run: npx jest
-
-      - name: Matcher type augmentation compiles (vitest + jest)
-        run: npx tsc --noEmit -p test/types/tsconfig.json
-
-      - name: Type check
-        run: npx tsc --noEmit
-
-      # 🔴 site/ and packages/report-view have their OWN tsconfig and were never typechecked here.
-      # A field added to the engine's inventory and not to the view's mirror therefore compiled
-      # clean through all three steps above and failed only for whoever ran
-      # `tsc -p site/tsconfig.json` by hand. That is precisely what happened to `untestedHarness`
-      # and `unevaluated` earlier in this PR: three green typecheck steps, none covering the project
-      # that broke. A check that passes without covering the thing that broke is the defect this
-      # whole PR is about, so it gets a step rather than a note.
-      - name: Type check (site + report-view)
-        run: npx tsc --noEmit -p site/tsconfig.json
-
-      - name: Check generated types compile
-        run: node dist/cli.js generate types && npx tsc --noEmit
-
-      # 🔴 THE STEP ABOVE REGENERATES THE FILE AND COMPILES THE RESULT — it never looks at the
-      # COMMITTED copy, so a stale `.vigiles/generated.d.ts` passes it every time. Measured
-      # 2026-08-16: the tracked file was behind by 314 lines / ~147 entries, and CI had been
-      # green throughout. The step's name is honest about this — it checks that generated types
-      # COMPILE, not that they are up to date — which is exactly why the gap survived review.
+      # ONE list, and it lives in `scripts/check.mjs` — not restated here.
       #
-      # The prediction is on record. `zernie/mine`'s .gitignore, 2026-08-08, gives this as the
-      # reason that repo refuses to track its own copy: "drift in a generated file is invisible
-      # unless something regenerates it with --check. Upstream vigiles tracks its own copy and it
-      # IS stale on main for exactly that reason." Eight days later it was staler. Writing the
-      # prediction down did not stop it; this line does.
-      - name: Generated types are up to date
-        run: git diff --exit-code .vigiles/generated.d.ts
-
-      # Do the TypeScript examples in the docs still import things that exist?
+      # On 2026-08-16 three PRs went to `main` red because the author ran a
+      # five-command list from memory while this job ran thirteen. The failing one
+      # (`tsc -p test/types/tsconfig.json`) sits in a separate tsconfig the root
+      # type-check cannot see, and three `@ts-expect-error` assertions had quietly
+      # stopped failing. A longer list to remember would not have fixed that; a
+      # single list that CI INVOKES does — the pre-commit / just / mise pattern.
       #
-      # Nothing checked this before 2026-08-16, and on that day the docs carried SIX package
-      # subpaths that raise ERR_PACKAGE_PATH_NOT_EXPORTED, plus two examples importing a real
-      # symbol from the wrong barrel — `scriptModel` (it lives in `vigiles/claude-code`) and
-      # `runHookProgram` (`vigiles/hook`). All copy-pasteable, all broken on the reader's first
-      # line. `scriptModel` was the THIRD occurrence of the same wrong import, twice previously
-      # written down as a known boundary. Prose did not hold it; this does.
+      # `npm run check` runs `build`, then the read-only checks in parallel, then
+      # the file-WRITING ones serially (a writer beside a reader is a race), and
+      # names whatever failed — which is what the per-step names here used to buy.
+      # `node scripts/check.mjs --list` prints the commands without running them.
       #
-      # 🔴 IT REPORTS ONLY THIS PACKAGE'S OWN MODULE SURFACE, AND THAT NARROWNESS IS THE WHOLE
-      # DESIGN. Measured over this repo's 102 ts/js blocks: full `tsc` on every block — the
-      # DEFAULT of all three off-the-shelf tools — yields 234 findings, 2 real and 232 false,
-      # because only 36.3% of blocks are self-contained; the rest are illustrative fragments with
-      # free variables. This gate yields 2 of 2, with no suppression markers anywhere. A checker
-      # that fires on legitimate input is muted within a week, so a tool with a 1:24 noise ratio
-      # is not a stricter version of this one — it is a dead one.
-      #
-      # Rust's doctests take the opposite route (compile everything, opt OUT with `ignore`); here
-      # that would mean ~65 suppression markers on day one, visible to every reader on GitHub.
-      # Inverting it costs nothing and makes the false positive unrepresentable rather than filtered.
-      # Opt IN to a full type-check per block with `<!-- vigiles:check -->` above the fence.
-      #
-      # Resolution needs no path rewriting: TypeScript resolves the package to itself through the
-      # `exports` map (self-reference), so a phantom subpath is an ordinary TS2307.
-      - name: Check doc imports
-        run: npm run docs:check
-
-      # Two gates on the same convention, entered from opposite ends. They look
-      # redundant and are not: one starts from the DOOR, the other from the TAG,
-      # and a symbol can be wrong in one way while right in the other.
-      #
-      # By DOOR — a subpath that carries a warning in its name must carry it on
-      # every symbol behind it: `./eval` → `paid_*`, `./experimental` →
-      # `experimental_*`. The path warns once at the top of a file; the name warns
-      # at every call site, which is where the money is spent. Held by prose it
-      # decays — `makeDockerRuntime` sat unprefixed among six `experimental_`
-      # siblings until this step was written, and ONE missing prefix is worse than
-      # none, because the six that comply teach the reader that an unprefixed name
-      # is safe. Types are exempt on purpose: a type is never called, and the
-      # report types are re-exported from the FREE barrel too.
-      - name: Check export prefixes
-        run: npm run exports:check
-
-      # By TAG — a public declaration tagged `@experimental` must say so in its
-      # name, wherever it lives. This is the half that caught `skill()`: it shipped
-      # stable-named from `vigiles/spec` — a door with no warning in it, so the
-      # door-based gate above could never see it — while its own doc opened with
-      # "`skill()` is experimental". Prose against mechanism, in the project built
-      # to catch exactly that. Reads the `@experimental` TSDoc already in the
-      # source plus the committed `api-surface/*.api.md` reports; no new marker.
-      - name: Check experimental naming
-        run: npm run experimental:check
-
-      - name: Lint
-        run: npm run lint
-
-      - name: Check formatting
-        run: npm run fmt:check
+      # The two `uses: ./` steps above are NOT in it on purpose: they dogfood this
+      # repo's own composite Action, which has no shell equivalent.
+      - name: Check suite (identical to `npm run check` locally)
+        run: npm run check
 
   harness:
     # Dogfood the harness-testing pillar on the in-repo build: the deterministic

--- a/.vigiles/generated.d.ts
+++ b/.vigiles/generated.d.ts
@@ -75,7 +75,7 @@ declare module "vigiles/generated" {
   /** All enabled linter rules across all detected linters. */
   export type LinterRule = EslintRule;
 
-  /** 22 npm scripts from package.json. */
+  /** 23 npm scripts from package.json. */
   export type NpmScript = 
     | "build"
     | "build:core"
@@ -95,6 +95,7 @@ declare module "vigiles/generated" {
     | "test:types"
     | "api:report"
     | "api:check"
+    | "check"
     | "docs:check"
     | "exports:check"
     | "experimental:check"
@@ -937,6 +938,7 @@ declare module "vigiles/spec" {
       | "test:types"
       | "api:report"
       | "api:check"
+      | "check"
       | "docs:check"
       | "exports:check"
       | "experimental:check"

--- a/api-surface/vigiles-claude-code.api.md
+++ b/api-surface/vigiles-claude-code.api.md
@@ -66,8 +66,16 @@ export interface ClaudeCodeToolVocabulary extends ToolVocabulary {
     readonly readOnly: ClaudeCodeReadOnlyTool;
 }
 
-// @public
-export function experimental_skill<const P extends AuthoredPurity | undefined = undefined>(spec: SkillSpecInput<P, ClaudeCodeToolVocabulary>): SkillSpec;
+// @public (undocumented)
+export const experimental_skill: typeof skillSpec & {
+    input: (name: string, hint: string, opts?: {
+        required?: boolean;
+    }) => SkillInput;
+    step: (instr: string | InstructionFragment[], opts?: {
+        gate?: Gate;
+        retry?: number;
+    }) => SkillStep;
+};
 
 // @public
 export function extractRequest(body: {

--- a/api-surface/vigiles-linting.api.md
+++ b/api-surface/vigiles-linting.api.md
@@ -248,8 +248,11 @@ export function experimental_pipe<A extends Shape, AE extends Shape, BN extends 
 // @public
 export function experimental_pipeStep<Needs extends Shape, Ok extends Shape, Err extends Shape>(a: TypedAgentSpec<Ok, Err>, needsContract?: Needs): PipeStep<Needs, Ok, Err>;
 
-// @public
-export function experimental_skill<const P extends AuthoredPurity | undefined = undefined, V extends ToolVocabulary = OpenToolVocabulary>(spec: SkillSpecInput<P, V>): SkillSpec;
+// @public (undocumented)
+export const experimental_skill: typeof skillSpec & {
+    input: typeof input;
+    step: typeof step;
+};
 
 // @public
 export function experimental_start<Ok extends Shape, Err extends Shape>(first: PipeStep<Record<string, never>, Ok, Err> | TypedAgentSpec<Ok, Err>): Pipeline<Ok, Err>;
@@ -315,11 +318,6 @@ export type Handoff<Producer extends Shape, Consumer extends Shape> = Supplies<P
 
 // @public (undocumented)
 export type HookEvent = "PreToolUse" | "PostToolUse" | "PreSession" | "PostSession" | "Notification";
-
-// @public
-export function input(name: string, hint: string, opts?: {
-    required?: boolean;
-}): SkillInput;
 
 // @public (undocumented)
 export type InstructionFragment = string | Ref | EffectRegion;
@@ -529,12 +527,6 @@ export interface SkillStep {
 
 // @public
 export type SpecPath<Output extends `${string}.md`> = `${Output}.spec.ts`;
-
-// @public
-export function step(instr: string | InstructionFragment[], opts?: {
-    gate?: Gate;
-    retry?: number;
-}): SkillStep;
 
 // @public (undocumented)
 export type StrictCmd = [keyof KnownNpmScripts] extends [never] ? string : `npm run ${KnownNpmScripts[keyof KnownNpmScripts] & string}` | `npm ${KnownNpmScripts[keyof KnownNpmScripts] & string}` | (string & {});

--- a/api-surface/vigiles-spec.api.md
+++ b/api-surface/vigiles-spec.api.md
@@ -155,8 +155,11 @@ export function experimental_pipe<A extends Shape, AE extends Shape, BN extends 
 // @public
 export function experimental_pipeStep<Needs extends Shape, Ok extends Shape, Err extends Shape>(a: TypedAgentSpec<Ok, Err>, needsContract?: Needs): PipeStep<Needs, Ok, Err>;
 
-// @public
-export function experimental_skill<const P extends AuthoredPurity | undefined = undefined, V extends ToolVocabulary = OpenToolVocabulary>(spec: SkillSpecInput<P, V>): SkillSpec;
+// @public (undocumented)
+export const experimental_skill: typeof skillSpec & {
+    input: typeof input;
+    step: typeof step;
+};
 
 // @public
 export function experimental_start<Ok extends Shape, Err extends Shape>(first: PipeStep<Record<string, never>, Ok, Err> | TypedAgentSpec<Ok, Err>): Pipeline<Ok, Err>;
@@ -222,11 +225,6 @@ export type Handoff<Producer extends Shape, Consumer extends Shape> = Supplies<P
 
 // @public (undocumented)
 export type HookEvent = "PreToolUse" | "PostToolUse" | "PreSession" | "PostSession" | "Notification";
-
-// @public
-export function input(name: string, hint: string, opts?: {
-    required?: boolean;
-}): SkillInput;
 
 // @public (undocumented)
 export type InstructionFragment = string | Ref | EffectRegion;
@@ -436,12 +434,6 @@ export interface SkillStep {
 
 // @public
 export type SpecPath<Output extends `${string}.md`> = `${Output}.spec.ts`;
-
-// @public
-export function step(instr: string | InstructionFragment[], opts?: {
-    gate?: Gate;
-    retry?: number;
-}): SkillStep;
 
 // @public (undocumented)
 export type StrictCmd = [keyof KnownNpmScripts] extends [never] ? string : `npm run ${KnownNpmScripts[keyof KnownNpmScripts] & string}` | `npm ${KnownNpmScripts[keyof KnownNpmScripts] & string}` | (string & {});

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,12 +40,14 @@ The docs are grouped by what you're trying to do:
 
 - [`harnesses.md`](harnesses.md) — which harness vigiles targets and how you pick one (by import), plus the capability matrix.
 - [`authoring-an-adapter.md`](authoring-an-adapter.md) — teach vigiles a new harness: the five ports, a worked skeleton, validating with the conformance kit.
+- [`non-js-harnesses.md`](non-js-harnesses.md) — running vigiles on a harness whose project is Kotlin, Go or anything else non-JS: what needs Node and what does not.
 - [`agent-setup.md`](agent-setup.md) — agent setup & workflows in one guide: what `init` does, per-agent recipes (Claude Code / Codex / multi-agent / Cursor), non-interactive setup + fallback hooks, and CI.
 
 ## Reference — "the exact flag, symbol, or rule"
 
 - [`cli.md`](cli.md) — the full CLI: every verb and flag, the Claude Code plugin, `lint` vs `audit`.
 - [`commands-and-how-they-relate.md`](commands-and-how-they-relate.md) — the mental model: how `audit` / `lint` / `test` / `eval` / `init` fit together, and why measuring "do my skills fire?" uses `init`, not `audit`.
+- [`testing-matrix.md`](testing-matrix.md) — every use case of the harness-testing API mapped to the tier that tests it, and what each tier costs.
 - [`testing-api.md`](testing-api.md) — the full harness-testing API: every predicate, assertion, `check`, matcher, and option (`measureTriggerRate` / `runEval` / significance).
 - [`spec-format.md`](spec-format.md) — the typed `.spec.ts` format (target, sections, rules, verified references) — the source of truth.
 - [`linter-support.md`](linter-support.md) — the 11 linters + `generate-types` / `generate-schema`.

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -1,8 +1,20 @@
 # Experimental surface — what is not settled yet
 
-Everything exported from `vigiles/experimental` carries an **`experimental_` prefix on the name itself**, so a call site says it is provisional without anyone opening this page. That is the whole contract of this file: **the prefix is the promise, and this page says what would have to be true to drop it.**
+**The prefix is the promise, wherever the symbol lives.** An `experimental_` name says a thing is provisional at the call site, without anyone opening this page — and that holds whether it comes from the quarantined `vigiles/experimental` subpath or sits beside stable exports in `vigiles/spec`. This page says what would have to be true to drop each one.
+
+It has not always held. `skill()` once shipped stable-named from `vigiles/spec` while its own guide opened with "`skill()` is experimental" — prose one way, API the other. `npm run experimental:check` now fails CI when a public declaration tagged `@experimental` is not named for it, so the tag and the name cannot drift apart again.
 
 Nothing here is covered by semver. An experimental export may change shape or disappear in a patch release. If that is not acceptable for your repo, do not import it — everything on this page has a non-experimental alternative, named below in each section.
+
+## `experimental_skill` — authoring a `SKILL.md` from a typed spec
+
+The declarative skill builder, and its two helpers `experimental_skill.input()` and `experimental_skill.step()`.
+
+The helpers hang off the builder rather than being exported beside it, and that placement is the point: both are used **only** by skill specs, so making them reachable only through the prefixed name makes the marking structural for the whole family. `cmd`, `file`, `project` and `result` are shared with subagents and stay top-level. Honest limit: `const { input } = experimental_skill` strips the marker inside one file — what the shape guarantees is narrower, that an unmarked name never crosses the package boundary.
+
+**What would have to be true to drop the prefix:** a real skill corpus converted to it (today: two example specs), and a compiled `SKILL.md` shown to load and run as an installed skill — never yet exercised end-to-end. See [`skills.md`](skills.md) §Status for the measured gaps.
+
+**Stable alternative:** hand-written `SKILL.md` with markdown-mode gate markers. Same enforcement, no spec.
 
 ## `experimental_emitTool` — a skill emits its result by calling a tool
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -45,22 +45,20 @@ Fix failures until the suite is green.
 
 ```ts
 import {
-  experimental_skill,
-  step,
-  input,
+  experimental_skill as skill,
   cmd,
   project,
   instructions,
 } from "vigiles/spec";
 
-export default experimental_skill({
+export default skill({
   name: "ship-pr",
   description: "Run the checks and open a PR once they pass",
-  inputs: [input("branch", "branch to open the PR from")],
+  inputs: [skill.input("branch", "branch to open the PR from")],
   body: instructions`## Reference\n\n…domain knowledge the model reads…`,
   steps: [
-    step("Run the linter and fix issues.", { gate: cmd("npm run lint") }),
-    step("Run the tests; fix until green.", {
+    skill.step("Run the linter and fix issues.", { gate: cmd("npm run lint") }),
+    skill.step("Run the tests; fix until green.", {
       gate: project("test"),
       retry: 3,
     }),
@@ -68,6 +66,8 @@ export default experimental_skill({
   result: project("test"),
 });
 ```
+
+**Why `skill.input` and `skill.step` instead of two more imports.** Both are used only by skill specs; `cmd`, `file`, `project` and `result` are shared with subagents and stay top-level. Hanging the skill-only pair off the builder makes the experimental marking structural for the whole family — you cannot reach `input()` without naming `experimental_skill` first, which a per-name prefix convention could not guarantee. Aliasing at the import, as above, keeps the prefix on the one line that crosses the package boundary and keeps the body readable.
 
 What each field does:
 

--- a/examples/ship-pr/SKILL.md.spec.ts
+++ b/examples/ship-pr/SKILL.md.spec.ts
@@ -7,26 +7,33 @@
  *
  * Run `vigiles compile` to generate SKILL.md from this spec.
  */
-import { experimental_skill, step, input, cmd } from "../../src/core/spec.js";
+// The prefix is what crosses the package boundary; aliasing at the import
+// keeps it visible there and keeps the body readable.
+import { experimental_skill as skill, cmd } from "../../src/core/spec.js";
 
-export default experimental_skill({
+export default skill({
   name: "ship-pr",
   description: "Run the project checks and open a pull request once they pass",
 
   inputs: [
-    input("branch", "the branch to open the PR from"),
-    input("title", "PR title", { required: false }),
+    skill.input("branch", "the branch to open the PR from"),
+    skill.input("title", "PR title", { required: false }),
   ],
 
   steps: [
-    step("Run the linter and fix any issues it reports.", {
+    skill.step("Run the linter and fix any issues it reports.", {
       gate: cmd("npm run lint"),
     }),
-    step("Run the test suite. Fix failures and re-run until it is green.", {
-      gate: cmd("npm test"),
-      retry: 3,
-    }),
-    step("Open the pull request from `$1` with title `$2` (if provided)."),
+    skill.step(
+      "Run the test suite. Fix failures and re-run until it is green.",
+      {
+        gate: cmd("npm test"),
+        retry: 3,
+      },
+    ),
+    skill.step(
+      "Open the pull request from `$1` with title `$2` (if provided).",
+    ),
   ],
 
   // The skill is not "done" until the test suite passes.

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "test:types": "npm run build && tsc --noEmit -p test/types/tsconfig.json",
     "api:report": "npm run build && node scripts/api-extractor.mjs --local",
     "api:check": "npm run build && node scripts/api-extractor.mjs",
+    "check": "node scripts/check.mjs",
     "docs:check": "npm run build && node scripts/check-doc-imports.mjs . docs README.md",
     "exports:check": "npm run build && node scripts/check-export-prefixes.mjs .",
     "experimental:check": "npm run api:check && node scripts/check-experimental-naming.mjs",

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * check.mjs — every command CI's `check` job runs, runnable in one line locally.
+ *
+ * WHY THIS EXISTS, and it is not "convenience". On 2026-08-16 three PRs went to
+ * `main` red. The author had run a five-command list from memory; the `check` job
+ * runs thirteen. The one that failed — `tsc -p test/types/tsconfig.json` — sits in
+ * a SEPARATE tsconfig excluded from the root one, so the root type-check could not
+ * see it, and three `@ts-expect-error` assertions had silently stopped failing.
+ *
+ * The fix is not a longer list to remember. It is that CI now INVOKES this file
+ * (`run: npm run check`) instead of restating the commands, so there is one list
+ * and it cannot drift from itself. That is the pre-commit / just / mise pattern:
+ * the task definition is the source of truth and CI calls it.
+ *
+ * WHAT STAYS IN ci.yml, deliberately: the two `uses: ./` steps that dogfood this
+ * repo's own composite Action (`command: lint`, `command: eval-check`). They
+ * exercise the ACTION WRAPPER, which has no shell equivalent — running
+ * `vigiles lint` here would test the CLI, which the `cli-lint` entry below
+ * already does, and would prove nothing about the wrapper. They are the only
+ * things in that job this file does not cover, and that is a property of what
+ * they test, not an omission.
+ *
+ * THE STAGES ARE LOAD-BEARING, not decoration. Some of these commands WRITE the
+ * files the others READ — `generate types` rewrites `.vigiles/generated.d.ts`,
+ * `api-extractor` rewrites `api-surface/*.api.md`, `build` rewrites `dist/`.
+ * Running a writer beside a reader is a race whose outcome depends on timing, so
+ * writers are serialized and only the read-only group runs in parallel.
+ *
+ * On failure it names the command that failed. That is the one thing the old
+ * per-step CI names bought, and it is cheap to keep.
+ *
+ *   node scripts/check.mjs            # everything
+ *   node scripts/check.mjs --list     # print the commands, run nothing
+ */
+import { spawn } from "node:child_process";
+import { cpus } from "node:os";
+
+/** Stage 1 — everything downstream reads `dist/`. */
+const BUILD = { name: "build", cmd: "npm run build" };
+
+/** Stage 2 — read-only. Safe to run together; none of these writes a tracked file. */
+const PARALLEL = [
+  { name: "types:root", cmd: "npx tsc --noEmit" },
+  { name: "types:test", cmd: "npx tsc --noEmit -p test/types/tsconfig.json" },
+  { name: "types:site", cmd: "npx tsc --noEmit -p site/tsconfig.json" },
+  { name: "jest", cmd: "npx jest" },
+  { name: "cli-lint", cmd: "node dist/cli.js lint" },
+  { name: "lint", cmd: "npm run lint" },
+  { name: "format", cmd: "npm run fmt:check" },
+  {
+    name: "docs-imports",
+    cmd: "node scripts/check-doc-imports.mjs . docs README.md",
+  },
+  { name: "export-prefixes", cmd: "node scripts/check-export-prefixes.mjs ." },
+  {
+    name: "experimental-naming",
+    cmd: "node scripts/check-experimental-naming.mjs",
+  },
+  { name: "typedoc", cmd: "npx typedoc" },
+  {
+    name: "corpus-guards",
+    cmd: "node bench/corpus/verify.mjs && node bench/corpus/verify-headroom.mjs",
+  },
+  {
+    name: "rule-enforcer",
+    cmd: "npm ci --prefix rule-enforcer && node rule-enforcer/gate.js",
+  },
+];
+
+/** Stage 3 — these WRITE. Serialized after the readers have finished. */
+const WRITERS = [
+  { name: "api-surface", cmd: "node scripts/api-extractor.mjs" },
+  {
+    name: "generated-types",
+    cmd: "node dist/cli.js generate types && npx tsc --noEmit",
+  },
+  {
+    name: "generated-types:committed",
+    cmd: "git diff --exit-code .vigiles/generated.d.ts",
+  },
+];
+
+const ALL = [BUILD, ...PARALLEL, ...WRITERS];
+
+if (process.argv.includes("--list")) {
+  for (const s of ALL) console.log(`${s.name.padEnd(26)} ${s.cmd}`);
+  process.exit(0);
+}
+
+function run({ name, cmd }) {
+  return new Promise((resolve) => {
+    const started = Date.now();
+    const p = spawn(cmd, { shell: true, stdio: ["ignore", "pipe", "pipe"] });
+    let out = "";
+    p.stdout.on("data", (d) => (out += d));
+    p.stderr.on("data", (d) => (out += d));
+    p.on("close", (code) =>
+      resolve({ name, cmd, code, out, ms: Date.now() - started }),
+    );
+  });
+}
+
+/** Bounded concurrency — 13 `tsc`/`jest` processes at once thrashes a laptop. */
+async function pool(items, limit) {
+  const results = [];
+  let next = 0;
+  const workers = Array.from(
+    { length: Math.min(limit, items.length) },
+    async () => {
+      for (;;) {
+        const i = next++;
+        if (i >= items.length) return;
+        const r = await run(items[i]);
+        results[i] = r;
+        console.log(
+          `${r.code === 0 ? "✓" : "✗"} ${r.name} (${(r.ms / 1000).toFixed(1)}s)`,
+        );
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+const failures = [];
+const t0 = Date.now();
+
+const build = await run(BUILD);
+console.log(
+  `${build.code === 0 ? "✓" : "✗"} ${build.name} (${(build.ms / 1000).toFixed(1)}s)`,
+);
+if (build.code !== 0) {
+  // Nothing downstream can be trusted without dist/, so stop rather than emit
+  // twelve derived failures that all say the same thing.
+  console.error(`\n${build.out}\n✗ build failed — the rest cannot run.`);
+  process.exit(1);
+}
+
+failures.push(
+  ...(await pool(PARALLEL, Math.max(2, Math.min(6, cpus().length - 1)))).filter(
+    (r) => r.code !== 0,
+  ),
+);
+
+for (const w of WRITERS) {
+  const r = await run(w);
+  console.log(
+    `${r.code === 0 ? "✓" : "✗"} ${r.name} (${(r.ms / 1000).toFixed(1)}s)`,
+  );
+  if (r.code !== 0) failures.push(r);
+}
+
+console.log(
+  `\n${ALL.length - failures.length}/${ALL.length} passed in ${((Date.now() - t0) / 1000).toFixed(0)}s`,
+);
+
+if (failures.length) {
+  for (const f of failures) {
+    console.error(
+      `\n──────── ✗ ${f.name} ────────\n$ ${f.cmd}\n${f.out.trimEnd()}`,
+    );
+  }
+  console.error(`\nFAILED: ${failures.map((f) => f.name).join(", ")}`);
+  process.exit(1);
+}

--- a/src/adapters/claude-code/skill-pipeline.test.ts
+++ b/src/adapters/claude-code/skill-pipeline.test.ts
@@ -6,7 +6,7 @@
 import { test } from "vitest";
 import assert from "node:assert/strict";
 
-import { experimental_skill, step, input, cmd, file } from "../../core/spec.js";
+import { experimental_skill, cmd, file } from "../../core/spec.js";
 import { compileSkill } from "../../core/compile.js";
 
 const opts = { specFile: "SKILL.md.spec.ts" };
@@ -16,10 +16,10 @@ test("typed inputs compile to argument-hint and an Arguments section", () => {
     name: "ship-pr",
     description: "Run checks and open a PR",
     inputs: [
-      input("branch", "the branch to open the PR from"),
-      input("title", "PR title", { required: false }),
+      experimental_skill.input("branch", "the branch to open the PR from"),
+      experimental_skill.input("title", "PR title", { required: false }),
     ],
-    steps: [step("Open the pull request.")],
+    steps: [experimental_skill.step("Open the pull request.")],
   });
   const { markdown, errors } = compileSkill(spec, opts);
   assert.equal(errors.length, 0, JSON.stringify(errors));
@@ -37,14 +37,14 @@ test("gated steps render gate markers + retry; result renders a result marker", 
     name: "ship-pr",
     description: "Run checks and open a PR once they pass",
     steps: [
-      step("Run the linter and fix any reported issues.", {
+      experimental_skill.step("Run the linter and fix any reported issues.", {
         gate: cmd("npm run lint"),
       }),
-      step("Run the test suite; fix failures until green.", {
+      experimental_skill.step("Run the test suite; fix failures until green.", {
         gate: cmd("npm test"),
         retry: 3,
       }),
-      step("Open the pull request."),
+      experimental_skill.step("Open the pull request."),
     ],
     result: cmd("npm test"),
   });
@@ -60,7 +60,11 @@ test("a step gate referencing a missing npm script is a compile error", () => {
   const spec = experimental_skill({
     name: "x",
     description: "...",
-    steps: [step("do a thing", { gate: cmd("npm run does-not-exist") })],
+    steps: [
+      experimental_skill.step("do a thing", {
+        gate: cmd("npm run does-not-exist"),
+      }),
+    ],
   });
   const { errors } = compileSkill(spec, opts);
   assert.ok(
@@ -87,7 +91,7 @@ test("a knowledge body composes with gated steps (both render, body first)", () 
     name: "docx",
     description: "...",
     body: "## Reference\n\nImportant domain knowledge here.",
-    steps: [step("do it", { gate: cmd("npm test") })],
+    steps: [experimental_skill.step("do it", { gate: cmd("npm test") })],
     result: cmd("npm test"),
   });
   const { markdown, errors } = compileSkill(spec, opts);
@@ -144,7 +148,11 @@ test("a script-runner gate verifies the referenced script file exists", () => {
     experimental_skill({
       name: "x",
       description: "...",
-      steps: [step("run it", { gate: cmd("python src/core/compile.ts") })],
+      steps: [
+        experimental_skill.step("run it", {
+          gate: cmd("python src/core/compile.ts"),
+        }),
+      ],
     }),
     opts,
   );
@@ -154,7 +162,11 @@ test("a script-runner gate verifies the referenced script file exists", () => {
     experimental_skill({
       name: "x",
       description: "...",
-      steps: [step("run it", { gate: cmd("python scripts/nope.py out.x") })],
+      steps: [
+        experimental_skill.step("run it", {
+          gate: cmd("python scripts/nope.py out.x"),
+        }),
+      ],
     }),
     opts,
   );

--- a/src/adapters/claude-code/typed-spec.ts
+++ b/src/adapters/claude-code/typed-spec.ts
@@ -70,11 +70,29 @@ export function agent<const P extends AuthoredPurity | undefined = undefined>(
 
 /**
  * Define a Claude Code skill with the purity floor enforced AT COMPILE TIME
- * against the Claude Code tool catalog. Identical to the core `skill()` at
- * runtime; the typed `tools` constraint is the only difference.
+ * against the Claude Code tool catalog. Identical to the core
+ * `experimental_skill()` at runtime; the typed `tools` constraint is the only
+ * difference.
+ *
+ * Carries the same `.input` / `.step` helpers as the core builder, and it must:
+ * those two stopped being standalone exports when the helper vocabulary moved
+ * onto the skill builder, so an author who picked this door would otherwise have
+ * no way to reach them. Before the move they came from `vigiles/spec` — a second
+ * import for one skill, which is the asymmetry this closes rather than a cost it
+ * introduces.
+ *
+ * @experimental
  */
-export function experimental_skill<
-  const P extends AuthoredPurity | undefined = undefined,
->(spec: SkillSpecInput<P, ClaudeCodeToolVocabulary>): SkillSpec {
+function skillSpec<const P extends AuthoredPurity | undefined = undefined>(
+  spec: SkillSpecInput<P, ClaudeCodeToolVocabulary>,
+): SkillSpec {
   return coreSkill<P, ClaudeCodeToolVocabulary>(spec);
 }
+
+/**
+ * @experimental
+ */
+export const experimental_skill = Object.assign(skillSpec, {
+  input: coreSkill.input,
+  step: coreSkill.step,
+});

--- a/src/core/spec.ts
+++ b/src/core/spec.ts
@@ -613,8 +613,13 @@ export interface SkillStep {
   readonly retry?: number;
 }
 
-/** Declare a skill input (compiles to argument-hint + an Arguments entry). */
-export function input(
+/**
+ * Declare a skill input (compiles to argument-hint + an Arguments entry).
+ *
+ * Deliberately NOT a standalone export — reached as `experimental_skill.input`.
+ * The reason is on `experimental_skill` below.
+ */
+function input(
   name: string,
   hint: string,
   opts: { required?: boolean } = {},
@@ -622,8 +627,12 @@ export function input(
   return { name, hint, required: opts.required };
 }
 
-/** Declare a gated pipeline step. */
-export function step(
+/**
+ * Declare a gated pipeline step.
+ *
+ * Deliberately NOT a standalone export — reached as `experimental_skill.step`.
+ */
+function step(
   instr: string | InstructionFragment[],
   opts: { gate?: Gate; retry?: number } = {},
 ): SkillStep {
@@ -731,14 +740,35 @@ export type SkillSpecInput<
  * DIFFERENT function — a `Check<Trace>` taking an id string, asking whether a
  * skill fired. This one authors a skill; that one observes one.
  *
+ * Its helper vocabulary hangs off it — `experimental_skill.input(…)` and
+ * `experimental_skill.step(…)` — rather than being exported beside it. Both are
+ * used ONLY by skill specs (measured: zero uses in agent/claude specs, against
+ * `cmd`/`file`/`ref`/`result`, which are shared and therefore stay top-level).
+ * Hanging them here makes the experimental marking STRUCTURAL for the whole
+ * family: you cannot reach `input()` without naming `experimental_skill` first.
+ * The prefix convention alone could not do that — it is a habit, and it had
+ * already leaked once when `skill()` shipped stable-named against its own docs.
+ *
+ * Honest limit: `const { input } = experimental_skill` strips the marker again
+ * inside one file. What the shape actually guarantees is narrower and still
+ * worth having — an unmarked name never crosses the package boundary.
+ *
+ * `Object.assign` rather than `export namespace`: the latter is banned by this
+ * repo's own lint (`no-namespace: error`, inherited from strict-type-checked).
+ *
  * @experimental
  */
-export function experimental_skill<
+function skillSpec<
   const P extends AuthoredPurity | undefined = undefined,
   V extends ToolVocabulary = OpenToolVocabulary,
 >(spec: SkillSpecInput<P, V>): SkillSpec {
   return { _specType: "skill", ...spec } as SkillSpec;
 }
+
+/**
+ * @experimental
+ */
+export const experimental_skill = Object.assign(skillSpec, { input, step });
 
 // ---------------------------------------------------------------------------
 // Subagent specs


### PR DESCRIPTION
## What and why

Three PRs went to `main` red today because the gate list was run from memory (five commands) while the `check` job runs thirteen. The one that failed — `tsc -p test/types/tsconfig.json` — lives in a **separate tsconfig** the root type-check cannot see, and three `@ts-expect-error` assertions had quietly stopped failing.

A longer list to remember does not fix that. One list that CI **invokes** does: `scripts/check.mjs` + `run: npm run check`, replacing thirteen restated steps. This is the field-standard shape (pre-commit / just / mise): the task definition is the source of truth and CI calls it. My earlier idea of "add a gate asserting the two lists agree" is withdrawn — it was a prop under a duplicate that is better removed.

**The stages are load-bearing, not decoration.** Some commands WRITE the files others READ (`generate types` → `.vigiles/generated.d.ts`, `api-extractor` → `api-surface/*`, `build` → `dist/`), so writers are serialized and only the read-only group runs in parallel. **17/17 in 70s** versus ~3 min sequentially.

Failure names are not lost — the runner prints which command failed, and `node scripts/check.mjs --list` prints the commands without running them.

🔴 **Two `uses: ./` steps are excluded on purpose**: they dogfood this repo's own composite Action, which has no shell equivalent. One of them (`eval-check`) was **swallowed by accident** on the first edit — it sat between two command-steps and a span-based replacement took it with them. Restored, with the reason recorded directly above it so the next span edit does not repeat it.

## Safety impact

None. No change to what any check does — only to where the list of them lives.

## Checks

- [x] `npm test` passes locally, or CI is green
- [x] New behaviour has a test — the runner tested itself on first run: it caught an unformatted `check.mjs` and a stale `generated.d.ts` (adding the `check` script changed the generated npm-script union). Both were real, both were fixed.
- [x] Docs updated — the rationale lives in the file header and in the ci.yml comment, where the next person editing either will see it

`npm run check` → **17/17 ✓**, `ci.yml` parses.

Note: `build` runs twice in the job — once as its own step (the Action dogfoods need `dist/`) and once inside `npm run check`. ~11s, left alone deliberately rather than adding freshness caching, which is its own class of stale-artifact bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Features**
- словарь скилла уехал на сам билдер — experimental_skill.input/.step

**CI**
- один список команд вместо двух — CI зовёт `npm run check`
<!-- vigiles:pr-summary:end -->

