### PR TITLE
fix(compile): integrity header displaced a skill's frontmatter — the harness lost its contract

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -333,6 +333,7 @@ import {
 import {
   checkIntegrity,
   ejectMarkdown,
+  findIntegrityHeader,
   parseIntegrityHeader,
   REQUIRE_INSTRUCTIONS_SPEC_DISABLE,
 } from "./core/integrity.js";
@@ -2018,12 +2019,16 @@ function vigilesDepSpec(): string {
   return Number.isFinite(major) && major > 0 ? `^${String(major)}` : "latest";
 }
 
-/** True when the file's first line carries a vigiles integrity hash (i.e. it
- * is a compiled artifact we own, safe to overwrite — not hand-written prose). */
+/** True when the file carries a vigiles integrity hash (i.e. it is a compiled artifact we own,
+ * safe to overwrite — not hand-written prose).
+ *
+ * 🔴 This used to read the FIRST LINE only. A compiled SKILL.md carries the header after its
+ * frontmatter, so the first line is `---` and this returned false — vigiles would have treated
+ * its own compiled skill as hand-written prose and refused to overwrite it. The whole-file read
+ * is the cost of not encoding the header's position in a fourth place. */
 function targetHasHash(absPath: string): boolean {
   try {
-    const first = readFileSync(absPath, "utf-8").split("\n", 1)[0];
-    return first.includes("vigiles:sha256");
+    return findIntegrityHeader(readFileSync(absPath, "utf-8")) !== null;
   } catch {
     return false;
   }

--- a/src/core/adopt.ts
+++ b/src/core/adopt.ts
@@ -19,7 +19,7 @@
  * `strengthen`'s separate, later job; adoption is lossless transcription.
  */
 
-import { parseIntegrityHeader } from "./integrity.js";
+import { findIntegrityHeader, parseIntegrityHeader } from "./integrity.js";
 import {
   readFrontmatter,
   frontmatterScalar,
@@ -303,10 +303,17 @@ function splitFrontmatterBody(markdown: string): {
   fm: FrontmatterRead;
   body: string;
 } {
-  const fm = readFrontmatter(markdown);
-  if (fm.block === null) return { fm, body: markdown.replace(/^\uFEFF/, "") };
-  const m = FRONTMATTER_CONSUME_RE.exec(markdown);
-  return { fm, body: m ? markdown.slice(m[0].length) : markdown };
+  // Strip the integrity header FIRST, wherever it sits. FRONTMATTER_CONSUME_RE above knows
+  // only the pre-2026-08-17 placement (a comment BEFORE the frontmatter); once the header
+  // moved below the frontmatter it landed inside what this function calls "the body", so a
+  // round-trip adopt \u2192 compile \u2192 re-adopt grew a stamp into the spec's body on every pass.
+  // Delegating keeps ONE site that knows where the header can be \u2014 which is the entire point
+  // of findIntegrityHeader, and this caller is the one the move missed.
+  const source = findIntegrityHeader(markdown)?.withoutHeader ?? markdown;
+  const fm = readFrontmatter(source);
+  if (fm.block === null) return { fm, body: source.replace(/^\uFEFF/, "") };
+  const m = FRONTMATTER_CONSUME_RE.exec(source);
+  return { fm, body: m ? source.slice(m[0].length) : source };
 }
 
 /** The first non-empty, non-heading paragraph — the CC fallback for a skill's

--- a/src/core/agent.test.ts
+++ b/src/core/agent.test.ts
@@ -20,6 +20,7 @@ import {
   guidance,
 } from "./spec.js";
 import { compileAgent, compileSkill, adoptDiff } from "./compile.js";
+import { readFrontmatter, frontmatterScalar } from "./frontmatter-read.js";
 import { claudeCodeDialect } from "../adapters/claude-code/dialect.js";
 import { makeTmpDir, cleanupTmpDir } from "./test-utils.js";
 
@@ -41,7 +42,24 @@ test("compileAgent renders frontmatter (name/description/model/tools) + hash", (
     { specFile: "agents/reviewer.md.spec.ts", dialect: claudeCodeDialect },
   );
   assert.deepEqual(errors, []);
-  assert.match(markdown, /^<!-- vigiles:sha256:[a-f0-9]+ compiled from/);
+  // The frontmatter — not the stamp — leads the file, and a READER must find the
+  // contract inside it. Asserting the text merely appears is what let the old
+  // placement ship: `name: reviewer` was present in both versions, while a `^---`
+  // parser found no frontmatter at all in the broken one.
+  assert.match(markdown, /^---\r?\n/);
+  const fm = readFrontmatter(markdown);
+  assert.notEqual(
+    fm.block,
+    null,
+    "a frontmatter reader must find a block here",
+  );
+  assert.equal(frontmatterScalar(fm, "name"), "reviewer");
+  assert.equal(
+    frontmatterScalar(fm, "description"),
+    "Review a diff for correctness.",
+  );
+  // The stamp still exists — below the frontmatter, which is the whole change.
+  assert.match(markdown, /\n<!-- vigiles:sha256:[a-f0-9]+ compiled from/);
   assert.match(markdown, /\nname: reviewer\n/);
   assert.match(markdown, /\ndescription: Review a diff for correctness\.\n/);
   assert.match(markdown, /\nmodel: sonnet\n/);

--- a/src/core/compile-generator.test.ts
+++ b/src/core/compile-generator.test.ts
@@ -10,6 +10,7 @@ import {
   compileGenerator,
   compileGeneratorSkill,
 } from "./compile-generator.js";
+import { readFrontmatter, frontmatterScalar } from "./frontmatter-read.js";
 
 const SRC = `
 import { skill, act, checkpoint, finish, cmd } from "vigiles";
@@ -101,7 +102,18 @@ test("compileGeneratorSkill renders frontmatter + body + integrity hash", () => 
     specFile: "skills/x/SKILL.md.spec.ts",
   });
   assert.equal(errors.length, 0, JSON.stringify(errors));
-  assert.match(markdown, /^<!-- vigiles:sha256:[a-f0-9]+ compiled from/);
+  // Frontmatter first, stamp below it — and asserted through a READER, because the
+  // defect this encodes was invisible to a text match: every field was still present
+  // in the file, just no longer in a block any parser would recognise.
+  assert.match(markdown, /^---\r?\n/);
+  const fm = readFrontmatter(markdown);
+  assert.notEqual(
+    fm.block,
+    null,
+    "a frontmatter reader must find a block here",
+  );
+  assert.equal(frontmatterScalar(fm, "name"), "ship-pr");
+  assert.match(markdown, /\n<!-- vigiles:sha256:[a-f0-9]+ compiled from/);
   assert.match(markdown, /name: ship-pr/);
   assert.match(markdown, /description: Open a PR once tests pass/);
   assert.match(markdown, /disable-model-invocation: true/);

--- a/src/core/compile.ts
+++ b/src/core/compile.ts
@@ -57,6 +57,25 @@ export function computeHash(content: string): string {
 
 /** @internal Prepend a hash comment to compiled content. */
 export function addHash(content: string, specFile: string): string {
+  // 🔴 THE LAST GATE BEFORE A COMPILED FILE IS WRITTEN. Every compile path returns through here
+  // (four call sites), which makes it the one place a whole class of defect can be stopped.
+  //
+  // `[object Object]` in output means a spec passed an object where the API takes a string, and
+  // JS stringified it instead of complaining — types cannot stop this for a user's spec, because
+  // `vigiles compile` runs `.spec.ts` through tsx: transpiled, types erased, never checked.
+  // Observed 2026-08-17 from `input({ name, description })`, which shipped
+  // `argument-hint: <[object Object]>` into a SKILL.md with no error anywhere.
+  //
+  // Hard error, not a warning: the string never appears legitimately (measured — zero
+  // occurrences across every `.md` in this repository), and a file carrying it is broken in a
+  // way its author cannot see by reading the spec.
+  if (content.includes("[object Object]")) {
+    throw new Error(
+      `Compiled output for ${specFile} contains "[object Object]" — a spec value was an object ` +
+        `where a string was expected, and JavaScript stringified it. Check the arguments to ` +
+        `input()/file()/cmd() and friends: they take strings, not option objects.`,
+    );
+  }
   return placeIntegrityHeader(content, computeHash(content), specFile);
 }
 

--- a/src/core/compile.ts
+++ b/src/core/compile.ts
@@ -10,6 +10,7 @@ import { globSync } from "glob";
 import { resolve, dirname, basename } from "node:path";
 
 import { sha256short, assertNever } from "./hash.js";
+import { findIntegrityHeader, placeIntegrityHeader } from "./integrity.js";
 import { fencedLineFlags } from "./markdown.js";
 import { fileDefinesSymbol, langForFile } from "./symbols.js";
 
@@ -44,32 +45,29 @@ const DEFAULT_TARGET = "CLAUDE.md";
 // Hash utilities
 // ---------------------------------------------------------------------------
 
-const HASH_RE =
-  /^<!-- vigiles:sha256:([a-f0-9]+) compiled from (.+) -->\r?\n\r?\n?/;
+// The header's position and format now live in ONE place — `./integrity.js`. The local
+// `HASH_RE` that used to sit here was one of four independent copies of "the header is the first
+// line", and that duplication is what let the placement invariant drift unnoticed (see the block
+// comment on FRONTMATTER_RE in integrity.ts).
 
 /** @internal Compute SHA-256 hash of content (excluding any existing hash line). */
 export function computeHash(content: string): string {
-  const body = content.replace(HASH_RE, "");
-  return sha256short(body);
+  return sha256short(findIntegrityHeader(content)?.withoutHeader ?? content);
 }
 
 /** @internal Prepend a hash comment to compiled content. */
 export function addHash(content: string, specFile: string): string {
-  const hash = computeHash(content);
-  return `<!-- vigiles:sha256:${hash} compiled from ${specFile} -->\n\n${content}`;
+  return placeIntegrityHeader(content, computeHash(content), specFile);
 }
 
 /** @internal Check if a file's hash matches its content. Returns null if no hash found. */
 export function verifyHash(
   content: string,
 ): { valid: boolean; specFile: string } | null {
-  const match = content.match(HASH_RE);
-  if (!match) return null;
-  const expectedHash = match[1];
-  const specFile = match[2];
-  const body = content.replace(HASH_RE, "");
-  const actualHash = sha256short(body);
-  return { valid: actualHash === expectedHash, specFile };
+  const found = findIntegrityHeader(content);
+  if (!found) return null;
+  const actualHash = sha256short(found.withoutHeader);
+  return { valid: actualHash === found.hash, specFile: found.specFile };
 }
 
 // ---------------------------------------------------------------------------
@@ -1401,10 +1399,13 @@ export function adoptDiff(
   }
 
   // Simple line-based diff
-  const currentLines = currentContent.replace(HASH_RE, "").split("\n");
-  const compiledLines = (compiledContent ?? "")
-    .replace(HASH_RE, "")
-    .split("\n");
+  const currentLines = (
+    findIntegrityHeader(currentContent)?.withoutHeader ?? currentContent
+  ).split("\n");
+  const compiledLines = (() => {
+    const c = compiledContent ?? "";
+    return (findIntegrityHeader(c)?.withoutHeader ?? c).split("\n");
+  })();
 
   const currentSet = new Set(currentLines);
   const compiledSet = new Set(compiledLines);

--- a/src/core/coverage.ts
+++ b/src/core/coverage.ts
@@ -10,6 +10,7 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
+import { findIntegrityHeader } from "./integrity.js";
 import { resolve } from "node:path";
 import { globSync } from "glob";
 
@@ -83,13 +84,13 @@ export function collectDocumentedCommands(
     const fullPath = resolve(basePath, mdFile);
     try {
       const content = readFileSync(fullPath, "utf-8");
-      const specMatch = content.match(
-        /^<!-- vigiles:sha256:[a-f0-9]+ compiled from (.+) -->/,
-      );
-      if (!specMatch) continue;
+      // Ask integrity.ts where the header is — a compiled SKILL.md carries it AFTER its
+      // frontmatter, so an `^`-anchored match here silently skipped every skill.
+      const found = findIntegrityHeader(content);
+      if (!found) continue;
 
       // Try to load the spec's compiled JS from dist/
-      const specFile = specMatch[1];
+      const specFile = found.specFile;
       const jsPath = resolve(
         basePath,
         "dist",

--- a/src/core/frontmatter-read.ts
+++ b/src/core/frontmatter-read.ts
@@ -29,8 +29,12 @@ export interface FrontmatterRead {
 // Frontmatter is the very first thing in the file. Anchoring at the start — not
 // `(?:^|\n)` — means a `---` horizontal rule in the BODY is never mistaken for
 // frontmatter (which matters for the malformed-YAML verdict). A leading BOM is
-// stripped first; an optional leading HTML comment is allowed too — vigiles
-// stamps a compiled file with `<!-- vigiles:sha256:… -->` before the `---`.
+// stripped first; an optional leading HTML comment is allowed too, which is what
+// lets this reader still parse files compiled BEFORE 2026-08-17, when vigiles put
+// the `<!-- vigiles:sha256:… -->` stamp above the `---` and thereby hid the
+// frontmatter from every stricter reader. Since then the stamp goes BELOW the
+// frontmatter (placeIntegrityHeader), so this branch is backward compatibility,
+// not a description of what the compiler emits today.
 const BLOCK_RE = /^\uFEFF?(?:<!--[\s\S]*?-->\s*)?---\r?\n([\s\S]*?)\r?\n---/;
 
 /** A YAML block-scalar indicator: `>`/`|` with optional chomp (`+`/`-`) + indent digit. */

--- a/src/core/integrity.test.ts
+++ b/src/core/integrity.test.ts
@@ -7,6 +7,8 @@ import {
   checkIntegrity,
   parseIntegrityHeader,
   ejectMarkdown,
+  findIntegrityHeader,
+  placeIntegrityHeader,
   REQUIRE_INSTRUCTIONS_SPEC_DISABLE,
 } from "./integrity.js";
 import { sha256short } from "./hash.js";
@@ -84,5 +86,79 @@ describe("ejectMarkdown", () => {
     expect(out?.markdown.split(REQUIRE_INSTRUCTIONS_SPEC_DISABLE).length).toBe(
       2,
     );
+  });
+});
+
+/**
+ * Where the integrity header sits relative to YAML frontmatter.
+ *
+ * 🔴 THE DEFECT THESE PIN. `addHash` prepended the header to every compiled file, including
+ * SKILL.md — whose frontmatter must be the first thing in the file or the harness cannot read the
+ * skill's name, description or tools. `ejectMarkdown`'s docstring in this very module had said so
+ * since it was written; the compiler two modules over did the opposite.
+ *
+ * Measured 2026-08-17 on five real skills: after compiling, a `^---` reader found NO frontmatter.
+ * That one line was the ENTIRE diff against the hand-written original — body byte-identical,
+ * section order untouched — so it was the whole reason a compiled skill could not be adopted.
+ */
+describe("integrity header placement", () => {
+  const FM = "---\nname: demo\nallowed-tools: [Read]\n---\n";
+  const BODY = "# Demo\n\nSome instructions.\n";
+
+  it("goes AFTER frontmatter, leaving `---` as the first line", () => {
+    const out = placeIntegrityHeader(FM + BODY, "abc123", "SKILL.md.spec.ts");
+    expect(out.startsWith("---\n")).toBe(true);
+    expect(out).toContain(
+      "<!-- vigiles:sha256:abc123 compiled from SKILL.md.spec.ts -->",
+    );
+    // The property that actually matters: a reader anchored at `^---` still finds the block.
+    expect(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/.exec(out)?.[1]).toContain(
+      "name: demo",
+    );
+  });
+
+  it("still goes FIRST when the file has no frontmatter", () => {
+    const out = placeIntegrityHeader(BODY, "abc123", "CLAUDE.md.spec.ts");
+    expect(out.startsWith("<!-- vigiles:sha256:abc123")).toBe(true);
+  });
+
+  it("round-trips: a stamped frontmatter file verifies as intact", () => {
+    const content = FM + BODY;
+    const stamped = placeIntegrityHeader(
+      content,
+      sha256short(content),
+      "s.spec.ts",
+    );
+    expect(checkIntegrity(stamped).intact).toBe(true);
+    expect(parseIntegrityHeader(stamped)?.specFile).toBe("s.spec.ts");
+  });
+
+  it("a hand-edit under the header is still caught", () => {
+    const content = FM + BODY;
+    const stamped = placeIntegrityHeader(
+      content,
+      sha256short(content),
+      "s.spec.ts",
+    );
+    expect(
+      checkIntegrity(stamped.replace("Some instructions.", "Tampered.")).intact,
+    ).toBe(false);
+  });
+
+  // Backward compatibility is not optional: every SKILL.md compiled before this fix carries the
+  // header FIRST and its frontmatter second. Those files must keep verifying, or upgrading vigiles
+  // would report every previously-compiled skill as hand-edited.
+  it("reads the OLD layout — header first, frontmatter second", () => {
+    const content = FM + BODY;
+    const old = `<!-- vigiles:sha256:${sha256short(content)} compiled from s.spec.ts -->\n\n${content}`;
+    const found = findIntegrityHeader(old);
+    expect(found?.specFile).toBe("s.spec.ts");
+    expect(found?.withoutHeader).toBe(content);
+    expect(checkIntegrity(old).intact).toBe(true);
+  });
+
+  it("finds nothing in plain markdown", () => {
+    expect(findIntegrityHeader(FM + BODY)).toBeNull();
+    expect(findIntegrityHeader(BODY)).toBeNull();
   });
 });

--- a/src/core/integrity.test.ts
+++ b/src/core/integrity.test.ts
@@ -12,6 +12,9 @@ import {
   REQUIRE_INSTRUCTIONS_SPEC_DISABLE,
 } from "./integrity.js";
 import { sha256short } from "./hash.js";
+import { addHash } from "./compile.js";
+import { experimental_skill } from "./spec.js";
+const { input } = experimental_skill;
 
 /** Build a compiled-file string with a VALID header for `body`. */
 function compiled(body: string, spec = "CLAUDE.md.spec.ts"): string {
@@ -160,5 +163,52 @@ describe("integrity header placement", () => {
   it("finds nothing in plain markdown", () => {
     expect(findIntegrityHeader(FM + BODY)).toBeNull();
     expect(findIntegrityHeader(BODY)).toBeNull();
+  });
+});
+
+/**
+ * The output boundary refuses a stringified object.
+ *
+ * 🔴 Measured 2026-08-17: `input({ name, description })` — the object form a reader reasonably
+ * guesses — compiled with no error and wrote `argument-hint: <[object Object]>` into a shipped
+ * SKILL.md. Types cannot stop it for a user's spec: `vigiles compile` runs `.spec.ts` through
+ * tsx, which transpiles and erases types without checking them.
+ */
+describe("addHash refuses stringified objects", () => {
+  it("throws when the compiled body carries [object Object]", () => {
+    expect(() =>
+      addHash(
+        "# Skill\n\n- `$1` **[object Object]** — undefined\n",
+        "s.spec.ts",
+      ),
+    ).toThrow(/\[object Object\]/);
+  });
+
+  it("stays quiet on ordinary content", () => {
+    expect(() =>
+      addHash("# Skill\n\nOrdinary prose.\n", "s.spec.ts"),
+    ).not.toThrow();
+  });
+});
+
+/** `input()` is the boundary where that object actually enters. */
+describe("input() refuses a non-string call", () => {
+  it("throws on the object form, and names the real signature", () => {
+    // @ts-expect-error — the point is that TS would catch this and tsx does not.
+    expect(() => input({ name: "p", description: "d" })).toThrow(
+      /input\(name, hint/,
+    );
+  });
+
+  it("throws on an empty hint rather than rendering a blank argument", () => {
+    expect(() => input("p", "  ")).toThrow(/two strings/);
+  });
+
+  it("accepts the documented call", () => {
+    expect(input("pattern", "regex to search for")).toEqual({
+      name: "pattern",
+      hint: "regex to search for",
+      required: undefined,
+    });
   });
 });

--- a/src/core/integrity.ts
+++ b/src/core/integrity.ts
@@ -23,6 +23,91 @@ import { sha256short } from "./hash.js";
 const HASH_LINE_RE =
   /^<!-- vigiles:sha256:([a-f0-9]+) compiled from (.+) -->\r?\n\r?\n?/;
 
+/**
+ * A YAML frontmatter block at the very start of a file: `---\n … \n---\n`.
+ *
+ * 🔴 THIS EXISTS BECAUSE THE INVARIANT WAS STATED IN THIS FILE AND VIOLATED IN ANOTHER.
+ * `ejectMarkdown` (bottom of this module) has documented since it was written that a compiled
+ * SKILL.md begins with frontmatter which MUST stay in first position, or "the harness would lose
+ * the skill's name/description/tools". `addHash` in compile.ts prepended the integrity header to
+ * every compiled file unconditionally — including those same skills.
+ *
+ * Measured 2026-08-17 on five real skills: after compiling, a reader anchored to `^---` finds NO
+ * frontmatter at all. The header was the ENTIRE delta — body byte-identical, section order
+ * untouched — so one misplaced line was the whole reason a compiled skill could not be adopted.
+ *
+ * The header now goes AFTER the frontmatter when there is one. Readers must ask this module where
+ * the header is rather than anchoring their own regex at `^`: four call sites had independently
+ * encoded "first line", and that duplication is what let the invariant drift unnoticed.
+ */
+const FRONTMATTER_RE = /^---\r?\n[\s\S]*?\r?\n---[ \t]*\r?\n/;
+
+/** Same header, matched where it sits below a frontmatter block (blank line allowed). */
+const HASH_LINE_IN_BODY_RE =
+  /^\s*<!-- vigiles:sha256:([a-f0-9]+) compiled from (.+) -->\r?\n\r?\n?/;
+
+/**
+ * Split off a leading frontmatter block. `head` is `""` when the file has none, so a caller can
+ * concatenate `head + body` unconditionally and get the original content back.
+ */
+export function splitFrontmatter(content: string): {
+  head: string;
+  body: string;
+} {
+  const m = FRONTMATTER_RE.exec(content);
+  return m
+    ? { head: m[0], body: content.slice(m[0].length) }
+    : { head: "", body: content };
+}
+
+/**
+ * Locate the integrity header wherever it legitimately sits — before the frontmatter (files
+ * compiled before 2026-08-17) or after it (files compiled since). Returns the hash, the spec
+ * path, and the content with the header removed and everything else intact.
+ *
+ * This is the ONLY place that knows where the header can be. Matching `/^<!-- vigiles:sha256/`
+ * by hand elsewhere is the bug this function exists to make unnecessary.
+ */
+export function findIntegrityHeader(content: string): {
+  hash: string;
+  specFile: string;
+  /** `content` minus the header, frontmatter still in place. */
+  withoutHeader: string;
+} | null {
+  const { head, body } = splitFrontmatter(content);
+  // After the frontmatter — the current placement. The leading `\s*` is load-bearing: the header
+  // is written one blank line below the closing `---` for readability, so an anchor at position 0
+  // of the body misses it. A test caught exactly that before it shipped.
+  const inBody = body.match(HASH_LINE_IN_BODY_RE);
+  if (inBody) {
+    return {
+      hash: inBody[1],
+      specFile: inBody[2],
+      withoutHeader: head + body.replace(HASH_LINE_IN_BODY_RE, ""),
+    };
+  }
+  // Or at the very top, which is what a file compiled before the fix looks like. Such a file has
+  // no leading frontmatter by definition — the header displaced it — so `head` is empty here.
+  const atTop = content.match(HASH_LINE_RE);
+  if (!atTop) return null;
+  return {
+    hash: atTop[1],
+    specFile: atTop[2],
+    withoutHeader: content.replace(HASH_LINE_RE, ""),
+  };
+}
+
+/** Render the header in its correct position for this content. */
+export function placeIntegrityHeader(
+  content: string,
+  hash: string,
+  specFile: string,
+): string {
+  const stamp = `<!-- vigiles:sha256:${hash} compiled from ${specFile} -->`;
+  const { head, body } = splitFrontmatter(content);
+  return head ? `${head}\n${stamp}\n\n${body}` : `${stamp}\n\n${body}`;
+}
+
 export interface IntegrityResult {
   intact: boolean;
   reason?: string;
@@ -33,12 +118,12 @@ export interface IntegrityResult {
  * Files without a hash header are treated as hand-written (intact).
  */
 export function checkIntegrity(content: string): IntegrityResult {
-  const match = content.match(HASH_LINE_RE);
-  if (!match) {
+  const found = findIntegrityHeader(content);
+  if (!found) {
     return { intact: true, reason: "No hash header (hand-written file)" };
   }
-  const expectedHash = match[1];
-  const body = content.replace(HASH_LINE_RE, "");
+  const expectedHash = found.hash;
+  const body = found.withoutHeader;
   if (sha256short(body) !== expectedHash) {
     return {
       intact: false,
@@ -62,9 +147,9 @@ export const REQUIRE_INSTRUCTIONS_SPEC_DISABLE =
 export function parseIntegrityHeader(
   content: string,
 ): { specFile: string; body: string } | null {
-  const match = content.match(HASH_LINE_RE);
-  if (!match) return null;
-  return { specFile: match[2], body: content.replace(HASH_LINE_RE, "") };
+  const found = findIntegrityHeader(content);
+  if (!found) return null;
+  return { specFile: found.specFile, body: found.withoutHeader };
 }
 
 /**

--- a/src/core/spec.ts
+++ b/src/core/spec.ts
@@ -624,6 +624,27 @@ function input(
   hint: string,
   opts: { required?: boolean } = {},
 ): SkillInput {
+  // 🔴 The types say `string`, and for a USER's spec nothing enforces that: `vigiles compile`
+  // loads `.spec.ts` through tsx, which transpiles and erases types without checking them.
+  // (vigiles's OWN specs are cross-checked by a separate `tsc --noEmit` over a generated
+  // registry — that safety net does not travel to the people compiling their own specs.)
+  //
+  // Measured 2026-08-17: calling `input({ name, description })` — the object form a reader
+  // reasonably guesses — compiled with NO error and wrote this into the shipped SKILL.md:
+  //
+  //     argument-hint: <[object Object]>
+  //     - `$1` **[object Object]** — undefined
+  //
+  // A wrong call became a wrong file, silently. Refusing here makes the mistake loud at the
+  // moment it is made, and the message carries the real signature because "expected string"
+  // alone does not tell the caller what to write instead.
+  const bad = (v: unknown) => typeof v !== "string" || v.trim() === "";
+  if (bad(name) || bad(hint)) {
+    throw new TypeError(
+      `input() takes two strings: input(name, hint, opts?) — e.g. input("pattern", "regex to search for").\n` +
+        `  got name=${JSON.stringify(name)}, hint=${JSON.stringify(hint)}`,
+    );
+  }
   return { name, hint, required: opts.required };
 }
 


### PR DESCRIPTION
## The defect

`addHash` prepended `<!-- vigiles:sha256:… -->` to **every** compiled file. For a `SKILL.md` that pushes the YAML frontmatter out of first position, and a reader anchored at `^---` then finds **no frontmatter at all** — no name, no description, no `allowed-tools`.

🔴 **The invariant was already written down, in the very module this fix lands in.** `ejectMarkdown` in `integrity.ts` has documented since it was written:

> *"A compiled SKILL.md / subagent body begins with YAML frontmatter (`---`) that **MUST stay in first position** — prepending an HTML comment there would push the frontmatter out of the lead block and **the harness would lose the skill's name/description/tools**."*

It honours that. `addHash`, two modules over, did exactly the prohibited thing to exactly those files.

## Measured, not reasoned

Five real skills from a live corpus (145–256 lines) translated to minimal specs and compiled. The header was the **entire** delta:

| | result |
|---|---|
| body | **byte-identical** |
| section order | untouched |
| diff | **5 added / 1–2 removed** — identical on all five regardless of size |
| frontmatter, original | ✅ found by a `^---` parser |
| frontmatter, compiled | 🔴 **NOT FOUND** |

So one misplaced line was the whole reason a compiled skill could not be adopted. Everything else feared about adoption — reordered sections, a generated `## Arguments` — turned out to be **opt-in and absent** unless `input()` is used.

Bonus, unchanged by this PR but worth naming: the hand-written `allowed-tools: Read, Write, Edit` parses as a **string**; the compiler emits a real YAML list. The compiler was already *fixing* a latent contract defect.

## The real defect was duplication

Four sites independently encoded "the header is the first line":

| site | form |
|---|---|
| `compile.ts` `HASH_RE` | `^<!--…` |
| `integrity.ts` `HASH_LINE_RE` | `^<!--…` |
| `coverage.ts` | `^<!--…` |
| `cli.ts` `targetHasHash` | **first line only** |

Position now lives in **one** place — `findIntegrityHeader` / `placeIntegrityHeader` — and the other three ask it.

`targetHasHash` was the dangerous one: it decides whether a file is ours and safe to overwrite. Reading only the first line, it would have called every compiled skill hand-written prose and **refused to update it**.

## Backward compatible by construction

Every `SKILL.md` compiled before today carries the header first — and such a file has no leading frontmatter (the header displaced it), so the same function finds it at the top. Without this, upgrading would report every previously-compiled file as hand-edited. Pinned by a test.

## Tests

Six new cases: placement with and without frontmatter · round-trip · tamper detection · the OLD layout · plain markdown.

**Mutation-proved:** reverting `placeIntegrityHeader` to prepend fails **exactly** the placement case (1 failed / 14 passed); restoring passes 15/15.

⚠️ One defect was caught by these tests **before shipping, not by review**: the header is written a blank line below the closing `---`, and the finder anchored at position 0 of the body missed it. The file *looked* correct and `checkIntegrity` failed on it. The `\s*` in `HASH_LINE_IN_BODY_RE` is what makes it hold, and it is commented as load-bearing.

## Gates

In order, named: `npx vitest run` · `npm run lint` · `npx prettier --check .` · `npm run api:check` · `npm run build` — via `npm run check`, **17/17 in 77s**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Fixes**
- integrity header displaced a skill's frontmatter, so the harness lost its contract
- a spec value that was an object shipped as "[object Object]" with no error
<!-- vigiles:pr-summary:end -->

