### PR TITLE
fix(site): add a self-referencing canonical to the landing

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -25,6 +25,12 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="vigiles" />
+    <!-- Self-referencing canonical. The same build is served from TWO hosts —
+         https://vigiles.sh/ (CNAME) and https://zernie.github.io/vigiles/ — so
+         without this Google picks the canonical itself and may consolidate onto
+         the github.io copy. The generated /checks/<slug>/ pages already carry one
+         (site/scripts/gen-check-pages.ts); the landing was the gap. -->
+    <link rel="canonical" href="https://vigiles.sh/" />
     <meta property="og:url" content="https://vigiles.sh/" />
     <!-- Absolute URL is required: OG crawlers can't resolve a relative path. -->
     <meta property="og:image" content="https://vigiles.sh/og.png" />


### PR DESCRIPTION
The same build is served from two hosts — `https://vigiles.sh/` (CNAME) and `https://zernie.github.io/vigiles/` — and the landing declared `og:url` but no `canonical`, so Google was free to pick which copy to index and could consolidate onto the `github.io` one.

The generated `/checks/<slug>/` pages already carry a canonical (`site/scripts/gen-check-pages.ts:43`). The landing was the only entry without one.

One line, next to the existing `og:url` so the two stay together. `prettier --check` passes.

Found while diagnosing an unrelated Search Console notice on another site; the gap here is real on its own.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqrFDeGcwXMMC29zapLU48)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Fixes**
- add a self-referencing canonical to the landing
<!-- vigiles:pr-summary:end -->
