### PR TITLE
feat!: fail on an empty positional match, and guard the squash title

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -28,3 +28,38 @@ jobs:
           requireScope: false
           subjectPattern: ^.+$
           subjectPatternError: "PR title must not be empty after the type prefix."
+
+      # 🔴 THE TITLE ABOVE IS NOT ALWAYS THE STRING THAT REACHES `main`.
+      #
+      # For a pull request with exactly ONE commit, GitHub's squash-merge takes the
+      # COMMIT's subject as the squash title, not the PR's. So a PR can pass the check
+      # above and still land a commit with no conventional prefix — and then
+      # semantic-release finds nothing releasable and cuts no version, silently.
+      #
+      # Measured on #163 (2026-08-19): PR title `feat!: group the CLI help, …`, check
+      # green, and the commit on main reads `CLI clarity, an execution-tier finding, and
+      # the Action's boundary documented (#163)`. Release ran, succeeded, published
+      # nothing. A breaking change sat in main unreleased and the consumer kept
+      # installing the previous major.
+      #
+      # This step closes the gap where it opens: when there is one commit, its subject is
+      # the one that must satisfy the same grammar.
+      - name: The squash title, for a single-commit PR
+        if: github.event.pull_request.commits == 1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          subject=$(gh api "repos/$REPO/pulls/$PR/commits" --jq '.[0].commit.message' | head -1)
+          echo "commit subject: $subject"
+          if ! printf '%s' "$subject" | grep -qE '^(feat|fix|docs|chore|refactor|test|perf|ci|build)(\([^)]+\))?!?: .+'; then
+            echo "::error::This PR has ONE commit, so GitHub's squash default will use the COMMIT subject"
+            echo "::error::as the squash title — not the PR title, which already passed the check above."
+            echo "::error::That subject is: $subject"
+            echo "::error::Fix either side: amend the commit to carry the same conventional prefix, or"
+            echo "::error::set the squash title explicitly when merging. Otherwise semantic-release sees"
+            echo "::error::no releasable change and publishes nothing, with every check green."
+            exit 1
+          fi


### PR DESCRIPTION
Two things, and the second is why the first is here rather than already released.

## The guard

For a pull request with **exactly one commit**, GitHub's squash-merge takes the **commit's** subject as the squash title — not the PR's. So the PR-title check and semantic-release read two different strings, and for a single-commit PR they diverge by default.

Measured on #163 (today):

| what | string |
|---|---|
| PR title (check green ✅) | `feat!: group the CLI help, fail on an empty positional match, name placement-only coverage` |
| commit that landed on `main` | `CLI clarity, an execution-tier finding, and the Action's boundary documented (#163)` |

The `Release` workflow ran on that commit, **completed successfully, and published nothing** — semantic-release found no releasable prefix. A breaking change has been sitting in `main` unreleased since this morning while consumers kept installing the previous major (`npm view vigiles version` → `17.0.2`).

Every check was green the whole time. That is the failure worth closing: not a red build, a *silent non-release*.

`pr-title.yml` now also validates the commit subject when `pull_request.commits == 1`, and the error names which of the two strings is wrong and both ways to fix it (amend the commit, or set the squash title explicitly at merge).

## The release

#163's behaviour change is breaking and never got a version, so this commit carries it in a `BREAKING CHANGE:` footer.

`vigiles test` / `vigiles eval` now exit 1 when a **positional** path or glob matches nothing. Bare auto-discovery finding nothing is unchanged and still exits 0 — an empty repository is a legitimate state, while a target you *named* that matched nothing is stale, wrong, or was never reached. `--min=0` is the opt-out and already existed, so **no flag is added**.

## Note for the reviewer

The guard cannot be tested by this PR passing: this PR has one commit whose subject *is* conventional, so the new step exercises its happy path only. Its failing path is evidenced by #163, which is the case it was written from.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Features**
- fail on an empty positional match, and guard the squash title
<!-- vigiles:pr-summary:end -->
