### PR TITLE
fix(coverage): the runner executed colocated tests and discarded the result

### DIFF
--- a/.vigiles/generated.d.ts
+++ b/.vigiles/generated.d.ts
@@ -101,7 +101,7 @@ declare module "vigiles/generated" {
     | "experimental:check"
     | "docs:api";
 
-  /** 371 project files. */
+  /** 372 project files. */
   export type ProjectFile = 
     | "src/CLAUDE.md"
     | "src/CLAUDE.md.spec.ts"
@@ -198,6 +198,7 @@ declare module "vigiles/generated" {
     | "src/cli.test.ts"
     | "src/cli.ts"
     | "src/codex.ts"
+    | "src/colocated-execution.test.ts"
     | "src/community-skills.test.ts"
     | "src/community-skills.ts"
     | "src/core/CLAUDE.md"
@@ -641,6 +642,7 @@ declare module "vigiles/spec" {
       | "src/cli.test.ts"
       | "src/cli.ts"
       | "src/codex.ts"
+      | "src/colocated-execution.test.ts"
       | "src/community-skills.test.ts"
       | "src/community-skills.ts"
       | "src/core/CLAUDE.md"

--- a/src/cli-coverage-record.test.ts
+++ b/src/cli-coverage-record.test.ts
@@ -400,3 +400,54 @@ test("…and the flag is not assumed: the default and an explicit `claude-code` 
     "naming the harness this repo already is must change nothing",
   );
 });
+
+/**
+ * A COLOCATED HARNESS THAT RAN IS RECORDED — end to end, through the real CLI.
+ *
+ * 🔴 THIS IS THE ONLY TEST THAT PROVES `checks` REACHES THE ARTIFACT. The unit
+ * tests in colocated-execution.test.ts hand-build `ScriptRunRecord`s, so every
+ * one of them would still pass if `cli.ts` dropped the field between
+ * `runScripts` and `runsFromResults` — the whole attribution is silently keyed on
+ * a number that travels four hops, and the hops are what break.
+ */
+test("a colocated harness that reported checks is MEASURED BY A RUN", () => {
+  write(
+    ".claude/skills/arc/SKILL.md",
+    "---\nname: arc\ndescription: does the arc\n---\nbody\n",
+  );
+  // Asserts through the counter, the way an ordinary harness does — no probe.
+  write(
+    ".claude/skills/arc/arc.harness.mjs",
+    `import { recordCheck } from ${JSON.stringify(
+      resolve(__dirname, "..", "dist", "check-count.js"),
+    )};\nrecordCheck();\n`,
+  );
+  vigilesTest();
+  assert.ok(
+    recorded()?.includes(".claude/skills/arc/SKILL.md"),
+    "the run happened and the runner watched it — it must not be reported as a directory listing",
+  );
+  assert.match(vigilesLint(), /MEASURED BY A RUN/);
+});
+
+test("…and an EMPTY colocated harness is not, though it also 'passes'", () => {
+  // THE QUIET HALF, and the one that matters more. `touch` → runs → exits 0.
+  // Without the reported-check bar this file would be promoted from "the file
+  // EXISTS" to "MEASURED BY A RUN": the same emptiness wearing the stronger
+  // label, which is worse than the hole being closed.
+  write(".claude/skills/arc/SKILL.md", "---\nname: arc\n---\nbody\n");
+  write(".claude/skills/arc/arc.harness.mjs", "");
+  vigilesTest();
+  // `null` — no artifact at all — is the stronger outcome and the one observed:
+  // a repo with nothing to record must not grow a `.vigiles/coverage.json`. That
+  // is the "absent artifact = today's behaviour, exactly" property.
+  assert.deepEqual(
+    recorded() ?? [],
+    [],
+    "an empty script cannot report a check, so it earns no execution record",
+  );
+  const out = vigilesLint();
+  assert.doesNotMatch(out, /MEASURED BY A RUN/);
+  // …while colocation still credits it, exactly as before this tier existed.
+  assert.match(out, /colocated/);
+});

--- a/src/colocated-execution.test.ts
+++ b/src/colocated-execution.test.ts
@@ -1,0 +1,295 @@
+/**
+ * A COLOCATED TEST THAT RAN IS EXECUTION EVIDENCE — and an empty one still is not.
+ *
+ * ## The defect
+ *
+ * Coverage had two tiers: a recorded run (`executed`) and a file sitting beside
+ * the surface (`colocated`). The second printed its own caveat — *"this says the
+ * file EXISTS, not that it ran"* — and on a real 52-surface repo it carried 23 of
+ * the 27 covered surfaces. Those 23 are ordinary `*.harness.mjs` files that
+ * `vigiles test` RUNS on every push. The run happened, the runner watched it, and
+ * the metric described it as a directory listing, because a harness asserting
+ * through `node:assert` reports a CHECK COUNT and no surface probe.
+ *
+ * 🔴 THE HAZARD WHILE FIXING IT POINTS THE OTHER WAY, which is why the negatives
+ * below matter more than the positive. `touch <skill>/<skill>.harness.mjs` — zero
+ * bytes — already drops the untested count by one, and `vigiles test` then runs it
+ * and prints `✓ passed`, because an empty script exits 0. Attributing on "it ran
+ * and exited 0" would promote that file from `colocated` to "MEASURED BY A RUN":
+ * the same emptiness wearing the stronger label, which is worse than the hole
+ * being closed. The bar is therefore a REPORTED CHECK, not an exit code.
+ */
+import { test } from "vitest";
+import assert from "node:assert/strict";
+
+import {
+  COVERAGE_ARTIFACT_VERSION,
+  readCoverageArtifact,
+  recordsFrom,
+  runsFromResults,
+  writeCoverageArtifact,
+  type CoverageRun,
+} from "./coverage-artifact.js";
+import { parseCheckReport } from "./check-count.js";
+import { isColocatedTest } from "./coverage-evidence.js";
+import type { Surface } from "./test-coverage.js";
+import { makeTmpDir, cleanupTmpDir } from "./core/test-utils.js";
+
+const skill = (name: string, path: string): Surface => ({
+  kind: "skill",
+  path,
+  name,
+  tokens: [],
+  ignored: false,
+});
+
+const ARC = skill("argument-arc", ".claude/skills/argument-arc/SKILL.md");
+const HARNESS = ".claude/skills/argument-arc/argument-arc.harness.mjs";
+
+function records(
+  run: { file: string; checks?: number },
+  surfaces: readonly Surface[] = [ARC],
+): ReturnType<typeof recordsFrom> {
+  return recordsFrom({
+    runs: [{ ...run, probes: [] }],
+    surfaces,
+    tier: "harness",
+    at: "2026-08-17T00:00:00.000Z",
+    readSurface: () => "body",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// FIRES — the half that was missing
+// ---------------------------------------------------------------------------
+
+test("a colocated script that reported a check attributes its surface", () => {
+  const out = records({ file: HARNESS, checks: 3 });
+  assert.equal(out.length, 1);
+  assert.equal(out[0]?.path, ARC.path);
+  assert.equal(out[0]?.by, HARNESS);
+  // The attribution is NAMED, so a reader of the artifact can tell this from a
+  // probe the script reported about itself.
+  assert.equal(out[0]?.how, "colocated");
+  assert.equal(out[0]?.tier, "harness");
+});
+
+test("runsFromResults keeps a passing run that reported checks and no probes", () => {
+  // The clause that used to be `surfaces.length > 0` and discarded exactly the
+  // ordinary case: a harness that asserts through node:assert.
+  assert.deepEqual(
+    runsFromResults([
+      { file: HARNESS, status: "pass", checks: 2, surfaces: [] },
+    ]),
+    [{ file: HARNESS, probes: [], checks: 2 }],
+  );
+});
+
+// ---------------------------------------------------------------------------
+// SILENT — the halves that keep this from becoming the defect it closes
+// ---------------------------------------------------------------------------
+
+test("an EMPTY colocated script earns nothing — it reported no check", () => {
+  // `touch foo.harness.mjs` → runs → exits 0 → `checks` is undefined, because a
+  // script that never imports vigiles cannot report. Silence is the legacy
+  // branch, never a verdict (check-count.ts), so it keeps its colocated credit
+  // and gains no execution credit.
+  assert.deepEqual(records({ file: HARNESS }), []);
+  assert.deepEqual(
+    runsFromResults([{ file: HARNESS, status: "pass", surfaces: [] }]),
+    [],
+  );
+});
+
+test("a script reporting ZERO checks earns nothing", () => {
+  assert.deepEqual(records({ file: HARNESS, checks: 0 }), []);
+});
+
+test("a script that is not colocated with anything earns nothing", () => {
+  // The generic root harness that walks every skill at runtime. It is discarded
+  // deliberately: a conformance lint over 21 skills is not 21 tests, which is the
+  // measurement that retired the `vigiles:covers` tier (coverage-evidence.ts).
+  assert.deepEqual(records({ file: "skills.harness.mjs", checks: 21 }), []);
+  // Right name, WRONG PLACE — a sibling directory is not beside it.
+  assert.deepEqual(
+    records({ file: "test/argument-arc.harness.mjs", checks: 4 }),
+    [],
+  );
+  // Right place, WRONG NAME — the defect №17 shape, reached through execution.
+  assert.deepEqual(
+    records({
+      file: ".claude/skills/argument-arc/grade-paper-writing.harness.mjs",
+      checks: 4,
+    }),
+    [],
+  );
+});
+
+test("an AMBIGUOUS colocation earns nothing rather than crediting both", () => {
+  // Colocation asks only that the basename START with `<name>.`, so one script
+  // can match two surfaces when one name prefixes the other. Exactly one of them
+  // is what the test is about and nothing here can say which; crediting both
+  // would INVENT a record. Same rule `resolveProbe` applies to probes.
+  const foo = skill("foo", "skills/foo/SKILL.md");
+  const fooBar = skill("foo.bar", "skills/foo/foo.bar.SKILL.md");
+  assert.deepEqual(
+    records({ file: "skills/foo/foo.bar.harness.mjs", checks: 9 }, [
+      foo,
+      fooBar,
+    ]),
+    [],
+  );
+  // The control: drop the second surface and the SAME run attributes cleanly, so
+  // the emptiness above is the ambiguity rule and not a broken match.
+  assert.equal(
+    records({ file: "skills/foo/foo.bar.harness.mjs", checks: 9 }, [foo])
+      .length,
+    1,
+  );
+});
+
+test("colocation does not DOWNGRADE an attribution the run already made", () => {
+  // 🔴 MEASURED REGRESSION, not a hypothetical. The first run of this tier on a
+  // 52-surface repo turned `.claude/hooks/paper-lint.mjs` from `command` — the
+  // harness executed that exact path — into `colocated`, and took three `fired`
+  // skill activations with it. `mergeRuns` dedupes on (surface, tier, script) and
+  // does NOT include `how`, so a second attribution of the same pair REPLACES the
+  // first rather than joining it; same `at` on both, so the last one pushed wins.
+  const hook: Surface = {
+    kind: "hook",
+    path: ".claude/hooks/paper-lint.mjs",
+    name: "paper-lint",
+    tokens: [],
+    ignored: false,
+  };
+  const out = recordsFrom({
+    runs: [
+      {
+        file: ".claude/hooks/paper-lint.harness.mjs",
+        probes: [{ how: "command", ref: ".claude/hooks/paper-lint.mjs" }],
+        checks: 7,
+      },
+    ],
+    surfaces: [hook],
+    tier: "harness",
+    at: "2026-08-17T00:00:00.000Z",
+    readSurface: () => "body",
+  });
+  // Colocation ALSO holds here (the harness is named after the hook and sits
+  // beside it), so this is exactly the collision — and the direct observation
+  // must survive it.
+  assert.equal(
+    isColocatedTest(hook, ".claude/hooks/paper-lint.harness.mjs"),
+    true,
+  );
+  assert.deepEqual(
+    out.map((r) => r.how),
+    ["command"],
+  );
+});
+
+test("a surface cannot be its own colocated test", () => {
+  // Degenerate, but the probe path guards it (`t.path === surface.path`) and this
+  // path must not be the one place a file covers itself.
+  assert.deepEqual(records({ file: ARC.path, checks: 5 }, [ARC]), []);
+});
+
+test("the artifact accepts `colocated` and still rejects an unknown attribution", () => {
+  // 🔴 NEITHER HALF WAS PINNED BY ANYTHING, and that was measured, not assumed:
+  // mutating the validator to `return typeof value === "string"` — accept ANY
+  // string as an attribution — left the whole coverage suite green (67 passed).
+  //
+  // Both directions matter. If `colocated` were not in the accepted set, records
+  // would be written and then silently DISCARDED on read, and the tier would
+  // appear to work inside one process and evaporate between runs. If the set were
+  // open, a hand-edited artifact could name any attribution it liked.
+  const dir = makeTmpDir("colocated-artifact");
+  try {
+    writeCoverageArtifact(dir, {
+      v: COVERAGE_ARTIFACT_VERSION,
+      generated: "2026-08-17T00:00:00.000Z",
+      runs: [
+        {
+          kind: "skill",
+          path: ARC.path,
+          name: "argument-arc",
+          tier: "harness",
+          how: "colocated",
+          by: HARNESS,
+          at: "2026-08-17T00:00:00.000Z",
+          sha: "deadbeefdeadbeef",
+        },
+        // Not an attribution. Hand-written, or a record from a future version.
+        {
+          kind: "skill",
+          path: ARC.path,
+          name: "argument-arc",
+          tier: "harness",
+          how: "declared",
+          by: HARNESS,
+          at: "2026-08-17T00:00:00.000Z",
+          sha: "deadbeefdeadbeef",
+        } as unknown as CoverageRun,
+      ],
+    });
+    assert.deepEqual(
+      readCoverageArtifact(dir)?.runs.map((r) => r.how),
+      ["colocated"],
+    );
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// The attribution cannot be DECLARED — `vigiles:covers` must not return
+// ---------------------------------------------------------------------------
+
+test("a script cannot hand-write a `colocated` probe over the wire", () => {
+  // `colocated` is deliberately NOT a ProbeOrigin: the origins are the wire
+  // vocabulary `parseCheckReport` reads out of a file the CHILD writes. If a
+  // harness could spell it, it could mint execution coverage for any surface by
+  // declaring it — which is the retired `vigiles:covers` marker returning through
+  // the back door.
+  const report = parseCheckReport(
+    JSON.stringify({
+      checks: 1,
+      surfaces: [
+        { how: "colocated", ref: ".claude/skills/argument-arc/SKILL.md" },
+        { how: "command", ref: "hooks/real.sh" },
+      ],
+    }),
+  );
+  assert.deepEqual(report, {
+    checks: 1,
+    surfaces: [{ how: "command", ref: "hooks/real.sh" }],
+  });
+});
+
+// ---------------------------------------------------------------------------
+// One predicate, not two — the mirror that was deleted
+// ---------------------------------------------------------------------------
+
+test("the colocation rule is one body: name AND place, separators folded", () => {
+  assert.equal(isColocatedTest(ARC, HARNESS), true);
+  assert.equal(
+    isColocatedTest(ARC, ".claude/skills/argument-arc/other.harness.mjs"),
+    false,
+  );
+  assert.equal(isColocatedTest(ARC, "argument-arc.harness.mjs"), false);
+  // A root SKILL.md lives at "." and discovery returns top-level files bare, so
+  // dirname is "." on both sides with no special case.
+  const root = skill("solo", "SKILL.md");
+  assert.equal(isColocatedTest(root, "solo.harness.mjs"), true);
+  assert.equal(isColocatedTest(root, "test/solo.harness.mjs"), false);
+  // Windows spellings reach the DISK caller (globSync yields `\` there) while the
+  // browser caller always passes `/`. One body serves both because separators are
+  // folded first — this is what removed the second copy.
+  assert.equal(
+    isColocatedTest(
+      skill("argument-arc", ".claude\\skills\\argument-arc\\SKILL.md"),
+      ".claude\\skills\\argument-arc\\argument-arc.harness.mjs",
+    ),
+    true,
+  );
+});

--- a/src/coverage-artifact.ts
+++ b/src/coverage-artifact.ts
@@ -46,6 +46,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { isAbsolute, posix, relative, resolve } from "node:path";
 
 import type { ProbeOrigin, SurfaceProbe } from "./check-count.js";
+import { isColocatedTest } from "./coverage-evidence.js";
 import type { Surface, SurfaceKind } from "./test-coverage.js";
 
 /** Bumped when the record shape changes in a non-additive way. */
@@ -63,6 +64,44 @@ export const COVERAGE_ARTIFACT_FILE = "coverage.json";
  */
 export type CoverageTierName = "harness" | "eval";
 
+/**
+ * How a RECORD came to name its surface.
+ *
+ * The three {@link ProbeOrigin} values are what the run REPORTED about itself
+ * from inside its own process — a command line it executed, a transcript it got
+ * back. `colocated` is the fourth and is different in kind: nothing inside the
+ * test said it. The RUNNER observed that the script it just executed is the
+ * surface's colocated test, by the same {@link isColocatedTest} rule that is
+ * already willing to credit that file for merely existing.
+ *
+ * 🔴 THE SPLIT IS THE POINT, AND IT IS WHY THIS IS NOT ON {@link ProbeOrigin}.
+ * `ProbeOrigin` is the wire vocabulary: `parseCheckReport` reads it out of a
+ * scratch file the CHILD writes. Putting `colocated` there would let a harness
+ * hand-write `{"how":"colocated","ref":"…"}` and mint execution coverage for a
+ * surface by declaring it — which is `vigiles:covers` returning through the back
+ * door, the tier this file's header records being deleted for exactly that. Kept
+ * off `ProbeOrigin`, a script cannot spell it at all: `toProbe` has no branch
+ * that produces it, so the only producer in the program is {@link recordsFrom}.
+ */
+export type RunAttribution = ProbeOrigin | "colocated";
+
+/**
+ * Every {@link RunAttribution}, as data — the artifact's validator reads it, so
+ * the accepted set and the type cannot drift apart into a record shape the
+ * program can produce and the reader silently discards. The `satisfies` is the
+ * lock: drop a member and this stops compiling.
+ */
+const ATTRIBUTIONS = new Set<string>([
+  "command",
+  "fired",
+  "dispatched",
+  "colocated",
+] satisfies RunAttribution[]);
+
+function isAttribution(value: unknown): value is RunAttribution {
+  return typeof value === "string" && ATTRIBUTIONS.has(value);
+}
+
 /** One surface, exercised by one script, at one moment, against one version. */
 export interface CoverageRun {
   readonly kind: SurfaceKind;
@@ -70,8 +109,8 @@ export interface CoverageRun {
   readonly path: string;
   readonly name: string;
   readonly tier: CoverageTierName;
-  /** How the run named it — see {@link ProbeOrigin}. */
-  readonly how: ProbeOrigin;
+  /** How the run named it — see {@link RunAttribution}. */
+  readonly how: RunAttribution;
   /** The script file that did the exercising. */
   readonly by: string;
   /** ISO-8601 timestamp of the run. */
@@ -374,6 +413,18 @@ export interface ScriptRunRecord {
   /** The script file that ran. */
   readonly file: string;
   readonly probes: readonly SurfaceProbe[];
+  /**
+   * How many checks the run REPORTED, or `undefined` when it reported nothing.
+   *
+   * The distinction is load-bearing and is not this file's invention — see
+   * `statusFor` in run-scripts.ts. `undefined` means the script never imported
+   * vigiles and therefore *could not* report; that silence is the legacy branch
+   * and is never a verdict. A positive number is the script saying, through the
+   * library, that it made an observation. Only the second is evidence, which is
+   * why {@link recordsFrom} attributes colocation on `> 0` rather than on
+   * "it exited 0".
+   */
+  readonly checks?: number;
 }
 
 /**
@@ -409,17 +460,100 @@ export interface ScriptRunRecord {
  * CLI would destroy a real result. A skip must not write, because it did not
  * finish. Both follow from "a skip is not an execution"; only the direction of
  * the conclusion differs.
+ *
+ * ## 🔴 A RUN WITH NO PROBES IS NO LONGER DISCARDED
+ *
+ * The second clause used to be `surfaces.length > 0`: a passing run that named no
+ * surface contributed nothing. That threw away the ordinary case. MEASURED on a
+ * 52-surface consumer repo, 23 of its 27 covered surfaces were carried by a
+ * colocated `*.harness.mjs` that `vigiles test` RUNS on every push — and every one
+ * of them reported `colocated` evidence, *"this says the file EXISTS, not that it
+ * ran"*, because a harness asserting through `node:assert` reports a CHECK COUNT
+ * and no probe. The run happened, the runner watched it happen, and the metric
+ * described it as a directory listing.
+ *
+ * So a passing run that reported at least one CHECK is kept even with no probes:
+ * {@link recordsFrom} can attribute it by where the script sits. `checks` travels
+ * with it because "exited 0" is not the bar — see {@link ScriptRunRecord.checks}.
  */
 export function runsFromResults(
   results: readonly {
     readonly file: string;
     readonly status: string;
+    readonly checks?: number;
     readonly surfaces?: readonly SurfaceProbe[];
   }[],
 ): ScriptRunRecord[] {
   return results
-    .filter((r) => r.status === "pass" && (r.surfaces?.length ?? 0) > 0)
-    .map((r) => ({ file: r.file, probes: r.surfaces ?? [] }));
+    .filter(
+      (r) =>
+        r.status === "pass" &&
+        ((r.surfaces?.length ?? 0) > 0 || (r.checks ?? 0) > 0),
+    )
+    .map((r) => ({
+      file: r.file,
+      probes: r.surfaces ?? [],
+      ...(r.checks === undefined ? {} : { checks: r.checks }),
+    }));
+}
+
+/**
+ * The surface a RUN's own script is the colocated test of, or `null`.
+ *
+ * This is the fourth attribution ({@link RunAttribution}), and the only one the
+ * script does not report about itself. The runner knows two facts the script
+ * cannot: which file it just executed, and which surfaces this repo has. Put
+ * together by {@link isColocatedTest} — the SAME predicate that already grants
+ * `colocated` evidence for that file merely existing — they say which surface the
+ * run was about.
+ *
+ * ## The bar is a REPORTED CHECK, not exit zero
+ *
+ * 🔴 WITHOUT THAT, THIS WOULD BE THE ORIGINAL DEFECT WEARING THE STRONGER LABEL.
+ * Measured 2026-08-17 on a two-skill fixture: `touch
+ * .claude/skills/argument-arc/argument-arc.harness.mjs` — a ZERO-BYTE file —
+ * drops the untested count by one, and `vigiles test` then RUNS it and prints
+ * `✓ … passed`. An empty script exits 0. Attributing on "it ran and exited 0"
+ * would promote that file from `colocated` ("the file EXISTS, not that it ran")
+ * to "MEASURED BY A RUN", which is strictly worse than the hole being closed:
+ * the same emptiness, now wearing execution's name.
+ *
+ * A zero-byte file cannot report a check — it never imports vigiles — so its
+ * `checks` is `undefined` and it earns nothing here, falling back to colocation
+ * exactly as before. This is `statusFor`'s distinction reused, not a new one:
+ * silence is the legacy branch, `0` is `vacuous` (never a `pass`, so it never
+ * reaches this function), and a positive count is the script saying through the
+ * library that it observed something.
+ *
+ * ⚠️ WHAT THIS STILL CANNOT SEE, stated rather than implied: a harness that
+ * asserts entirely on its own and never imports vigiles reports nothing, so it is
+ * indistinguishable here from the empty file. It keeps its colocated credit and
+ * gains no execution credit. That is deliberate and it is `check-count.ts`'s
+ * standing decision — force-loading the counter into every child was considered
+ * and rejected there, because it would report `0` for a blameless hand-rolled
+ * harness. The cost is a missed upgrade; the alternative was a false one.
+ *
+ * 🔴 AMBIGUITY RESOLVES TO NOTHING, the same rule {@link only} applies to probes.
+ * Two surfaces in one directory can both claim a script when one name prefixes
+ * the other (`foo` and `foo.bar` both match `foo.bar.harness.mjs`, since
+ * colocation asks only that the basename START with `<name>.`). Exactly one of
+ * them is what the test is about, and nothing here can say which — so crediting
+ * both would INVENT a record, which is the failure the rest of this file spends
+ * its length refusing.
+ */
+function colocatedSurface(
+  run: ScriptRunRecord,
+  surfaces: readonly Surface[],
+  alreadyProbed: ReadonlySet<string>,
+): Surface | null {
+  if ((run.checks ?? 0) <= 0) return null;
+  const matches = surfaces.filter(
+    (s) =>
+      s.path !== run.file &&
+      !alreadyProbed.has(s.path) &&
+      isColocatedTest(s, run.file),
+  );
+  return matches.length === 1 ? (matches[0] ?? null) : null;
 }
 
 /**
@@ -428,6 +562,12 @@ export function runsFromResults(
  * run); a surface it cannot read is skipped — an unhashable record could never
  * be checked for staleness and would therefore be permanent, unfalsifiable
  * coverage.
+ *
+ * Two sources of attribution, in one pass: the probes a run reported, and — for a
+ * run that reported a check — the surface its own script is colocated with
+ * ({@link colocatedSurface}). The dedupe key already carries `how`, so a run that
+ * BOTH probed a surface and sits beside it records once per attribution and the
+ * report can still say which kinds of evidence exist.
  */
 export function recordsFrom(
   opts: ResolveOptions & {
@@ -440,15 +580,39 @@ export function recordsFrom(
 ): CoverageRun[] {
   const out: CoverageRun[] = [];
   const seen = new Set<string>();
-  const pairs = opts.runs.flatMap((run) =>
-    run.probes.flatMap((probe) =>
-      resolveProbe(probe, opts.surfaces, opts).map((surface) => ({
-        run,
-        probe,
-        surface,
-      })),
-    ),
-  );
+  const pairs: {
+    run: ScriptRunRecord;
+    probe: { how: RunAttribution };
+    surface: Surface;
+  }[] = [];
+  for (const run of opts.runs) {
+    const probed = new Set<string>();
+    for (const probe of run.probes)
+      for (const surface of resolveProbe(probe, opts.surfaces, opts)) {
+        pairs.push({ run, probe, surface });
+        probed.add(surface.path);
+      }
+    // 🔴 COLOCATION IS THE FALLBACK ATTRIBUTION, NOT AN ADDITIONAL ONE, and
+    // skipping what this run already named is what keeps it from DOWNGRADING the
+    // record. MEASURED 2026-08-17 on a 52-surface repo the first time this tier
+    // ran: `.claude/hooks/paper-lint.mjs` went from `command` — the harness
+    // literally executed that path — to `colocated`, and three `fired` skill
+    // activations went the same way. The cause is one key: `mergeRuns` dedupes on
+    // (surface, tier, script) and does NOT include `how`, so a second attribution
+    // of the same pair does not sit beside the first, it REPLACES it — and with
+    // both records stamped the same `at`, `held.at <= run.at` hands the win to
+    // whichever was pushed last.
+    //
+    // The ordering is the same one this file already applies one level up: a
+    // direct observation of the surface being exercised outranks an inference
+    // from where a file sits. Emitting both and teaching the merge to keep the
+    // stronger was the alternative; it costs a wider key, a second record per
+    // pair, and a ranking function — to store a fact that adds nothing, since
+    // both resolve to the same `executed` evidence.
+    const beside = colocatedSurface(run, opts.surfaces, probed);
+    if (beside)
+      pairs.push({ run, probe: { how: "colocated" }, surface: beside });
+  }
   for (const { run, probe, surface } of pairs) {
     const key = `${surface.path}\u0000${run.file}\u0000${probe.how}`;
     if (seen.has(key)) continue;
@@ -599,7 +763,7 @@ function isCoverageRun(value: unknown): value is CoverageRun {
     typeof r.path === "string" &&
     typeof r.name === "string" &&
     (r.tier === "harness" || r.tier === "eval") &&
-    (r.how === "command" || r.how === "fired" || r.how === "dispatched") &&
+    isAttribution(r.how) &&
     typeof r.by === "string" &&
     typeof r.at === "string" &&
     typeof r.sha === "string"

--- a/src/coverage-evidence.ts
+++ b/src/coverage-evidence.ts
@@ -82,6 +82,7 @@
  * impossible there and its count is 0 — see `test-coverage-files.ts`.
  */
 import { readFrontmatter, frontmatterScalar } from "./core/frontmatter-read.js";
+import { basename, dirname } from "./posix-path.js";
 
 /**
  * How a covered surface was decided to be covered.
@@ -113,6 +114,55 @@ export interface CoverableSurface {
  */
 export interface PreparedTest {
   readonly path: string;
+}
+
+/**
+ * Is `testPath` the colocated test OF this surface — NAMED after it, SITTING
+ * BESIDE it?
+ *
+ * 🔴 THIS USED TO BE WRITTEN TWICE, and the second copy said so in its own
+ * comment: `test-coverage-files.ts` carried a function whose docstring was
+ * *"Mirror of test-coverage.ts `isColocated`"*. A mirror is a promise that two
+ * bodies stay equal, kept by whoever remembers — and this file already documents
+ * three separate occasions where a change landed in one report builder and not
+ * the other ({@link declaredSurfaceName}, {@link hookScriptRefs}). The rule now
+ * has ONE body and three callers: the disk detector, the browser twin, and the
+ * runner that turns an executed script into an execution record
+ * (`coverage-artifact.ts`). There is nothing left to mirror wrong.
+ *
+ * That third caller is why this became shared rather than merely deduplicated.
+ * Colocation and execution were answering the same question — *which surface is
+ * this test about?* — with two different pieces of code, so a script vigiles had
+ * just RUN could not be attributed by the very rule that was already willing to
+ * credit it for existing.
+ *
+ * SEPARATORS ARE NORMALISED FIRST, then POSIX semantics apply. The disk detector
+ * feeds paths from `globSync`, which yields `\` on Windows; the browser twin
+ * feeds file-map keys, which are always `/`. Folding `\` to `/` makes one body
+ * correct for both instead of asking each caller to bring its own path module —
+ * which is exactly the seam the mirror lived in.
+ *
+ * ⚠️ THE COST, STATED: a POSIX file whose NAME literally contains a backslash is
+ * now read as a directory boundary. That is not reachable for either input here —
+ * a skill directory or a test filename with a `\` in it does not survive the glob
+ * patterns that discover it in the first place — and it is the same trade
+ * `hookScriptRefs` already makes one function up.
+ */
+export function isColocatedTest(
+  surface: Pick<CoverableSurface, "name" | "path">,
+  testPath: string,
+): boolean {
+  const test = posixly(testPath);
+  const home = posixly(surface.path);
+  if (!basename(test).startsWith(`${surface.name}.`)) return false;
+  // A root `SKILL.md` (single-skill-dir target) lives at ".", and discovery
+  // returns top-level files without a "./" prefix — so `dirname` is "." on both
+  // sides and the comparison holds without a special case.
+  return dirname(test) === dirname(home);
+}
+
+function posixly(p: string): string {
+  return p.replaceAll("\\", "/");
 }
 
 /** Wrap a discovered path. Kept as a function so both twins share one shape. */

--- a/src/coverage-probe.ts
+++ b/src/coverage-probe.ts
@@ -50,12 +50,20 @@
  *    file is named by anyone. That API contract is the feature — it is how you
  *    test a hook you did not write, verbatim as its plugin ships it.
  *
- *  - **The in-process tier CAN, and currently reports nothing.** `loadHook(file)`
- *    resolves the path itself, and `harness-assert.ts` / `load-hook.ts` contain
- *    ZERO `recordSurfaceProbe` calls — so the tier where attribution needs no
- *    parsing at all is the tier that attributes nothing. That is a real gap and a
- *    better source of truth than any parse, but it ADDS a source; it cannot
- *    retire this one while `runHook(command)` remains public.
+ *  - **The in-process tier CAN — and since 2026-08-13 it DOES.** ⚠️ This bullet
+ *    used to read *"`harness-assert.ts` / `load-hook.ts` contain ZERO
+ *    `recordSurfaceProbe` calls — the tier where attribution needs no parsing at
+ *    all is the tier that attributes nothing"*, and that is no longer true:
+ *    `runCountedHookProgram` in harness-assert.ts records a `command` probe for a
+ *    hook it is about to evaluate, when `loadHook` knew the file. Verified by
+ *    count, not by memory — `harness-assert.ts` has the call, `load-hook.ts`
+ *    still does not, and deliberately so (loading a hook is not running it; see
+ *    that function's note). Left corrected rather than deleted because a header
+ *    that advertises a gap somebody already closed sends the next reader to build
+ *    a second recorder.
+ *
+ *    It did not retire this parser, as predicted: it ADDS a source, and
+ *    `runHook(command)` is still public.
  *
  * So parsing stays, and the lesson taken instead is about DIRECTION. The scan was
  * a deny-list — skip what we recognise, attribute what is left — so every gap in

--- a/src/test-coverage-files.ts
+++ b/src/test-coverage-files.ts
@@ -41,6 +41,7 @@ import {
   declaredSurfaceName,
   evidenceFor,
   hookScriptRefs,
+  isColocatedTest,
   isEvalScript,
   prepareTest,
   type PreparedTest,
@@ -222,10 +223,17 @@ function discoverTests(files: Record<string, string>): PreparedTest[] {
   return out;
 }
 
-/** Mirror of test-coverage.ts `isColocated` — named after the surface, beside it. */
+/**
+ * Named after the surface, beside it — the SHARED rule, no longer a copy of it.
+ *
+ * 🔴 THIS WAS A MIRROR, and its own docstring said so. Two bodies, one promise
+ * that they stay equal, kept by whoever remembers — and this file's header
+ * already records the last time a coverage change landed in one engine and not
+ * the other. It now calls `isColocatedTest`, which the disk detector and the
+ * run-record builder call too.
+ */
 function isColocated(surface: Surface, testPath: string): boolean {
-  if (!basename(testPath).startsWith(`${surface.name}.`)) return false;
-  return dirname(testPath) === dirname(surface.path);
+  return isColocatedTest(surface, testPath);
 }
 
 /** Mirror of test-coverage.ts `coverageOf` — strongest evidence across tests. */

--- a/src/test-coverage.ts
+++ b/src/test-coverage.ts
@@ -75,6 +75,7 @@ import {
   evidenceFor,
   formatEvidence,
   hookScriptRefs,
+  isColocatedTest,
   isEvalScript,
   prepareTest,
   type CoverageEvidence,
@@ -478,11 +479,7 @@ function discoverTests(
  * to remove.
  */
 function isColocated(surface: Surface, testPath: string): boolean {
-  if (!basename(testPath).startsWith(`${surface.name}.`)) return false;
-  // A root `SKILL.md` (single-skill-dir target) lives at ".", and globSync returns
-  // top-level files without a "./" prefix — so `dirname` is "." on both sides and
-  // the comparison holds without a special case.
-  return dirname(testPath) === dirname(surface.path);
+  return isColocatedTest(surface, testPath);
 }
 
 /**


### PR DESCRIPTION
## What this closes

The report's own provenance line has carried an honest caveat for a while: *"This says the file EXISTS, not that it ran."* It was literally true — `vigiles test` **runs** colocated test files and throws the result away. A passing run whose probe list was empty was discarded, which is every harness that asserts through `node:assert`.

Reproduced before changing anything: `touch <surface>.harness.mjs` (0 bytes) moves the untested count `2 → 1`; `vigiles test` then runs that empty file, prints `✓`, and lint still reports it as `colocated`.

## Measured, on a real 52-surface corpus, both builds, same fixture

| | baseline | after |
|---|---|---|
| covered | 27 | 27 |
| **MEASURED BY A RUN** | **4** | **27** |
| `colocated` | 23 | **0** |
| untested | 30 | 30 |
| downgraded attributions | — | **0** |

**No coverage is lost.** The count does not move; the evidence under 23 of 27 does. The weak tier's meaning narrows from "may or may not have run" to "has not been observed to run".

⚠️ This repo's own number cannot move — it has 23 surfaces and no colocated tests at all (its harnesses live in `examples/harness/`).

## Two defects the journal listed as blockers do not exist

Both were reproduced against `origin/main` **before** any edit, and neither fires:

- **№10** — appending `// probe: .claude/skills/argument-arc` to a harness leaves the untested count at `2 → 2`. The `mention` tier was deleted on 2026-08-11 and evidence selection no longer reads test contents at all.
- **№17** — a surface directory holding only another surface's `*.eval.mjs` is reported **untested**; colocation already requires the basename to start with the surface's name.

The false-negative half of №10 (a generic harness scoring zero) is **an adjudicated decision, not a defect** — `coverage-evidence.ts` records the measurement behind it.

## A bug this change introduced, caught by measurement rather than review

First run on the real corpus went `{command: 1, fired: 3}` → `{colocated: 28}`: `mergeRuns` dedupes on (surface, tier, script) and does **not** include the attribution, so the weaker one replaced the stronger and took three activations with it. Fixed by making colocation a fallback; pinned by a test.

## Inexpressible, not discouraged

An empty file *cannot* report a check — it never imports vigiles, so it has no `checks` and mints no record. `colocated` is deliberately **not** a `ProbeOrigin`, so no wire-format writer can hand-declare it and mint coverage. Ambiguity resolves to nothing rather than to credit.

**Subtracts:** a duplicated predicate (`isColocatedTest` was written twice, the copy's own docstring said "Mirror of…"), and the `surfaces.length > 0` precondition.

## Testing

8 mutations, each grep-proved to have landed before running, each dying on its own assertion. Two are worth naming: attributing on exit-0 was rejected **by measurement** (a 0-byte file exits 0, which would put the same emptiness under the stronger label); and one mutation came back green, where ranking the causes gave the right answer first — the artifact's `how` validator was pinned by **nothing**, and mutating it to `typeof value === "string"` left 67 tests passing. Widened and closed.

## Gates

`npx vitest run` · `npm run lint` · `npx prettier --check .` · `npm run api:check` · `npm run build`. One pre-existing failure (`spec.test.ts`, a 15 s `tsc` budget under load) reproduces identically on untouched `origin/main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Fixes**
- a colocated test that RAN is execution evidence, not a directory listing

**Chores**
- regenerate generated.d.ts for the new colocated-execution test
<!-- vigiles:pr-summary:end -->

