### PR TITLE
feat: an errored emit is not an emission, and a contract field can be an enum

### DIFF
--- a/api-surface/vigiles-experimental.api.md
+++ b/api-surface/vigiles-experimental.api.md
@@ -31,6 +31,9 @@ export type EmitFieldSchema = {
     readonly items: {
         readonly type: "string";
     };
+} | {
+    readonly type: "string";
+    readonly enum: readonly string[];
 };
 
 // @public

--- a/api-surface/vigiles-linting.api.md
+++ b/api-surface/vigiles-linting.api.md
@@ -382,7 +382,7 @@ export interface OutputContract<Ok extends Shape = Shape, Err extends Shape = Sh
 }
 
 // @public
-export type OutputFieldType = "string" | "number" | "boolean" | "string[]";
+export type OutputFieldType = "string" | "number" | "boolean" | "string[]" | readonly [string, ...string[]];
 
 // @public
 export type OutputPath<Spec extends `${string}.md.spec.ts`> = Spec extends `${infer Base}.spec.ts` ? Base : never;

--- a/api-surface/vigiles-spec.api.md
+++ b/api-surface/vigiles-spec.api.md
@@ -289,7 +289,7 @@ export interface OutputContract<Ok extends Shape = Shape, Err extends Shape = Sh
 }
 
 // @public
-export type OutputFieldType = "string" | "number" | "boolean" | "string[]";
+export type OutputFieldType = "string" | "number" | "boolean" | "string[]" | readonly [string, ...string[]];
 
 // @public
 export type OutputPath<Spec extends `${string}.md.spec.ts`> = Spec extends `${infer Base}.spec.ts` ? Base : never;

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -28,7 +28,9 @@ A **tool call needs no return boundary**. The skill does not _return_ the struct
 import { experimental_emitTool } from "vigiles/experimental";
 
 const CONTRACT = result(
-  { verdict: "string", count: "number", report: "string" },
+  // `["CUT", "MERGE", "KEEP"]` is an ENUM — the permitted values travel with the tool
+  // definition, so the model sees them even if it skimmed the prose around them.
+  { verdict: ["CUT", "MERGE", "KEEP"], count: "number", report: "string" },
   { reason: "string" },
 );
 
@@ -45,18 +47,65 @@ assert.equal(v.verdict.startsWith("BLOCKED"), true);
 assert.ok(v.count > 0); // `count` is a number because the contract said so
 ```
 
+### How a wrong emission is caught
+
+The reader is **total**: every way an emission can fail to satisfy the contract has its own
+branch with its own reason. There is no "it happened to look fine" path.
+
+| what the model did                             | what you get back                                                                                                                          |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| never called the tool                          | `malformed` — `no \`emit_result\` tool call in the run`                                                                                    |
+| called it twice                                | `malformed` — `called 2 times; the contract is exactly once`                                                                               |
+| called it with no object argument              | `malformed` — `carried no object argument`                                                                                                 |
+| omitted `track` (or sent something else)       | `malformed` — `has no \`track\` of "ok" or "err"`                                                                                          |
+| declared a track, sent no payload for it       | `malformed` — `declared track "ok" but carried no \`ok\` object`                                                                           |
+| sent a payload that misses or mistypes a field | `malformed` — `ok payload: field "verdict" should be "CUT" \| "MERGE" \| "KEEP"`                                                           |
+| **the call itself was denied or errored**      | `malformed` — `errored or was denied; nothing reached the server. Check the tool's permissions and the exact spelling in \`allowedTools\`` |
+
+The last row is worth dwelling on, because until 2026-08-19 it was a **silent success**: the
+reader filtered calls by name and never looked at `ToolCall.isError`, so a permission-denied
+call carrying a valid payload returned `ok` for an emission the server never received. A
+wrong `allowedTools` spelling is the likely cause, not an exotic one — MCP names are
+host-mangled (`mcp__plugin_<plugin>_<server>__emit_result` on Claude Code, two segments on
+Codex), so getting it wrong is easy.
+
+Two neighbouring collapses are avoided on purpose: a denied call is **not** reported as "no
+call" (that sends you to the skill's instructions when the fault is in permissions), and a
+retried denial is **not** reported as "called twice" (a true signal under a false name). A
+successful call alongside a denied one is one successful emission — the contract was met.
+
+**What none of this catches: whether the emitted result is TRUE.** The channel checks form.
+A skill that emits `verdict: "KEEP"` about work it never did is well-formed and wrong, and
+no schema can say otherwise. Gating on an emitted verdict was measured and rejected —
+self-report disagreed with a judged check in 45–75.8% of runs.
+
 ### What is measured, and what is not
 
-**Measured 2026-08-13** against one real unforked skill on sonnet: **8 runs, 8 emits**, all on the `ok` track, all parsing against the contract, none repeated. Raw arguments and a free re-scorer ship in `examples/experimental-emit/`.
+**2026-08-13, one skill, sonnet:** 8 runs, 8 emits, all on `ok`, all parsing, none repeated.
 
-That answers _"does it land at all"_ and says **nothing about the rate**: 8-of-8 bounds the true failure rate at roughly 31%, which is not evidence of reliability.
+**2026-08-14, breadth — five real skills, two models:** on sonnet **15 emissions from 15
+runs**, across bodies of 97 and 354 lines, two insertion modes, and two natural languages.
+On haiku a **zero appears**: `cold-read-diff` emitted on 1 run of 3 — and not because the
+channel dropped anything. The skill stopped on its third turn without reaching its own first
+step, so there was nothing to emit. That distinction is why **the pooled number is not
+printed**: across both models it would read as 19/21 ≈ 90% while containing a skill at 33%.
 
-**Not measured, and each of these could reshape the surface:**
+**2026-08-19, serving:** a plugin-bundled MCP server registers (`√ Connected`), the model
+called it, and the payload reached the server — confirmed by the server's own log, not only
+by the transcript. So question 3 below is answered.
 
-1. **One skill, one model, N=8.** No breadth across skills, models, or task shapes.
-2. **Nothing depends on it.** Neither `compileSkill` nor `compileAgent` emits the instruction — you paste `.instruction` and serve `.tool` by hand. There is no compile-time path, so no skill in any corpus is typed by it.
-3. **The transport is not part of the contract.** MCP is how the tool reached the model in the measurement; whether a plugin can serve a tool _without_ standing up a process is **untested**, and the answer would change the shape of this API.
-4. **Triggering is unmeasured** — whether adding the instruction changes how often the skill fires at all.
+**Still not measured, and each could reshape the surface:**
+
+1. **The rate.** 15-of-15 on one model is not a reliability claim; the design calls for ≥30
+   runs and ≥2 models before the number means anything.
+2. **Nothing depends on it yet.** Neither `compileSkill` nor `compileAgent` emits the
+   instruction — you paste `.instruction` and serve `.tool` by hand.
+3. **Triggering** — whether adding the instruction changes how often the skill fires at all.
+   Deliberately skipped, with the reasoning written down rather than the number guessed.
+4. **A COMPILED `SKILL.md` has never been observed loading as an installed skill.** The
+   `vigiles:sha256:` header pushes frontmatter off line 1. The neighbouring surface (a
+   compiled subagent) was measured working, a skill was not — so the compile-time path is
+   theory until that first end-to-end run.
 
 ### What it does NOT buy — stated because it is the obvious thing to assume
 
@@ -65,7 +114,14 @@ That answers _"does it land at all"_ and says **nothing about the rate**: 8-of-8
 
 ### To drop the `experimental_` prefix
 
-Breadth across several skills and at least two models; a compile-time path so the instruction is not hand-pasted; and an answer to whether a plugin can serve the tool without a separate process.
+Three conditions, one of them now met:
+
+- ~~an answer to whether a plugin can serve the tool without a separate process~~ — **answered
+  2026-08-19**. It can serve the tool; "without a process" turns out not to exist for anything
+  in the shipped CLI (hooks are processes too), so the question was retired rather than passed.
+- **Breadth** — partly: five skills, two models, but on a subset. Needs ≥30 runs.
+- **A compile-time path** so the instruction is not hand-pasted. Not started; the design is
+  locked and its first gate is the end-to-end run in point 4 above.
 
 ### The non-experimental alternative
 

--- a/src/adapters/claude-code/agent-result.ts
+++ b/src/adapters/claude-code/agent-result.ts
@@ -49,7 +49,17 @@ function fieldMatches(value: unknown, type: OutputFieldType): boolean {
       return typeof value === "boolean";
     case "string[]":
       return Array.isArray(value) && value.every((v) => typeof v === "string");
+    default:
+      // An enum, declared as a readonly tuple of the permitted literals.
+      return typeof value === "string" && type.includes(value);
   }
+}
+
+/** How a field type reads in a message to a human: `string`, or `"CUT" | "MERGE"`. */
+function typeName(type: OutputFieldType): string {
+  return typeof type === "string"
+    ? type
+    : type.map((v) => JSON.stringify(v)).join(" | ");
 }
 
 /**
@@ -67,7 +77,9 @@ export function shapeError(
   for (const [field, type] of Object.entries(shape)) {
     if (!(field in obj)) return `missing field "${field}"`;
     if (!fieldMatches(obj[field], type)) {
-      return `field "${field}" should be ${type}`;
+      // `typeName`, not `type`: an enum interpolated raw renders as `CUT,MERGE,KEEP`,
+      // which reads like a value rather than a choice among values.
+      return `field "${field}" should be ${typeName(type)}`;
     }
   }
   return null;

--- a/src/core/compile.ts
+++ b/src/core/compile.ts
@@ -1135,7 +1135,12 @@ function renderAgentSections(
 /** Render a result-contract track shape as a compact `{ "f": type, … }` line. */
 function renderShape(shape: Readonly<Record<string, OutputFieldType>>): string {
   const fields = Object.entries(shape)
-    .map(([k, t]) => `"${k}": ${t}`)
+    // An enum renders as the choice itself — `"verdict": "CUT" | "MERGE" | "KEEP"` — so
+    // the fenced rail shows a worker the same permitted values the tool schema shows.
+    .map(
+      ([k, t]) =>
+        `"${k}": ${typeof t === "string" ? t : t.map((v) => JSON.stringify(v)).join(" | ")}`,
+    )
     .join(", ");
   return fields ? `{ ${fields} }` : "{}";
 }

--- a/src/core/spec.ts
+++ b/src/core/spec.ts
@@ -999,8 +999,28 @@ export function agent<
 // research/railway-subagents.md and research/subagent-compilation.md.
 // ---------------------------------------------------------------------------
 
-/** The field types a result contract can declare (kept tiny + dependency-free). */
-export type OutputFieldType = "string" | "number" | "boolean" | "string[]";
+/**
+ * The field types a result contract can declare (kept tiny + dependency-free).
+ *
+ * The literal-array member is an ENUM: `["CUT", "MERGE", "KEEP"] as const` declares a
+ * field whose value must be one of those strings. It is the ONLY extension to this union,
+ * and it was added because a measured failure had no other cure: across 14 real payloads
+ * a `verdict: "string"` field held 3 mutually incomparable invented categories over 3
+ * runs, and vocabulary compliance was 3/19 — 16%. `string` cannot express "one of these",
+ * so nothing downstream could notice.
+ *
+ * Nothing RELATIONAL follows it — no `object[]`, no tuples, no per-element enums.
+ * Declaring one throws rather than rendering an unsatisfiable schema, because the body of
+ * a result is prose by decision: on those same 14 payloads, 23 scalar values carried
+ * every assertion anyone made while 80,981 characters of prose carried none.
+ */
+export type OutputFieldType =
+  | "string"
+  | "number"
+  | "boolean"
+  | "string[]"
+  // An enum: the permitted values, as a non-empty readonly tuple of literals.
+  | readonly [string, ...string[]];
 
 /** A field SHAPE — a record of field-name → field-type, kept in the TYPE so a
  *  typed pipeline can cross-reference one agent's `ok` against the next agent's

--- a/src/experimental-emit.test.ts
+++ b/src/experimental-emit.test.ts
@@ -251,3 +251,118 @@ test("a field type outside the ceiling THROWS rather than serving an unsatisfiab
   assert.equal("actions" in roundTripped.properties, false);
   assert.deepEqual(Object.keys(roundTripped.properties), ["verdict"]);
 });
+
+// ---------------------------------------------------------------------------
+// A call that ERRORED is not an emission — the defect this closes, and the three
+// collapses it deliberately avoids.
+// ---------------------------------------------------------------------------
+
+/** Like `call`, but the host refused it: the payload is present, the server never saw it. */
+function deniedCall(name: string, input: unknown): ToolCall {
+  return {
+    name,
+    input,
+    resultText: "User denied permission for this tool call",
+    isError: true,
+  };
+}
+
+const GOOD = {
+  track: "ok",
+  ok: { verdict: "CUT", count: 3, report: "…" },
+};
+
+test("a DENIED call is malformed, not ok — it used to parse as a success", () => {
+  // Measured 2026-08-19 on the shipped build: this exact input returned
+  // {"kind":"ok","value":{…}}, because the reader filtered by NAME and never looked at
+  // `isError`. The call never reached the server. Reporting success for it is the same
+  // class of lie the emit channel exists to remove from the fenced rail.
+  const r = experimental_parseEmitted(
+    [deniedCall("emit_result", GOOD)],
+    CONTRACT,
+  );
+  assert.equal(r.kind, "malformed");
+  // The reason must send the reader to PERMISSIONS, not to the skill's instructions.
+  assert.match(r.reason, /errored or was denied/);
+  assert.match(r.reason, /allowedTools/);
+  assert.match(r.reason, /nothing reached the/);
+});
+
+test("two denials are named as denials, NOT as `called 2 times`", () => {
+  // A model that retries a denied call produces a true signal under a false name if the
+  // errored calls are counted: "the contract is exactly once" sends the reader hunting a
+  // double-emission bug that does not exist.
+  const r = experimental_parseEmitted(
+    [deniedCall("emit_result", GOOD), deniedCall("emit_result", GOOD)],
+    CONTRACT,
+  );
+  assert.equal(r.kind, "malformed");
+  assert.match(r.reason, /2 attempts/);
+  assert.doesNotMatch(r.reason, /exactly once/);
+});
+
+test("a denial ALONGSIDE a real emission is one emission — the contract was met", () => {
+  // Dropping this to malformed would fail a run that did exactly what was asked, and the
+  // denial is already visible in the trace for anyone who wants it.
+  const r = experimental_parseEmitted(
+    [deniedCall("emit_result", GOOD), call("emit_result", GOOD)],
+    CONTRACT,
+  );
+  assert.equal(r.kind, "ok");
+  assert.deepEqual(r.value, GOOD.ok);
+});
+
+test("no call at all still says NO CALL — denial must not swallow the plain miss", () => {
+  // The third collapse: dropping errored calls silently would turn a permissions fault
+  // into "the skill never emitted", pointing at the instructions instead of the cause.
+  const r = experimental_parseEmitted([], CONTRACT);
+  assert.equal(r.kind, "malformed");
+  assert.match(r.reason, /no `emit_result` tool call in the run/);
+  assert.doesNotMatch(r.reason, /denied/);
+});
+
+// ---------------------------------------------------------------------------
+// ENUM — the one extension to OutputFieldType, and the measurement behind it.
+// ---------------------------------------------------------------------------
+
+const ENUM_CONTRACT = result(
+  { verdict: ["CUT", "MERGE", "KEEP"], count: "number" },
+  { reason: "string" },
+);
+
+test("an enum field reaches the model as a JSON-Schema enum, not as a string", () => {
+  // The permitted values must travel WITH the tool definition. Declared as `string`, the
+  // vocabulary lives only in prose the model may not have read — measured at 3/19 = 16%
+  // compliance, with 3 mutually incomparable invented categories across 3 runs.
+  const { tool } = experimental_emitTool(ENUM_CONTRACT);
+  const ok = tool.inputSchema.properties.ok as EmitObjectSchema;
+  assert.deepEqual(ok.properties.verdict, {
+    type: "string",
+    enum: ["CUT", "MERGE", "KEEP"],
+  });
+});
+
+test("a value outside the enum is malformed, and the reason names the choices", () => {
+  const bad = experimental_parseEmitted(
+    [call("emit_result", { track: "ok", ok: { verdict: "SHIP", count: 1 } })],
+    ENUM_CONTRACT,
+  );
+  assert.equal(bad.kind, "malformed");
+  // Rendered as a choice (`"CUT" | "MERGE" | "KEEP"`), never as `CUT,MERGE,KEEP`, which
+  // reads like one value rather than a set of them.
+  assert.match(bad.reason, /should be "CUT" \| "MERGE" \| "KEEP"/);
+
+  const good = experimental_parseEmitted(
+    [call("emit_result", { track: "ok", ok: { verdict: "CUT", count: 1 } })],
+    ENUM_CONTRACT,
+  );
+  assert.equal(good.kind, "ok");
+});
+
+test("a non-string in an enum field is malformed too — membership implies the type", () => {
+  const r = experimental_parseEmitted(
+    [call("emit_result", { track: "ok", ok: { verdict: 7, count: 1 } })],
+    ENUM_CONTRACT,
+  );
+  assert.equal(r.kind, "malformed");
+});

--- a/src/experimental-emit.ts
+++ b/src/experimental-emit.ts
@@ -69,9 +69,14 @@ export type EmitFieldSchema =
   | { readonly type: "string" }
   | { readonly type: "number" }
   | { readonly type: "boolean" }
-  | { readonly type: "array"; readonly items: { readonly type: "string" } };
+  | { readonly type: "array"; readonly items: { readonly type: "string" } }
+  // A declared enum. Structurally identical to `EmitTrackSchema` and deliberately kept
+  // separate: that one is the fixed `ok`/`err` discriminator this module owns, this one
+  // is whatever the skill author declared, and collapsing them would let a change to the
+  // discriminator silently widen every author's enum.
+  | { readonly type: "string"; readonly enum: readonly string[] };
 
-/** The `track` discriminator's schema — the only enum this surface emits. */
+/** The `track` discriminator's schema — the enum this module owns, not the author's. */
 export interface EmitTrackSchema {
   readonly type: "string";
   readonly enum: readonly ["ok", "err"];
@@ -110,6 +115,10 @@ export interface ExperimentalEmitTool {
 }
 
 function fieldSchema(type: OutputFieldType): EmitFieldSchema {
+  // An enum reaches the model as a JSON-Schema `enum`, which is the whole point: the
+  // permitted values travel WITH the tool definition instead of living in prose the
+  // model may or may not have read.
+  if (typeof type !== "string") return { type: "string", enum: [...type] };
   switch (type) {
     case "string":
       return { type: "string" };
@@ -252,8 +261,44 @@ export function experimental_parseEmitted(
   options: { readonly name?: string } = {},
 ): ParsedAgentResult {
   const name = options.name ?? DEFAULT_EMIT_TOOL;
-  const calls = toolCalls.filter((c) => isEmitCall(c.name, name));
+  const all = toolCalls.filter((c) => isEmitCall(c.name, name));
+
+  // 🔴 A CALL THAT ERRORED IS NOT AN EMISSION, AND USED TO PARSE AS ONE.
+  //
+  // Measured 2026-08-19: a permission-denied call carrying a perfectly valid payload
+  // returned `{"kind":"ok", …}`, because this function filtered by NAME and never looked
+  // at `ToolCall.isError` — a field that has been on the type all along. The call never
+  // reached the server; the reader reported success. That is the exact shape of defect
+  // this channel exists to remove from the fenced rail, reproduced inside the channel.
+  //
+  // Denial is not hypothetical: it is what a wrong `allowedTools` spelling produces, and
+  // MCP tool names mangle per host (`mcp__plugin_<plugin>_<server>__emit_result` on Claude
+  // Code, two segments on Codex), so mis-spelling it is the likely case, not the exotic one.
+  //
+  // The errored calls get their OWN branch rather than being dropped or counted, because
+  // all three collapses lie in a different direction:
+  //   - counting them → this defect, success for a call nobody received;
+  //   - dropping them silently → "no tool call in the run", which sends the reader to the
+  //     skill's instructions when the fault is in permissions;
+  //   - lumping them with "called twice" → a model that retries a denied call produces a
+  //     true signal under a false name. (Observed: two denials in one run.)
+  // A successful call ALONGSIDE a denied one is one successful emission; the denial is
+  // mentioned, not fatal, because the contract was in fact satisfied.
+  // `isError` is a required boolean on ToolCall, so truthiness is exact here.
+  const errored = all.filter((c) => c.isError);
+  const calls = all.filter((c) => !c.isError);
+
   if (calls.length === 0) {
+    if (errored.length > 0) {
+      return {
+        kind: "malformed",
+        reason:
+          `the \`${name}\` call itself errored or was denied ` +
+          `(${String(errored.length)} attempt${errored.length === 1 ? "" : "s"}); nothing reached the ` +
+          `server, so nothing was emitted. Check the tool's permissions and the exact spelling ` +
+          `in \`allowedTools\` — MCP names are host-mangled.`,
+      };
+    }
     return { kind: "malformed", reason: `no \`${name}\` tool call in the run` };
   }
   if (calls.length > 1) {

--- a/src/scaffold-test.ts
+++ b/src/scaffold-test.ts
@@ -187,7 +187,10 @@ assertTriggerRate(report, { min: 0.8, maxFalsePositive: 0.3 });
 }
 
 /** A JSON value placeholder for an `OutputFieldType`, for the `vigiles:ok` block. */
-function placeholderFor(type: string): unknown {
+function placeholderFor(type: unknown): unknown {
+  // An enum's placeholder must be a MEMBER, or the scaffolded test fails the moment it
+  // is run — a generated test that cannot pass teaches the author to distrust the tool.
+  if (Array.isArray(type) && type.length > 0) return type[0];
   switch (type) {
     case "number":
       return 1;


### PR DESCRIPTION
Steps 1 and 2 of the locked emit design, plus the public docs brought level with what has actually been measured.

## 1. A call that errored is not an emission

Measured on the shipped build — a permission-denied call carrying a valid payload:

```
DENIED call parses as: {"kind":"ok","value":{"verdict":"BLOCKED","count":3}}
```

The reader filtered calls by **name** and never looked at `ToolCall.isError`, a field that has been on the type all along. The server never received that call. This is the exact class of lie the emit channel exists to remove from the fenced rail, reproduced inside the channel.

A wrong `allowedTools` spelling is the likely cause, not an exotic one: MCP names are host-mangled (`mcp__plugin_<plugin>_<server>__emit_result` on Claude Code, two segments on Codex).

Errored calls now get **their own branch**, because all three collapses lie in a different direction:

| collapse | what it produces |
|---|---|
| count them (today) | success for a call nobody received |
| drop them silently | `no tool call in the run` — sends the reader to the skill's instructions when the fault is in permissions |
| lump with "called twice" | a model retrying a denial gives a true signal under a false name |

A successful call **alongside** a denied one is one successful emission — the contract was met, and the denial is visible in the trace for anyone who wants it.

Four tests, each naming its collapse. Mutation-checked: removing the split fails three of the four (the fourth doesn't depend on it, correctly).

## 2. Enum — the one extension to `OutputFieldType`

```ts
result({ verdict: ["CUT", "MERGE", "KEEP"], count: "number" }, { reason: "string" })
```

Renders as a JSON-Schema `enum` in the tool definition and as `"verdict": "CUT" | "MERGE" | "KEEP"` in the fenced rail, so **both deliveries show a worker the same permitted values**.

The measurement behind it: a `verdict` field declared as `string` held **three mutually incomparable invented categories over three runs**, with **3/19 = 16%** vocabulary compliance. `string` cannot express "one of these", so nothing downstream could notice.

Nothing relational follows it — no `object[]`, no tuples, no per-element enums. On 14 real payloads, **23 scalar values carried every assertion anyone made while 80,981 characters of prose carried none**, so the body stays prose by decision rather than by omission.

## 3. Docs

`docs/experimental.md` gains the **outcome table** — every way an emission can fail to satisfy the contract, with the actual reason text. That was the one thing a reader could not find anywhere, and it is the first question anyone asks about a channel like this.

Also updated: the measurements now reflect the breadth study (15/15 on sonnet; the haiku zero was the skill stopping early, not the channel dropping, which is why the pooled number is deliberately not printed); the serving question is marked answered; the prefix-removal conditions now say which of the three is met.

And it states plainly what the channel does **not** check: whether the emitted result is *true*. Gating on an emitted verdict was measured and rejected — self-report disagreed with a judged check in **45–75.8%** of runs.

## Gates

`npx vitest run` · `npm run lint` · `npx prettier --check .` · `npm run api:check` · `npm run build` — via `npm run check`, **18/18**. The `api-surface` diff is the intended widening of `OutputFieldType` and `EmitFieldSchema`, reviewed and committed.

## Not in this PR

Step 3 of the design (the compile-time path) is gated on an end-to-end run that has never been done: a **compiled** `SKILL.md` has never been observed loading as an installed skill, because the `vigiles:sha256:` header pushes frontmatter off line 1. That gate comes first, and this PR does not pretend otherwise.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Features**
- an errored emit is not an emission, and a contract field can be an enum
<!-- vigiles:pr-summary:end -->
