### PR TITLE
fix(release): джоба релиза умирала на Node 20 и уносила v16.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,23 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          # 🔴 20 → 22 on 2026-08-16, because the release job DIED on this line and took a
+          # major with it. `semantic-release` refuses to start on Node 20:
+          #
+          #   [semantic-release]: node version ^22.14.0 || >= 24.10.0 is required. Found v20.20.2.
+          #
+          # It fails BEFORE analysing a single commit, so `fix(release)!:` in #152 — the commit
+          # that repaired the preset so `!` means major at all — never became v16.0.0. npm sat
+          # at 15.4.1 while `main` carried breaking changes, which is the exact condition #152
+          # existed to end.
+          #
+          # ⚠️ THE REAL DEFECT IS NOT THIS NUMBER. `semantic-release` is not in package.json at
+          # all, so `npx semantic-release` resolves the newest published version on every run.
+          # The release pipeline therefore changes behaviour with no commit to this repository:
+          # run 132 passed at 19:30 and run 133 failed at 21:24 on the same config, because a
+          # release in between dropped Node 20. Bumping the runtime unblocks today and leaves
+          # that open — pinning the tool as a devDependency is the fix that closes it.
+          node-version: "22"
           cache: "npm"
 
       - run: npm ci


### PR DESCRIPTION
## Что сломано

Джоба релиза умирает на строке с версией Node и уносит с собой мажор:

```
[semantic-release]: node version ^22.14.0 || >= 24.10.0 is required. Found v20.20.2.
```

Она выходит **до** анализа хотя бы одного коммита. Поэтому прогон 133 на `f8280a9` упал, и `fix(release)!:` из #152 — тот самый коммит, который починил пресет, чтобы `!` вообще означал мажор, — так и не стал релизом.

**npm стоит на 15.4.1, пока `main` несёт ломающие изменения.** Это ровно то состояние, ради прекращения которого существовал #152.

## Замер, а не предположение

С уже отгруженным `.releaserc.json` и настоящими коммитами после `v15.4.1`:

```
fix(release)!: `feat!` не давал релиза ВООБЩЕ … (#152)
ci: one list of commands instead of two … (#151)
→ RELEASE TYPE: major
```

То есть этот однострочный бамп и есть то, что публикует **v16.0.0**.

## ⚠️ Настоящий дефект — не это число

`semantic-release` **вообще отсутствует в `package.json`**, поэтому `npx semantic-release` каждый прогон резолвит свежайшую опубликованную версию. Пайплайн релиза меняет поведение **без единого коммита в репозиторий**:

| прогон | время | результат | конфиг |
|---|---|---|---|
| 132 | 19:30 | success | тот же |
| 133 | 21:24 | **failure** | тот же |

Между ними вышел релиз `semantic-release`, уронивший поддержку Node 20. Бамп рантайма разблокирует сегодня; **пин инструмента в devDependencies — это то, что закрывает класс**, и он намеренно НЕ включён сюда, чтобы одобренная публикация не зависела от правки лок-файла. Оговорка записана в самом workflow, а не только тут.

Это тот же класс, что чинился сегодня в `zernie/mine`: зависимость, от которой всё зависит, не зафиксирована, и её дрейф невидим для CI.

## Проверки

Локально на Node 22.22.2 (тот же мажор, что теперь в workflow):

- `npm ci` ✅
- `npm run build` ✅
- `npm run check` — **17/17 за 72s** ✅
- YAML разобран парсером ✅
- вердикт анализатора на реальных коммитах — `major` ✅

## Что произойдёт после мёрджа

Публикуется **v16.0.0**. Это чинит ситуацию, где `15.4.0`/`15.4.1` увезли переименования `experimental_*` под минорной и патч-версиями — у чего теперь есть измеренная цена: в `zernie/mine` они ломают **30 из 44** харнессов.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Fixes**
- release job died on Node 20 and took v16.0.0 with it
<!-- vigiles:pr-summary:end -->
