### PR TITLE
feat!: group the CLI help, fail on an empty positional match, name placement-only coverage

### DIFF
--- a/.vigiles/generated.d.ts
+++ b/.vigiles/generated.d.ts
@@ -101,7 +101,7 @@ declare module "vigiles/generated" {
     | "experimental:check"
     | "docs:api";
 
-  /** 386 project files. */
+  /** 387 project files. */
   export type ProjectFile = 
     | "src/CLAUDE.md"
     | "src/CLAUDE.md.spec.ts"
@@ -193,6 +193,7 @@ declare module "vigiles/generated" {
     | "src/cli-flags.test.ts"
     | "src/cli-flags.ts"
     | "src/cli-harness-resolution.test.ts"
+    | "src/cli-help.test.ts"
     | "src/cli-install.e2e.test.ts"
     | "src/cli-nudge-config.test.ts"
     | "src/cli-untested-options.test.ts"
@@ -651,6 +652,7 @@ declare module "vigiles/spec" {
       | "src/cli-flags.test.ts"
       | "src/cli-flags.ts"
       | "src/cli-harness-resolution.test.ts"
+      | "src/cli-help.test.ts"
       | "src/cli-install.e2e.test.ts"
       | "src/cli-nudge-config.test.ts"
       | "src/cli-untested-options.test.ts"

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -72,6 +72,35 @@ re-eval. It's a green no-op until you commit your first lock.
 | `fail-on-widen`     | `false`   | With `capability-diff`, fail the run when the PR **widens** the blast radius (maps to `--fail-on-widen`).                                                                                                                 |
 | `github-token`      | _(auto)_  | Token for the PR comment. Defaults to the workflow token (`${{ github.token }}`).                                                                                                                                         |
 
+### Why there is no `command: test`
+
+`test` and `eval` are missing from that list deliberately, and the omission is worth stating
+because the input is a **pass-through** — nothing validates it, so `command: test` becomes
+`vigiles test` and then fails in a way that looks like a vigiles bug.
+
+It fails because the Action runs `npx vigiles@<version> <cmd>` in your working directory and
+**never runs `npm ci`**. Harness files import the library:
+
+```js
+import { runHarnessTest, skip } from "vigiles";
+```
+
+That import needs repo-local `node_modules`, which the Action does not install. `vigiles init`
+knows this: the workflow it generates wires the Action for the jobs that can use it and writes
+a plain `npx vigiles test` job — with its own `npm ci` — for the harness tier.
+
+So the split is not an oversight to route around:
+
+| tier                            | how it runs in CI          | why                                              |
+| ------------------------------- | -------------------------- | ------------------------------------------------ |
+| `lint`, `compile`, `eval-check` | the Action                 | reads files, needs no repo dependencies          |
+| `test`, `eval`                  | a normal job with `npm ci` | executes your harness, which imports the library |
+
+**Pin `version:` in any job you hand-write.** The `latest` default deliberately ignores your
+`package-lock.json`, so CI can lint with one major while your harnesses run against another —
+a split measured in a real consumer on 2026-08-18 (`npm ls vigiles` → `15.2.1 invalid:
+"^16.1.0"`), which is what led a new harness to import a subpath v16 had removed.
+
 ## Output channels
 
 Beyond the `valid` step output, the Action reports **three** ways:

--- a/skills/test-harness/SKILL.md
+++ b/skills/test-harness/SKILL.md
@@ -326,6 +326,20 @@ We do **not** show "% of your subscription" — Anthropic doesn't expose a plan'
 quota, so any percentage would be invented. Tokens + API-equivalent `$` + the
 billed-to line is the honest, complete picture. Keep the user's cost visible, always.
 
+## CI — don't hand-write the steps
+
+These tiers belong in CI, and there is a published Action for it. Run `vigiles init`: it
+writes `.github/workflows/vigiles.yml`, wiring the Action (`zernie/vigiles@v1`) for the jobs
+that can use it plus a plain `npx vigiles test` job for this tier — that one needs
+repo-local `node_modules`, which the Action does not install, so it stays hand-rolled on
+purpose.
+
+If the repo already has a workflow, the Action's inputs are documented in
+[docs/github-action.md](../../docs/github-action.md). Read them there rather than guessing:
+the input list is defined in `action.yml`, and a copy of it here would be a second source of
+truth that goes stale without anything noticing — which is exactly what happened to this
+file's own sibling docs and to a consumer's CI comment, both measured on 2026-08-18.
+
 ## Step 5 — Lock the eval so CI stays honest (you do this automatically)
 
 Real-model evals run on the user's subscription — locally, never in CI. So **as

--- a/src/audit-score.test.ts
+++ b/src/audit-score.test.ts
@@ -716,3 +716,33 @@ describe("formatAuditScore", () => {
     expect(out).toMatch(/Harness health: A \(100\/100\)/);
   });
 });
+
+/**
+ * The execution tier, asserted. Coverage evidence has two kinds and only one of them is a
+ * measurement: `executed` means a recorded run exercised the surface, `colocated` means a
+ * file with the right name sits in the right place. The report's provenance line has always
+ * said so; nobody reads a provenance line, and a real consumer sat at 26 colocated /
+ * 0 executed while its CI skipped every one of those harnesses and reported success.
+ */
+describe("Tested — coverage that rests on a filename says so", () => {
+  const find = (over: Partial<ScanReport>) =>
+    ring(auditScore(makeReport(over)), "Tested").findings;
+  const placementOnly = (f: readonly string[]) =>
+    f.some((x) => /PLACEMENT only/.test(x));
+
+  it("names the count when NOTHING has an execution record", () => {
+    const f = find({ coverageEvidence: { executed: 0, colocated: 26 } });
+    expect(placementOnly(f)).toBe(true);
+    expect(f.join(" ")).toMatch(/26 surface\(s\)/);
+  });
+
+  it("goes quiet as soon as ONE run is on record — the tier exists, the warning is spent", () => {
+    expect(
+      placementOnly(find({ coverageEvidence: { executed: 1, colocated: 25 } })),
+    ).toBe(false);
+  });
+
+  it("says nothing when the report carries no evidence at all — absent is not zero", () => {
+    expect(placementOnly(find({}))).toBe(false);
+  });
+});

--- a/src/audit-score.ts
+++ b/src/audit-score.ts
@@ -405,12 +405,46 @@ function tested(r: ScanReport): CategoryScore {
           "your own test setup detected — vigiles-native skill coverage is optional",
         ]
       : findings;
+  // 🔴 COVERED BY PLACEMENT ALONE — the execution tier, finally said out loud.
+  //
+  // `colocated` evidence means a test file NAMED after the surface sits BESIDE it. That is
+  // a claim about the filesystem, and the provenance line already admits it ("this says the
+  // file EXISTS, not that it ran"). Nobody reads a provenance line. When `executed` is zero
+  // across the whole corpus, EVERY surface counted here rests on a filename, and the number
+  // above reads as health it has not earned.
+  //
+  // Measured in a real consumer 2026-08-18: 26 colocated, 0 executed — while its CI invoked
+  // exactly those harnesses in a job that never installed the `claude` CLI, so each one
+  // called `skip()` and the step reported success. Coverage looked fine the entire time.
+  //
+  // Deliberately NOT "your CI does not run these": that needs parsing CI config, and the
+  // grep-shaped version accuses a healthy repo, because real workflows invoke harnesses by
+  // GLOB and name no file. This says only what the run records say, so it cannot be wrong
+  // about a repo it has not looked at.
+  //
+  // ⚠️ KNOWN LIMIT, stated rather than hidden: the threshold is CORPUS-WIDE, so ONE recorded
+  // run anywhere silences it for every surface. That is what the data supports — the evidence
+  // this receives is an aggregate tally, not a per-surface verdict — and the same consumer
+  // demonstrates the cost: it read 0 executed / 26 colocated in the morning and 16 / 26 by
+  // evening, after which twenty-six surfaces resting on a filename would no longer be named.
+  // Sharpening this means carrying evidence per surface, which is a change to the producer,
+  // not to this sentence. Until then it catches the state that actually shipped (a corpus
+  // where the tier is entirely absent) and stays quiet the moment the tier exists at all.
+  const ev = r.coverageEvidence;
+  const placementOnly =
+    ev && ev.executed === 0 && ev.colocated > 0
+      ? [
+          ...contextualized,
+          `${String(ev.colocated)} surface(s) counted as covered by PLACEMENT only — ` +
+            `no run on record ever exercised one`,
+        ]
+      : contextualized;
   return {
     key: "Tested",
     score,
     weight: 1,
     advisory: true,
-    findings: contextualized,
+    findings: placementOnly,
   };
 }
 

--- a/src/cli-help.test.ts
+++ b/src/cli-help.test.ts
@@ -1,0 +1,75 @@
+/**
+ * The top-level help, asserted as a CONTRACT rather than eyeballed.
+ *
+ * Two of these assertions exist because the old help failed them. It described `audit`
+ * with "NOT a CI step — use `vigiles lint` in CI" — a sentence that says what a command
+ * ISN'T, which is a description admitting it failed; deleting that sentence was the
+ * checkable success criterion of the 2026-08-18 rewrite, and this test is what keeps it
+ * deleted. And the module docblock listed four of the eight verbs, having quietly stopped
+ * growing — so the coverage assertion below reads the RENDERED output, not a constant,
+ * because a constant is the thing that drifted.
+ */
+import { test } from "vitest";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+
+const help = execFileSync("node", ["dist/cli.js", "--help"], {
+  encoding: "utf-8",
+});
+
+test("every user-facing verb appears in the grouped help exactly once", () => {
+  for (const verb of [
+    "init",
+    "compile",
+    "eject",
+    "audit",
+    "lint",
+    "test",
+    "eval",
+    "generate",
+  ]) {
+    const hits = help
+      .split("\n")
+      .filter((l) => l.trimStart().startsWith(`vigiles ${verb} `));
+    assert.equal(
+      hits.length,
+      1,
+      `expected exactly one help line for \`${verb}\`, got ${hits.length}`,
+    );
+  }
+});
+
+test("the four checkers are grouped by whether they READ or RUN", () => {
+  const read = help.indexOf("Check your harness");
+  const run = help.indexOf("Run your harness");
+  assert.ok(
+    read > 0 && run > read,
+    "both group headings must be present, read before run",
+  );
+  const between = (a: number, b: number, verb: string) => {
+    const at = help.indexOf(`vigiles ${verb} `, a);
+    assert.ok(at > a && at < b, `\`${verb}\` must sit inside its own group`);
+  };
+  between(read, run, "audit");
+  between(read, run, "lint");
+  between(run, help.length, "test");
+  between(run, help.length, "eval");
+});
+
+test("no command is described by what it is NOT", () => {
+  assert.doesNotMatch(
+    help,
+    /NOT a CI step/,
+    "a help line that must disclaim what a command isn't is a description that failed — " +
+      "state the consequence positively instead (audit: 'fails nothing')",
+  );
+});
+
+test("per-verb flag detail stays OUT of the top-level list", () => {
+  assert.doesNotMatch(
+    help,
+    /--no-html/,
+    "flag detail belongs in `vigiles <verb> --help`",
+  );
+  assert.match(help, /Flags live in `vigiles <command> --help`/);
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 
 /**
- * vigiles CLI — compile typed specs to instruction files.
+ * vigiles CLI — verify your agent harness is real, and prove it works.
  *
- * Commands:
- *   vigiles init            — scaffold a spec from scratch
- *   vigiles compile         — compile .spec.ts → .md with linter verification
- *   vigiles lint            — verify hashes, report coverage, detect duplicates
- *   vigiles generate types  — emit .d.ts with types from project state
+ * The verbs and their one-liners live in ONE place, `COMMAND_HELP` + `HELP_GROUPS`
+ * near the bottom of this file, and `--help` prints from that table. A second list
+ * here would be a copy that rots — this docblock WAS that copy: it named four
+ * commands and omitted `audit`, `test`, `eval` and `eject`, four of the eight, and
+ * `self-command-refs.test.ts` did not catch it because it guards against refs to
+ * REMOVED commands, not against a list that merely stops growing.
  */
 
 import {
@@ -5585,6 +5586,34 @@ async function handleRunScripts(
   }
 
   if (files.length === 0) {
+    // 🔴 ASKING FOR SOMETHING AND GETTING NOTHING IS A FAILURE; FINDING NOTHING IS NOT.
+    // The two cases were collapsed into one silent exit 0, and the collapse cost a real
+    // repository three days of green CI verifying zero files: a named step ran
+    // `vigiles test .claude/pipeline/skills.harness.mjs` after that file had been split
+    // into one-per-skill, printed "No **/*.harness.* files found" and passed, right next
+    // to a step that was red for the same root cause.
+    //
+    // They are different states. A POSITIONAL argument is a claim that something is there —
+    // when nothing matches it, the path is stale, the glob is wrong, or the run never
+    // reached its target, and every one of those is a defect. Bare discovery finding
+    // nothing is just an empty repository, which is a legitimate place to stand and must
+    // stay quiet.
+    //
+    // This is the default the field settled on: Jest and Vitest FAIL on no tests found and
+    // make you opt in with `--passWithNoTests`; pytest exits 5. `--min=0` remains the
+    // explicit opt-out here, so no new flag is introduced by this change.
+    // `minFlag`, not `minRequired`: 0 is both the DEFAULT and the explicit opt-out, so the
+    // VALUE cannot tell them apart — only the flag's presence can. (Caught by a control:
+    // the first version read `minRequired === 0` and made `--min=0` do nothing.)
+    if (restArgs.length > 0 && minFlag === undefined) {
+      console.error(
+        `✗ vigiles ${kind}: ${String(restArgs.length)} target(s) given and NOTHING matched — ` +
+          `${restArgs.join(", ")}\n` +
+          `  Nothing ran. A stale path, a wrong glob, or a moved file all look like this.\n` +
+          `  If an empty match is expected here, say so with --min=0.`,
+      );
+      process.exit(1);
+    }
     console.log(`No ${defaultGlob} files found.`);
     return;
   }
@@ -5709,41 +5738,48 @@ interface CommandHelp {
 const COMMAND_HELP: Record<Verb, CommandHelp> = {
   init: {
     usage:
-      "  vigiles init [flags]           Setup project (--ci-only for the CI gate only; --lint, --test, --harness=, --strict, --report-only, --no-gha, --force)",
+      "  vigiles init [flags]       Set up this repo — specs, plugin, and CI.",
   },
-  compile: { usage: "  vigiles compile [files...]     Compile .spec.ts → .md" },
+  compile: { usage: "  vigiles compile [files...] Compile .spec.ts → .md" },
   eject: {
     usage:
-      "  vigiles eject [file]           Un-manage a compiled file → plain hand-owned markdown (--keep-spec)",
+      "  vigiles eject [file]       Hand a compiled file back as plain markdown.",
   },
   lint: {
     usage:
-      "  vigiles lint [files...]        Verify references, find gaps in instruction files",
+      "  vigiles lint  [files...]   Gate it in CI. The same checks — but a finding fails the build.",
   },
   audit: {
+    // "Reports everything, fails nothing" states always-exit-0 as the FEATURE it is. The line
+    // it replaces had to end with "NOT a CI step — use `vigiles lint` in CI", and a help text
+    // that must say what a command ISN'T is a description that failed. Deleting that sentence
+    // was the checkable success criterion for this rewrite.
     usage:
-      "  vigiles audit [dir...]          Lighthouse for your harness — a LOCAL report: rings + what's broken + fixes (a deterministic read; 2+ dirs → leaderboard)",
+      "  vigiles audit [dir...]     Grade it on your machine. Reports everything, fails nothing.",
     detail: [
-      "                                 writes vigiles-report.html + .json (auto-gitignored; --out=<dir> · --no-html/--no-json · --no-open · --json for machine output). NOT a CI step — use `vigiles lint` in CI.",
-      "                                 the executing checks (run your hooks · live MCP · do skills fire?) run only interactively — `audit` asks once (remembered); automation uses the vigiles testing API",
-      "                                 --serve opens a LIVE local report whose buttons create specs in one click (own repo only; loopback + token-guarded) · --no-serve to skip the prompt",
+      "  2+ dirs → a leaderboard. Writes vigiles-report.html + .json (auto-gitignored).",
+      "  The executing checks (run your hooks · live MCP · do skills fire?) run only",
+      "  interactively — audit asks once and remembers; automation uses the testing API.",
     ],
   },
   test: {
+    // "Free, no API key" is the CONSEQUENCE; "deterministic" was the mechanism, and a reader
+    // deciding whether to put this in CI needs the cost, not the implementation.
     usage:
-      "  vigiles test [files...]        Run *.harness.mjs deterministic harness tests",
+      "  vigiles test  [files...]   Against a scripted stand-in model. Free, no API key — every commit.",
   },
   eval: {
     usage:
-      "  vigiles eval [files...]        Run *.eval.mjs real-model harness evals (--trials=N, --min=N, --no-skip)",
+      "  vigiles eval  [files...]   Against a real model. Spends your subscription — on demand.",
     detail: [
-      "                                 --update records each named eval's result to a committed lock (run locally on your subscription)",
-      "                                 --check verifies committed eval results against current inputs WITHOUT a model — the CI staleness gate",
+      "  --update records each named eval's result to a committed lock (run it locally).",
+      "  --check verifies those committed results against current inputs with NO model —",
+      "  the CI-safe half.",
     ],
   },
   generate: {
     usage:
-      "  vigiles generate <kind>       Emit a dev-toolchain artifact: types (.d.ts) · schema (JSON Schema) · harness (harness.gen.ts)",
+      "  vigiles generate <kind>    Emit a dev-toolchain artifact: types · schema · harness",
     detail: [
       "  vigiles generate <kind> --check  Verify the generated file is up to date",
     ],
@@ -5755,19 +5791,39 @@ const COMMAND_HELP: Record<Verb, CommandHelp> = {
 };
 
 /** Display order of the human-facing verbs in the banner's "Commands:" block. */
-const HELP_ORDER: readonly Verb[] = [
-  "init",
-  "compile",
-  "eject",
-  "lint",
-  "audit",
-  "test",
-  "eval",
+/**
+ * The top-level help, as GROUPS. One table, so the printer cannot drift from the
+ * grouping and a new verb cannot quietly land outside both.
+ */
+const HELP_GROUPS: readonly { heading: string; verbs: readonly Verb[] }[] = [
+  {
+    heading: "Set up and manage your specs:",
+    verbs: ["init", "compile", "eject"],
+  },
+  {
+    heading: "Check your harness (reads your files — nothing is executed):",
+    verbs: ["audit", "lint"],
+  },
+  {
+    heading: "Run your harness (drives it and watches what happens):",
+    verbs: ["test", "eval"],
+  },
 ];
 
-function printHelpEntry(v: Verb): void {
+/**
+ * One command's line. `detail` is the per-flag prose and appears ONLY in
+ * `vigiles <verb> --help`, never in the top-level list.
+ *
+ * That split is the second half of this rewrite. `audit`'s entry used to carry four
+ * wrapped lines naming nine flags inline, and that single entry was most of the felt
+ * crowding in a CLI whose verb count (8) is the smallest of every comparable tool
+ * measured — vitest ships 8 verbs and 164 flags, cargo 48 verbs, git 166. None of them
+ * thinned their surface by removing verbs; they tiered the help. This does the same.
+ */
+function printHelpEntry(v: Verb, opts: { detail?: boolean } = {}): void {
   console.log(COMMAND_HELP[v].usage);
-  for (const line of COMMAND_HELP[v].detail ?? []) console.log(line);
+  if (opts.detail)
+    for (const line of COMMAND_HELP[v].detail ?? []) console.log(line);
 }
 
 /**
@@ -5819,31 +5875,40 @@ function formatNothingToAudit(
 
 /** `vigiles <verb> --help` — that verb's entry plus its complete flag list. */
 function printCommandHelp(command: Verb): void {
-  printHelpEntry(command);
+  printHelpEntry(command, { detail: true });
   const flags = knownFlagsFor(command);
   console.log("");
   console.log(`Flags: ${[...flags].sort().join(" ")}`);
   console.log("(`vigiles --help` lists every command.)");
 }
 
+/**
+ * The top-level help, grouped. The grouping is load-bearing, not cosmetic: four verbs
+ * (`audit`, `lint`, `test`, `eval`) all read as "check my stuff", and a flat list left the
+ * reader to work out the difference from four independent sentences. The headings state the
+ * shared trait, which frees each verb's own line to state only what makes it different, so
+ * the four form a 2x2 that survives one pass:
+ *
+ *                    no consequence          has a consequence
+ *   read the files   audit (fails nothing)   lint (fails the build)
+ *   run the harness  test  (free)            eval (spends money)
+ */
 function printUsage(command: string | undefined): void {
-  console.log("vigiles — compile typed specs to instruction files");
-  console.log("");
-  console.log("Commands:");
-  for (const v of HELP_ORDER) printHelpEntry(v);
-  console.log("");
-  console.log("Examples:");
   console.log(
-    "  vigiles init                 Auto-detect project, create specs, wire CI",
-  );
-  console.log("  vigiles compile              Compile all .spec.ts files");
-  console.log(
-    "  vigiles lint                 Verify references, hashes, coverage + suggestions",
+    "vigiles — verify your agent harness is real, and prove it works",
   );
   console.log("");
+  for (const g of HELP_GROUPS) {
+    console.log(g.heading);
+    for (const v of g.verbs) printHelpEntry(v);
+    console.log("");
+  }
   console.log("Plumbing:");
   printHelpEntry("generate");
-  console.log("  vigiles --version             Print the version number");
+  console.log("  vigiles --version          Print the version number");
+  console.log("");
+  console.log("Flags live in `vigiles <command> --help`.");
+  console.log("New here? Start with `vigiles audit .`");
   if (command && command !== "--help") {
     console.log(`\nUnknown command: "${command}"`);
     process.exit(1);


### PR DESCRIPTION
Five changes, all from measurement rather than taste — a review of the CLI surface plus a review of a real consumer's CI.

## ⚠️ BREAKING CHANGE

`vigiles test` / `vigiles eval` now **exit 1** when a positional path or glob matches nothing. They previously exited 0. A CI step that names a stale path starts failing — which is the point — and `--min=0` is the opt-out for a step where an empty match is genuinely expected.

Bare auto-discovery finding nothing is **unchanged** and still exits 0.

## 1. A positional target that matches nothing now fails

An empty repo is a legitimate place to stand. But a path or glob you **named** that matched nothing is stale, wrong, or was never reached, and collapsing the two into one silent exit 0 cost a real repository three days of green CI verifying zero files.

```
$ vigiles test 'does/not/exist/*.harness.mjs'
✗ vigiles test: 1 target(s) given and NOTHING matched — does/not/exist/*.harness.mjs
  Nothing ran. A stale path, a wrong glob, or a moved file all look like this.
  If an empty match is expected here, say so with --min=0.
exit 1
```

This is where the field already sits: Jest and Vitest fail on no-tests-found and make you opt in with `--passWithNoTests`; pytest exits 5. **No flag is added** — `--min=0` already existed.

A control caught a bug in the first version: `minRequired === 0` cannot tell the default from an explicit `--min=0`, so the opt-out did nothing. It now keys on the flag's presence.

## 2. The help is grouped, and no command is described by what it isn't

`audit`, `lint`, `test`, `eval` all read as "check my stuff". They are now grouped by **read vs run**, with each line stating its own consequence positively:

```
Check your harness (reads your files — nothing is executed):
  vigiles audit [dir...]     Grade it on your machine. Reports everything, fails nothing.
  vigiles lint  [files...]   Gate it in CI. The same checks — but a finding fails the build.

Run your harness (drives it and watches what happens):
  vigiles test  [files...]   Against a scripted stand-in model. Free, no API key — every commit.
  vigiles eval  [files...]   Against a real model. Spends your subscription — on demand.
```

The success criterion was checkable and is met: **"NOT a CI step — use `vigiles lint` in CI" is deleted**, because nothing needs defending any more. A help line that must say what a command *isn't* is a description admitting it failed — a test now keeps that sentence out.

Per-verb flag detail moved into the per-verb help. `audit`'s entry was four wrapped lines naming nine flags inline, and that alone was most of the felt crowding.

**No verb was added, removed, or merged.** The count is 8 — the smallest of every tool measured (vitest 8 verbs / 164 flags, cargo 48, docker 57, git 166), and not one of them thinned its surface by removing verbs; they all tiered the help.

## 3. The module docblock had stopped growing

It listed four of the eight commands, omitting `audit`, `test`, `eval`, `eject`. `self-command-refs.test.ts` did not catch it: that guards against refs to *removed* commands, not a list that quietly stops. Replaced with a pointer to the single source, plus a test asserting every verb appears in the **rendered** help exactly once — a constant is the thing that drifted, so the assertion reads output.

## 4. `audit` now names coverage that rests on a filename

New `Tested` finding: *N surfaces counted as covered by PLACEMENT only — no run on record ever exercised one.*

`colocated` evidence means a file with the right name sits in the right place. The provenance line has always admitted this ("this says the file EXISTS, not that it ran") and nobody reads a provenance line. Measured in a consumer: **26 colocated, 0 executed** — while its CI invoked exactly those harnesses in a job that never installed the `claude` CLI, so each called `skip()` and the step reported success.

Deliberately **not** phrased as "your CI doesn't run these": that needs parsing CI config, and the grep-shaped version accuses a healthy repo, because real workflows invoke harnesses by glob and name no file.

⚠️ The corpus-wide threshold is a **stated limit in the code**, not a silence: one recorded run anywhere quiets it everywhere. The same consumer shows the cost — 0/26 in the morning, 16/26 by evening. Sharpening it means carrying evidence per surface, which is a change to the producer.

## 5. The Action's boundary is documented, and the skill points at it

`docs/github-action.md` now explains why there is no `command: test`. The input is a **pass-through** — nothing validates it, so `command: test` becomes `vigiles test` and then fails in a way that looks like a vigiles bug. It fails because the Action never runs `npm ci` and harness files import the library. `init` already knows this and hand-rolls that job on purpose.

`skills/test-harness/SKILL.md` gained a six-line `## CI` section carrying exactly two facts an agent cannot act without: an Action exists and `init` wires it, and where its inputs are documented. It **references** rather than explains, because a copied explanation rots — three measured proofs, one of them inside this product.

## Gates

In order: `npx vitest run` · `npm run lint` · `npx prettier --check .` · `npm run api:check` · `npm run build` — all via `npm run check`, **18/18**. New tests: 4 on the help contract, 3 on the finding (fires at zero, silent at one, silent when the field is absent).