### PR TITLE
fix(hook-install): recompiling appended a duplicate beside a hand-wired hook

### DIFF
--- a/src/hook-install.test.ts
+++ b/src/hook-install.test.ts
@@ -25,6 +25,130 @@ const compiled = {
 };
 
 describe("mergeHooksJson", () => {
+  // A settings.json wired the way Claude Code's own docs recommend carries BOTH
+  // a quote and $CLAUDE_PROJECT_DIR. Before 2026-08-21 neither was stripped, so
+  // recompiling appended a second block beside the first — measured at twelve
+  // duplicates across twelve hooks in a real repo.
+  const wiredByHand = (hook: string) => ({
+    matcher: "Bash",
+    hooks: [
+      {
+        type: "command" as const,
+        command: `node "$CLAUDE_PROJECT_DIR/node_modules/vigiles/dist/cli.js" hook-runtime run-program "$CLAUDE_PROJECT_DIR/${hook}"`,
+      },
+    ],
+  });
+
+  it("replaces a hand-wired entry that quotes the path and uses $CLAUDE_PROJECT_DIR", () => {
+    const existing = {
+      hooks: { PreToolUse: [wiredByHand(".claude/hooks/x.hook.ts")] },
+    };
+    const compiled = {
+      PreToolUse: [
+        {
+          matcher: "Bash",
+          hooks: [
+            {
+              type: "command" as const,
+              command:
+                "npx vigiles hook-runtime run-program .claude/hooks/x.hook.ts",
+            },
+          ],
+        },
+      ],
+    };
+    const out = mergeHooksJson(existing, compiled, ".claude/hooks/x.hook.ts");
+    expect(out.hooks?.PreToolUse).toHaveLength(1);
+  });
+
+  // The over-match that ACTUALLY threatens this change: `$CLAUDE_PROJECT_DIR` is
+  // stripped because it IS the project root by definition. Any OTHER variable
+  // names an unknown location — a sibling checkout, a plugin dir — and treating
+  // it as the root would delete a hook pointing somewhere else entirely.
+  it("does not treat a hook under a DIFFERENT variable as this project's", () => {
+    const existing = {
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Bash",
+            hooks: [
+              {
+                type: "command" as const,
+                command:
+                  'npx vigiles hook-runtime run-program "$OTHER_REPO/.claude/hooks/x.hook.ts"',
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const compiled = {
+      PreToolUse: [
+        {
+          matcher: "Bash",
+          hooks: [
+            {
+              type: "command" as const,
+              command:
+                "npx vigiles hook-runtime run-program .claude/hooks/x.hook.ts",
+            },
+          ],
+        },
+      ],
+    };
+    const out = mergeHooksJson(existing, compiled, ".claude/hooks/x.hook.ts");
+    expect(out.hooks?.PreToolUse).toHaveLength(2);
+  });
+
+  // 🔴 The over-match half, and it needed its own case: a mutation that ORs in a
+  // raw `command.includes(ref)` passed the "different hook" test green, because
+  // `other.hook.ts` does not contain `x.hook.ts` as a substring. Only a PREFIX
+  // COLLISION separates the two rules — which is the very case the module header
+  // says a substring test used to get wrong.
+  it("does not swallow a hand-wired hook whose name merely ENDS WITH this one", () => {
+    const existing = {
+      hooks: { PreToolUse: [wiredByHand(".claude/hooks/my-x.hook.ts")] },
+    };
+    const compiled = {
+      PreToolUse: [
+        {
+          matcher: "Bash",
+          hooks: [
+            {
+              type: "command" as const,
+              command:
+                "npx vigiles hook-runtime run-program .claude/hooks/x.hook.ts",
+            },
+          ],
+        },
+      ],
+    };
+    const out = mergeHooksJson(existing, compiled, ".claude/hooks/x.hook.ts");
+    expect(out.hooks?.PreToolUse).toHaveLength(2);
+  });
+
+  it("still keeps a hand-wired entry for a DIFFERENT hook", () => {
+    const existing = {
+      hooks: { PreToolUse: [wiredByHand(".claude/hooks/other.hook.ts")] },
+    };
+    const compiled = {
+      PreToolUse: [
+        {
+          matcher: "Bash",
+          hooks: [
+            {
+              type: "command" as const,
+              command:
+                "npx vigiles hook-runtime run-program .claude/hooks/x.hook.ts",
+            },
+          ],
+        },
+      ],
+    };
+    const out = mergeHooksJson(existing, compiled, ".claude/hooks/x.hook.ts");
+    expect(out.hooks?.PreToolUse).toHaveLength(2);
+  });
+
   it("adds the hook block to an empty settings object", () => {
     const out = mergeHooksJson({}, compiled, ".vigiles/hooks/g.mjs");
     expect(out.hooks?.PreToolUse).toHaveLength(1);

--- a/src/hook-install.ts
+++ b/src/hook-install.ts
@@ -101,10 +101,43 @@ export function normalizeHookRef(
 function managesHook(entry: HookEntry, hookPath: string): boolean {
   const ref = normalizeHookRef(hookPath);
   return entry.hooks.some((h) =>
-    h.command
-      .split(/\s+/)
-      .some((token) => token !== "" && normalizeHookRef(token) === ref),
+    h.command.split(/\s+/).some((token) => {
+      const bare = bareToken(token);
+      return bare !== "" && normalizeHookRef(bare) === ref;
+    }),
   );
+}
+
+/**
+ * A command token reduced to the PATH it names, so two spellings of the same
+ * hook file compare equal.
+ *
+ * 🔴 BOTH STRIPS ARE REGRESSIONS, MEASURED IN A CONSUMER REPO 2026-08-21, and
+ * they compound: a settings.json wired the Claude-Code-recommended way carries
+ * BOTH a quote and the project-dir variable, so `managesHook` saw
+ * `"$CLAUDE_PROJECT_DIR/.claude/hooks/x.hook.ts"`, canonicalized it to
+ * something under the cwd that resembles nothing, and reported "not managed by
+ * this hook". Recompiling then APPENDED its own block beside the existing one.
+ * Twelve hooks, twelve duplicates, and the duplicate is the WORSE of the two:
+ * it spells the path relative to the cwd, so it dies with exit 2 the moment the
+ * agent runs from a subdirectory — while the healthy copy beside it keeps
+ * working, which is why this survived a full day unnoticed.
+ *
+ * - QUOTES. A path with a space MUST be quoted, so the quoted form is not an
+ *   exotic spelling — it is the correct one. Comparing it raw could never match.
+ * - `$CLAUDE_PROJECT_DIR`. It is defined as the project root, which is exactly
+ *   what `normalizeHookRef` resolves relative paths against, so stripping the
+ *   prefix makes the two spellings the same path by definition rather than by
+ *   guess. `${CLAUDE_PROJECT_DIR}` is the same variable in brace syntax.
+ *
+ * Nothing else is stripped. A token this function does not recognise is left
+ * alone and simply fails to match, which is the pre-existing behaviour: the
+ * cost of a miss here is a duplicate block, and the cost of an over-match is
+ * deleting a hook the user wrote themselves.
+ */
+function bareToken(token: string): string {
+  const unquoted = token.replace(/^["']/, "").replace(/["']$/, "");
+  return unquoted.replace(/^\$\{?CLAUDE_PROJECT_DIR\}?[/\\]/, "");
 }
 
 /**


### PR DESCRIPTION
Recompiling appended a duplicate wiring beside a hand-wired hook. Measured in a consumer repo on 2026-08-21: `vigiles compile` over twelve hooks produced **twelve duplicates**, because `managesHook` could not see that the existing entry pointed at the same file.

The existing entries were wired the way Claude Code's own docs recommend:

```
node "$CLAUDE_PROJECT_DIR/node_modules/vigiles/dist/cli.js" \
  hook-runtime run-program "$CLAUDE_PROJECT_DIR/.claude/hooks/x.hook.ts"
```

`managesHook` splits the command on whitespace and canonicalises each token, so it compared the literal `"$CLAUDE_PROJECT_DIR/.claude/hooks/x.hook.ts"` — quotes included — against `.claude/hooks/x.hook.ts`. Two independent reasons it could never match, and they compound:

- **Quotes** are not an exotic spelling. A path containing a space *must* be quoted, so the quoted form is the correct one and was unmatchable.
- **`$CLAUDE_PROJECT_DIR` is the project root** — exactly what `normalizeHookRef` resolves relative paths against — so the two spellings name the same file by definition, not by guess.

## Why it survived a full day

The duplicate is the worse of the two copies: it spells the path relative to the cwd, so it exits 2 the moment the agent runs from a subdirectory. The healthy copy beside it keeps working, so the harness looks fine right up until someone `cd`s.

## What is deliberately *not* stripped

Only `$CLAUDE_PROJECT_DIR`. Any other variable names an unknown location — a sibling checkout, a plugin dir — and treating it as the root would **delete** a hook pointing somewhere else. A token this function does not recognise is left alone and simply fails to match, which is the pre-existing behaviour: the cost of a miss is a duplicate block, the cost of an over-match is losing the user's own hook.

## Mutations

Each with evidence the patch landed:

| mutation | fails on |
| --- | --- |
| stop stripping quotes | `replaces a hand-wired entry that quotes the path…` |
| stop stripping `$CLAUDE_PROJECT_DIR` | same |
| strip **any** `$VAR/` | `does not treat a hook under a DIFFERENT variable as this project's` |

⚠️ Two earlier mutations were worthless and are recorded in the commit so nobody repeats them: a `command.includes(ref)` over-match passed **green** (a full-path ref makes `includes` nearly as strict as `===`), and a hand-written regex mutation produced a syntax error, which reads as "no tests" rather than as a failure. A green mutation is a finding about the *test*, not a verdict about the code.

## Gates

`npm run check` 18/18 · `npx vitest run` 3240 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uvk2Zx66BAuxuLGLFL2umd)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Fixes**
- recompiling appended a duplicate beside a hand-wired hook
<!-- vigiles:pr-summary:end -->
