### PR TITLE
feat(cli)!: load specs in a vigiles-owned spec host, not a two-loader guess

### DIFF
--- a/.vigiles/generated.d.ts
+++ b/.vigiles/generated.d.ts
@@ -101,7 +101,7 @@ declare module "vigiles/generated" {
     | "internal:check"
     | "docs:api";
 
-  /** 393 project files. */
+  /** 394 project files. */
   export type ProjectFile = 
     | "src/CLAUDE.md"
     | "src/CLAUDE.md.spec.ts"
@@ -480,6 +480,7 @@ declare module "vigiles/generated" {
     | "src/skill-refs.ts"
     | "src/skill-test.test.ts"
     | "src/skill-test.ts"
+    | "src/spec-loader.test.ts"
     | "src/stats.test.ts"
     | "src/stats.ts"
     | "src/subagent-delivery.test.ts"
@@ -945,6 +946,7 @@ declare module "vigiles/spec" {
       | "src/skill-refs.ts"
       | "src/skill-test.test.ts"
       | "src/skill-test.ts"
+      | "src/spec-loader.test.ts"
       | "src/stats.test.ts"
       | "src/stats.ts"
       | "src/subagent-delivery.test.ts"

--- a/.vigiles/generated.d.ts
+++ b/.vigiles/generated.d.ts
@@ -101,7 +101,7 @@ declare module "vigiles/generated" {
     | "internal:check"
     | "docs:api";
 
-  /** 394 project files. */
+  /** 396 project files. */
   export type ProjectFile = 
     | "src/CLAUDE.md"
     | "src/CLAUDE.md.spec.ts"
@@ -480,6 +480,8 @@ declare module "vigiles/generated" {
     | "src/skill-refs.ts"
     | "src/skill-test.test.ts"
     | "src/skill-test.ts"
+    | "src/spec-hooks.mts"
+    | "src/spec-host.mts"
     | "src/spec-loader.test.ts"
     | "src/stats.test.ts"
     | "src/stats.ts"
@@ -946,6 +948,8 @@ declare module "vigiles/spec" {
       | "src/skill-refs.ts"
       | "src/skill-test.test.ts"
       | "src/skill-test.ts"
+      | "src/spec-hooks.mts"
+      | "src/spec-host.mts"
       | "src/spec-loader.test.ts"
       | "src/stats.test.ts"
       | "src/stats.ts"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -483,16 +483,22 @@ export function describeLoadFailure(
   nativeError: unknown,
   tsxError: unknown,
 ): string {
-  const tsxMsg =
-    tsxError instanceof Error ? tsxError.message : String(tsxError);
-  const nativeMsg =
-    nativeError instanceof Error ? nativeError.message : String(nativeError);
+  const msg = (e: unknown) => (e instanceof Error ? e.message : String(e));
+  const tsxMsg = msg(tsxError);
+  const nativeMsg = msg(nativeError);
 
-  // execSync surfaces a timeout as a killed child, not as a message.
-  const killed =
-    typeof tsxError === "object" &&
-    tsxError !== null &&
-    (tsxError as { killed?: boolean; signal?: string }).killed === true;
+  // On Node < 22.6 (or with --no-strip-types) the native attempt ALWAYS fails
+  // this way. It is expected noise, not a diagnosis, so it must never be the
+  // headline — the repository's own CI runs Node 20, where every load takes the
+  // fallback and this is the only thing the native attempt can say.
+  const nativeUnsupported =
+    /Unknown file extension|ERR_UNKNOWN_FILE_EXTENSION|ERR_UNSUPPORTED_/i.test(
+      nativeMsg,
+    );
+
+  const status = (tsxError as { status?: number | null } | null)?.status;
+  const killed = (tsxError as { killed?: boolean } | null)?.killed === true;
+
   if (killed || /ETIMEDOUT|timed out/i.test(tsxMsg)) {
     return (
       "the `npx tsx` fallback timed out after 15s. Install tsx locally " +
@@ -500,14 +506,23 @@ export function describeLoadFailure(
       "Node >= 22.6 where no subprocess is needed."
     );
   }
-  if (/not found|ENOENT|could not determine executable/i.test(tsxMsg)) {
+
+  // 127 is the shell's "command not found". Matching the child's stderr text
+  // instead would misread a SPEC that happens to mention "not found" — e.g. a
+  // missing config it requires — as a missing runner.
+  if (status === 127) {
     return (
-      "neither native import nor `npx tsx` could run this spec. Install tsx " +
-      "locally (`npm i -D tsx`), or upgrade to Node >= 22.6 for native type " +
-      `stripping. Native import said: ${nativeMsg}`
+      "neither native import nor `npx tsx` could run this spec: tsx is not " +
+      "installed. Install it locally (`npm i -D tsx`), or upgrade to " +
+      "Node >= 22.6 for native type stripping."
     );
   }
-  return `the spec did not load. Native import said: ${nativeMsg}`;
+
+  // tsx ran and the spec itself failed: its error is the actionable one.
+  const detail = nativeUnsupported
+    ? tsxMsg
+    : `${nativeMsg} · tsx said: ${tsxMsg}`;
+  return `the spec did not load. ${detail}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -549,10 +549,26 @@ export function describeLoadFailure(
       nativeMsg,
     );
 
-  const status = (tsxError as { status?: number | null } | null)?.status;
-  const killed = (tsxError as { killed?: boolean } | null)?.killed === true;
+  const meta = tsxError as {
+    status?: number | null;
+    killed?: boolean;
+    signal?: string | null;
+    code?: unknown;
+  } | null;
+  const status = meta?.status;
 
-  if (killed || /ETIMEDOUT|timed out/i.test(tsxMsg)) {
+  // Timeout is read from exec METADATA, never from the child's output. execSync
+  // embeds the child's stderr in Error.message, so text-matching here would
+  // rewrite a spec whose own failure mentions «timed out» — a network call it
+  // makes, say — into fallback-timeout plus advice to install tsx, which is
+  // already installed. Same defect as the `not found` match below, reported in
+  // review on #178 and fixed there first; this is the other half of it.
+  const timedOut =
+    meta?.killed === true ||
+    meta?.code === "ETIMEDOUT" ||
+    meta?.signal === "SIGTERM";
+
+  if (timedOut) {
     return (
       "the `npx tsx` fallback timed out after 15s. Install tsx locally " +
       "(`npm i -D tsx`) so npx does not fetch it over the network, or run on " +

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -449,9 +449,23 @@ async function loadSpec(specPath: string): Promise<AnySpec | null> {
       return (raw as { default: AnySpec }).default;
     }
     if (raw) return raw;
-    nativeError = new Error("module has no default export");
+    // The module DID evaluate; running it again under tsx would repeat its side
+    // effects to learn the same thing.
+    lastSpecLoadFailure = "the spec has no default export.";
+    return null;
   } catch (err) {
     nativeError = err;
+    // 🔴 ONLY a capability failure may fall through to the subprocess. `import()`
+    // both LOADS and EVALUATES, so this catch also sees exceptions thrown by the
+    // spec itself — and re-running such a spec under tsx executes it a SECOND
+    // time. A spec (or a helper it imports) that writes a file or makes a request
+    // before throwing would do it twice. Reported in review on #178.
+    if (!nativeFailedBeforeEvaluating(err)) {
+      lastSpecLoadFailure = `the spec did not load. ${
+        err instanceof Error ? err.message : String(err)
+      }`;
+      return null;
+    }
   }
 
   // Fallback for runtimes without type stripping: older Node, 22.6-22.17 where it
@@ -481,6 +495,43 @@ async function loadSpec(specPath: string): Promise<AnySpec | null> {
  * of them: a spec that does not parse, a `tsx` that is not installed (so `npx`
  * goes to the registry), and a timeout.
  */
+/**
+ * Did the native `import()` fail BEFORE the module body ran?
+ *
+ * That is the property that matters, not "was it a capability error". The
+ * fallback re-runs the spec in a subprocess, so it is safe exactly when nothing
+ * of the spec has executed yet — resolution, parsing and the missing-loader case
+ * all fail before evaluation and carry no side effects. An exception thrown by
+ * the module body does not, and re-running it would repeat whatever it did
+ * first (write a file, send a request).
+ *
+ * 🔴 `ERR_MODULE_NOT_FOUND` MUST fall through, measured: tsx rewrites a `.js`
+ * specifier to the `.ts` source next to it (the TypeScript ESM convention) and
+ * native Node does not. This repo's own specs import `src/core/spec.js`, a file
+ * that does not exist — native resolution fails, tsx resolves it. Treating that
+ * as a spec failure broke 8 tests in src/cli.test.ts.
+ */
+function nativeFailedBeforeEvaluating(err: unknown): boolean {
+  const code = (err as { code?: unknown } | null)?.code;
+  if (
+    code === "ERR_UNKNOWN_FILE_EXTENSION" ||
+    code === "ERR_MODULE_NOT_FOUND" ||
+    code === "ERR_PACKAGE_PATH_NOT_EXPORTED" ||
+    code === "ERR_UNSUPPORTED_DIR_IMPORT" ||
+    code === "ERR_INVALID_MODULE_SPECIFIER" ||
+    code === "ERR_UNSUPPORTED_ESM_URL_SCHEME"
+  ) {
+    return true;
+  }
+  // A parse error also precedes execution. Runtimes without type stripping
+  // report TypeScript syntax this way instead of with a code.
+  if (err instanceof SyntaxError) return true;
+  const msg = err instanceof Error ? err.message : String(err);
+  return /Unknown file extension|Cannot find module|Cannot find package/i.test(
+    msg,
+  );
+}
+
 export function describeLoadFailure(
   nativeError: unknown,
   tsxError: unknown,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -398,10 +398,30 @@ type HostReply =
   | { path: string; ok: true; value: AnySpec }
   | { path: string; ok: false; error: string };
 
+type Settle = (reply: HostReply | "timeout" | "died") => void;
+
 type Host = {
   child: ChildProcessWithoutNullStreams;
-  /** Resolves the pending request; only one is outstanding at a time. */
-  pending: ((reply: HostReply) => void) | null;
+  /**
+   * Outstanding requests keyed BY PATH.
+   *
+   * 🔴 This was a single slot until a `--trace-warnings` run showed
+   * `checkCoverageThresholds` calling `loadSpec` through `Array.map`, i.e.
+   * concurrently. A single slot is overwritten by each new caller, so a reply
+   * settles whichever request happened to be last — `loadSpec` could return
+   * ANOTHER spec's value for the path it was asked about.
+   *
+   * ⚠️ **Honest scope of that claim.** The mispairing is wrong by construction,
+   * but it is NOT observable today: the one concurrent caller aggregates and
+   * never asks which spec it got. Measured — the same `vigiles lint` run with a
+   * last-wins dispatch produces byte-identical output. So this is a latent
+   * defect closed before it had consequences, not a bug anyone hit; the visible
+   * symptom was only the MaxListeners warning. I could not construct an
+   * end-to-end test that fails without keying by path, and the test beside this
+   * file says so rather than implying otherwise. The next concurrent caller
+   * that DOES care about identity is the one this protects.
+   */
+  pending: Map<string, Settle>;
   /** Last spec the host said it had STARTED — the culprit when a deadline fires. */
   started: string | null;
   buffered: string;
@@ -419,7 +439,7 @@ function startHost(): Host {
     cwd: process.cwd(),
     stdio: ["pipe", "pipe", "pipe"],
   });
-  const h: Host = { child, pending: null, started: null, buffered: "" };
+  const h: Host = { child, pending: new Map(), started: null, buffered: "" };
 
   child.stdout.setEncoding("utf-8");
   child.stdout.on("data", (chunk: string) => {
@@ -439,8 +459,8 @@ function startHost(): Host {
         h.started = reply.path;
         continue;
       }
-      const done = h.pending;
-      h.pending = null;
+      const done = h.pending.get(reply.path);
+      h.pending.delete(reply.path);
       done?.(reply);
     }
   });
@@ -455,6 +475,15 @@ function startHost(): Host {
   // then hung forever waiting on a host that had nothing left to say. The
   // in-flight deadline timer keeps the loop alive while a request is pending,
   // which is exactly as long as we need it.
+  // ONE exit listener per host, not one per request: with concurrent callers the
+  // per-request version added a listener each time and Node warned at eleven.
+  // It fails every outstanding request, because a dead host answers none of them.
+  child.once("exit", () => {
+    const waiting = [...h.pending.values()];
+    h.pending.clear();
+    for (const settle of waiting) settle("died");
+  });
+
   // The stdio types are Readable/Writable, which do not declare `unref` — the
   // objects are pipes and do have it. Optional-called so this stays correct if
   // a platform ever hands back a stream that genuinely lacks it.
@@ -467,13 +496,20 @@ function startHost(): Host {
   return h;
 }
 
-/** Kill the host and forget it; the next request starts a fresh one. */
+/**
+ * Kill the host and forget it; the next request starts a fresh one.
+ *
+ * Outstanding requests are failed rather than dropped: a killed host will never
+ * answer them, and a promise nobody settles is a hang wearing a different hat.
+ */
 function dropHost(): void {
   if (!host) return;
   const dying = host;
   host = null;
-  dying.pending = null;
+  const waiting = [...dying.pending.values()];
+  dying.pending.clear();
   dying.child.kill("SIGKILL");
+  for (const settle of waiting) settle("died");
 }
 
 process.on("exit", dropHost);
@@ -507,31 +543,17 @@ async function loadSpec(specPath: string): Promise<AnySpec | null> {
 
   const reply = await new Promise<HostReply | "timeout" | "died">((done) => {
     let settled = false;
-    let cleanup = () => {};
-    const finish = (r: HostReply | "timeout" | "died") => {
+    const finish: Settle = (r) => {
       if (settled) return;
       settled = true;
-      cleanup();
+      clearTimeout(timer);
+      h.pending.delete(fullPath);
       done(r);
     };
     const timer = setTimeout(() => {
       finish("timeout");
     }, SPEC_DEADLINE_MS);
-    // 🔴 The exit listener is REMOVED when the request settles. `once` fires at
-    // most once but stays registered until it does, so one per spec accumulated
-    // for the life of the host and Node warned at eleven:
-    //   MaxListenersExceededWarning: 11 exit listeners added to [ChildProcess]
-    // Found by dogfooding `vigiles lint` on this repo, not by a test — a leak
-    // that only shows past a threshold is invisible to fixtures with few specs.
-    const onExit = () => {
-      finish("died");
-    };
-    h.child.once("exit", onExit);
-    cleanup = () => {
-      clearTimeout(timer);
-      h.child.off("exit", onExit);
-    };
-    h.pending = finish;
+    h.pending.set(fullPath, finish);
     h.child.stdin.write(JSON.stringify({ path: fullPath }) + "\n");
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -507,19 +507,31 @@ async function loadSpec(specPath: string): Promise<AnySpec | null> {
 
   const reply = await new Promise<HostReply | "timeout" | "died">((done) => {
     let settled = false;
+    let cleanup = () => {};
     const finish = (r: HostReply | "timeout" | "died") => {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      cleanup();
       done(r);
     };
     const timer = setTimeout(() => {
       finish("timeout");
     }, SPEC_DEADLINE_MS);
-    h.pending = finish;
-    h.child.once("exit", () => {
+    // 🔴 The exit listener is REMOVED when the request settles. `once` fires at
+    // most once but stays registered until it does, so one per spec accumulated
+    // for the life of the host and Node warned at eleven:
+    //   MaxListenersExceededWarning: 11 exit listeners added to [ChildProcess]
+    // Found by dogfooding `vigiles lint` on this repo, not by a test — a leak
+    // that only shows past a threshold is invisible to fixtures with few specs.
+    const onExit = () => {
       finish("died");
-    });
+    };
+    h.child.once("exit", onExit);
+    cleanup = () => {
+      clearTimeout(timer);
+      h.child.off("exit", onExit);
+    };
+    h.pending = finish;
     h.child.stdin.write(JSON.stringify({ path: fullPath }) + "\n");
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -434,7 +434,8 @@ async function loadSpec(specPath: string): Promise<AnySpec | null> {
     }
   }
 
-  // Load the .ts directly. Node >= 22.6 strips types itself, so no subprocess and
+  // Load the .ts directly. Node strips types itself where that is ON BY DEFAULT —
+  // 22.18+ on the 22 line, 23.6+ on 23 — so no subprocess and
   // no network are needed — measured 0.7s against >60s for the `npx tsx` path when
   // tsx is not installed locally. This is tried FIRST for exactly that reason.
   let nativeError: unknown;
@@ -453,7 +454,8 @@ async function loadSpec(specPath: string): Promise<AnySpec | null> {
     nativeError = err;
   }
 
-  // Fallback for runtimes without type stripping (Node < 22.6, or stripping off).
+  // Fallback for runtimes without type stripping: older Node, 22.6-22.17 where it
+  // sits behind --experimental-strip-types, or any runtime with it switched off.
   try {
     const { execSync } =
       require("node:child_process") as typeof import("node:child_process");
@@ -487,7 +489,7 @@ export function describeLoadFailure(
   const tsxMsg = msg(tsxError);
   const nativeMsg = msg(nativeError);
 
-  // On Node < 22.6 (or with --no-strip-types) the native attempt ALWAYS fails
+  // Without type stripping the native attempt ALWAYS fails
   // this way. It is expected noise, not a diagnosis, so it must never be the
   // headline — the repository's own CI runs Node 20, where every load takes the
   // fallback and this is the only thing the native attempt can say.
@@ -503,7 +505,8 @@ export function describeLoadFailure(
     return (
       "the `npx tsx` fallback timed out after 15s. Install tsx locally " +
       "(`npm i -D tsx`) so npx does not fetch it over the network, or run on " +
-      "Node >= 22.6 where no subprocess is needed."
+      "Node >= 22.18 (or >= 23.6), where type stripping is on by default and no " +
+      "subprocess is needed. On 22.6-22.17 it needs --experimental-strip-types."
     );
   }
 
@@ -514,7 +517,8 @@ export function describeLoadFailure(
     return (
       "neither native import nor `npx tsx` could run this spec: tsx is not " +
       "installed. Install it locally (`npm i -D tsx`), or upgrade to " +
-      "Node >= 22.6 for native type stripping."
+      "Node >= 22.18 (or >= 23.6) for native type stripping — 22.6-22.17 have it " +
+      "only behind --experimental-strip-types."
     );
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -370,8 +370,29 @@ function findSpecs(pattern?: string): string[] {
 
 type AnySpec = ClaudeSpec | SkillSpec | AgentSpec | Railway;
 
+/**
+ * Why the last `loadSpec()` returned null.
+ *
+ * Exists because the caller used to print «Ensure the spec is compiled: run
+ * `npm run build` first» for EVERY failure, and that advice is wrong for most of
+ * them. Measured 2026-08-31 in a consuming repo: all 50 specs failed to load and
+ * the true cause was that `tsx` was not installed locally, so the `npx tsx`
+ * fallback below went to the network and blew its 15s budget. The message sent
+ * the reader to a build step that does not exist in a consumer install.
+ *
+ * Kept as module state rather than a widened return type on purpose: `loadSpec`
+ * has six call sites and only one of them reports to a human.
+ */
+let lastSpecLoadFailure: string | null = null;
+
+/** Reason the most recent `loadSpec()` returned null, or null if it succeeded. */
+export function specLoadFailureReason(): string | null {
+  return lastSpecLoadFailure;
+}
+
 async function loadSpec(specPath: string): Promise<AnySpec | null> {
   const fullPath = resolve(process.cwd(), specPath);
+  lastSpecLoadFailure = null;
 
   // Try multiple dist/ path strategies
   const candidates: string[] = [];
@@ -413,7 +434,26 @@ async function loadSpec(specPath: string): Promise<AnySpec | null> {
     }
   }
 
-  // Try loading .ts directly via tsx
+  // Load the .ts directly. Node >= 22.6 strips types itself, so no subprocess and
+  // no network are needed — measured 0.7s against >60s for the `npx tsx` path when
+  // tsx is not installed locally. This is tried FIRST for exactly that reason.
+  let nativeError: unknown;
+  try {
+    const { pathToFileURL } = require("node:url") as typeof import("node:url");
+    const mod = (await import(pathToFileURL(fullPath).href)) as {
+      default: AnySpec | { default: AnySpec };
+    };
+    const raw = mod.default;
+    if (raw && typeof raw === "object" && "default" in raw) {
+      return (raw as { default: AnySpec }).default;
+    }
+    if (raw) return raw;
+    nativeError = new Error("module has no default export");
+  } catch (err) {
+    nativeError = err;
+  }
+
+  // Fallback for runtimes without type stripping (Node < 22.6, or stripping off).
   try {
     const { execSync } =
       require("node:child_process") as typeof import("node:child_process");
@@ -426,9 +466,48 @@ async function loadSpec(specPath: string): Promise<AnySpec | null> {
       timeout: 15000,
     });
     return JSON.parse(output.trim()) as AnySpec;
-  } catch {
+  } catch (err) {
+    lastSpecLoadFailure = describeLoadFailure(nativeError, err);
     return null;
   }
+}
+
+/**
+ * Turn the two swallowed errors into one line a reader can act on.
+ *
+ * Three causes need three different fixes, and the old single message named none
+ * of them: a spec that does not parse, a `tsx` that is not installed (so `npx`
+ * goes to the registry), and a timeout.
+ */
+export function describeLoadFailure(
+  nativeError: unknown,
+  tsxError: unknown,
+): string {
+  const tsxMsg =
+    tsxError instanceof Error ? tsxError.message : String(tsxError);
+  const nativeMsg =
+    nativeError instanceof Error ? nativeError.message : String(nativeError);
+
+  // execSync surfaces a timeout as a killed child, not as a message.
+  const killed =
+    typeof tsxError === "object" &&
+    tsxError !== null &&
+    (tsxError as { killed?: boolean; signal?: string }).killed === true;
+  if (killed || /ETIMEDOUT|timed out/i.test(tsxMsg)) {
+    return (
+      "the `npx tsx` fallback timed out after 15s. Install tsx locally " +
+      "(`npm i -D tsx`) so npx does not fetch it over the network, or run on " +
+      "Node >= 22.6 where no subprocess is needed."
+    );
+  }
+  if (/not found|ENOENT|could not determine executable/i.test(tsxMsg)) {
+    return (
+      "neither native import nor `npx tsx` could run this spec. Install tsx " +
+      "locally (`npm i -D tsx`), or upgrade to Node >= 22.6 for native type " +
+      `stripping. Native import said: ${nativeMsg}`
+    );
+  }
+  return `the spec did not load. Native import said: ${nativeMsg}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -673,9 +752,7 @@ async function compile(
     const spec = await loadSpec(specPath);
     if (!spec) {
       console.log(`\n✗ ${specPath} — failed to load`);
-      console.log(
-        `  Ensure the spec is compiled: run \`npm run build\` first.`,
-      );
+      console.log(`  ${specLoadFailureReason() ?? "reason unavailable"}`);
       allValid = false;
       continue;
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,7 @@ import {
   isAbsolute,
   sep as pathSep,
 } from "node:path";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { globSync } from "glob";
 import { generateTypes } from "./core/generate-types.js";
 import {
@@ -373,15 +374,8 @@ type AnySpec = ClaudeSpec | SkillSpec | AgentSpec | Railway;
 /**
  * Why the last `loadSpec()` returned null.
  *
- * Exists because the caller used to print «Ensure the spec is compiled: run
- * `npm run build` first» for EVERY failure, and that advice is wrong for most of
- * them. Measured 2026-08-31 in a consuming repo: all 50 specs failed to load and
- * the true cause was that `tsx` was not installed locally, so the `npx tsx`
- * fallback below went to the network and blew its 15s budget. The message sent
- * the reader to a build step that does not exist in a consumer install.
- *
- * Kept as module state rather than a widened return type on purpose: `loadSpec`
- * has six call sites and only one of them reports to a human.
+ * Kept as module state rather than a widened return type: `loadSpec` has six
+ * call sites and only one of them reports to a human.
  */
 let lastSpecLoadFailure: string | null = null;
 
@@ -390,210 +384,168 @@ export function specLoadFailureReason(): string | null {
   return lastSpecLoadFailure;
 }
 
+/**
+ * How long one spec may take to evaluate before the host is killed.
+ *
+ * Overridable because 15s is a guess that fits the specs we have seen, not a
+ * law; a repo with genuinely slow specs should be able to raise it rather than
+ * discover the number by hitting it.
+ */
+const SPEC_DEADLINE_MS = Number(process.env.VIGILES_SPEC_TIMEOUT_MS) || 15_000;
+
+type HostReply =
+  | { path: string; phase: "start" }
+  | { path: string; ok: true; value: AnySpec }
+  | { path: string; ok: false; error: string };
+
+type Host = {
+  child: ChildProcessWithoutNullStreams;
+  /** Resolves the pending request; only one is outstanding at a time. */
+  pending: ((reply: HostReply) => void) | null;
+  /** Last spec the host said it had STARTED — the culprit when a deadline fires. */
+  started: string | null;
+  buffered: string;
+};
+
+let host: Host | null = null;
+
+/** The compiled host entry, beside this file in `dist/`. */
+function hostEntry(): string {
+  return resolve(__dirname, "spec-host.mjs");
+}
+
+function startHost(): Host {
+  const child = spawn(process.execPath, [hostEntry()], {
+    cwd: process.cwd(),
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  const h: Host = { child, pending: null, started: null, buffered: "" };
+
+  child.stdout.setEncoding("utf-8");
+  child.stdout.on("data", (chunk: string) => {
+    h.buffered += chunk;
+    let nl: number;
+    while ((nl = h.buffered.indexOf("\n")) >= 0) {
+      const line = h.buffered.slice(0, nl).trim();
+      h.buffered = h.buffered.slice(nl + 1);
+      if (!line) continue;
+      let reply: HostReply;
+      try {
+        reply = JSON.parse(line) as HostReply;
+      } catch {
+        continue; // not ours; a spec writing to stdout cannot corrupt the stream
+      }
+      if ("phase" in reply) {
+        h.started = reply.path;
+        continue;
+      }
+      const done = h.pending;
+      h.pending = null;
+      done?.(reply);
+    }
+  });
+
+  // Anything the child says on stderr is the spec's own noise; keep it out of
+  // our stdout so `--json` consumers are not corrupted, but do not lose it.
+  child.stderr.setEncoding("utf-8");
+  child.stderr.on("data", (chunk: string) => process.stderr.write(chunk));
+
+  // 🔴 Unreferenced, or the CLI never exits. A piped child and its three
+  // streams each hold the event loop open, so `compile` finished its work and
+  // then hung forever waiting on a host that had nothing left to say. The
+  // in-flight deadline timer keeps the loop alive while a request is pending,
+  // which is exactly as long as we need it.
+  // The stdio types are Readable/Writable, which do not declare `unref` — the
+  // objects are pipes and do have it. Optional-called so this stays correct if
+  // a platform ever hands back a stream that genuinely lacks it.
+  const unref = (s: unknown) => (s as { unref?: () => void })?.unref?.();
+  child.unref();
+  unref(child.stdin);
+  unref(child.stdout);
+  unref(child.stderr);
+
+  return h;
+}
+
+/** Kill the host and forget it; the next request starts a fresh one. */
+function dropHost(): void {
+  if (!host) return;
+  const dying = host;
+  host = null;
+  dying.pending = null;
+  dying.child.kill("SIGKILL");
+}
+
+process.on("exit", dropHost);
+
+/**
+ * Load one spec in the spec host.
+ *
+ * 🔴 **Why a child process rather than `import()` here.** A module evaluation
+ * cannot be cancelled once started — `Promise.race` hands control back but the
+ * evaluation keeps running and holds the event loop — so an in-process loader
+ * gives a stalled spec an unbounded hang in `compile`, `test` and `audit`. It
+ * also cannot tell whether a failed spec already ran (Node reports
+ * `ERR_MODULE_NOT_FOUND` and `SyntaxError` both before and during evaluation),
+ * which is what made the previous two-loader arrangement unfixable rather than
+ * merely buggy: it had to guess whether re-running was safe.
+ *
+ * The host is spawned with `process.execPath` — never `npx` — so nothing is
+ * fetched and nothing needs installing.
+ */
 async function loadSpec(specPath: string): Promise<AnySpec | null> {
   const fullPath = resolve(process.cwd(), specPath);
   lastSpecLoadFailure = null;
 
-  // Try multiple dist/ path strategies
-  const candidates: string[] = [];
-
-  // src/ → dist/ mapping (e.g., src/CLAUDE.md.spec.ts → dist/CLAUDE.md.spec.js)
-  if (fullPath.includes("/src/")) {
-    candidates.push(
-      fullPath.replace(/\/src\//, "/dist/").replace(/\.ts$/, ".js"),
-    );
+  if (!existsSync(fullPath)) {
+    lastSpecLoadFailure = `no such file: ${specPath}`;
+    return null;
   }
 
-  // Root-level spec → dist/ (e.g., CLAUDE.md.spec.ts → dist/CLAUDE.md.spec.js)
-  const dir = fullPath.substring(0, fullPath.lastIndexOf("/"));
-  const base = fullPath.substring(fullPath.lastIndexOf("/") + 1);
-  candidates.push(resolve(dir, "dist", base.replace(/\.ts$/, ".js")));
+  host ??= startHost();
+  const h = host;
 
-  // examples/ → dist/examples/ mapping
-  candidates.push(
-    fullPath
-      .replace(/\.ts$/, ".js")
-      .replace(process.cwd(), resolve(process.cwd(), "dist")),
-  );
-
-  for (const distPath of candidates) {
-    if (existsSync(distPath)) {
-      try {
-        const mod = (await import(distPath)) as {
-          default: AnySpec | { default: AnySpec };
-        };
-        // CJS double-default: `{ default: { default: spec } }`.
-        const raw = mod.default;
-        if (raw && typeof raw === "object" && "default" in raw) {
-          return (raw as { default: AnySpec }).default;
-        }
-        return raw;
-      } catch {
-        // Try next candidate
-      }
-    }
-  }
-
-  // Load the .ts directly. Node strips types itself where that is ON BY DEFAULT —
-  // 22.18+ on the 22 line, 23.6+ on 23 — so no subprocess and
-  // no network are needed — measured 0.7s against >60s for the `npx tsx` path when
-  // tsx is not installed locally. This is tried FIRST for exactly that reason.
-  let nativeError: unknown;
-  try {
-    const { pathToFileURL } = require("node:url") as typeof import("node:url");
-    const mod = (await import(pathToFileURL(fullPath).href)) as {
-      default: AnySpec | { default: AnySpec };
+  const reply = await new Promise<HostReply | "timeout" | "died">((done) => {
+    let settled = false;
+    const finish = (r: HostReply | "timeout" | "died") => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      done(r);
     };
-    const raw = mod.default;
-    if (raw && typeof raw === "object" && "default" in raw) {
-      return (raw as { default: AnySpec }).default;
-    }
-    if (raw) return raw;
-    // The module DID evaluate; running it again under tsx would repeat its side
-    // effects to learn the same thing.
-    lastSpecLoadFailure = "the spec has no default export.";
-    return null;
-  } catch (err) {
-    nativeError = err;
-    // 🔴 ONLY a capability failure may fall through to the subprocess. `import()`
-    // both LOADS and EVALUATES, so this catch also sees exceptions thrown by the
-    // spec itself — and re-running such a spec under tsx executes it a SECOND
-    // time. A spec (or a helper it imports) that writes a file or makes a request
-    // before throwing would do it twice. Reported in review on #178.
-    if (!nativeFailedBeforeEvaluating(err)) {
-      lastSpecLoadFailure = `the spec did not load. ${
-        err instanceof Error ? err.message : String(err)
-      }`;
-      return null;
-    }
-  }
-
-  // Fallback for runtimes without type stripping: older Node, 22.6-22.17 where it
-  // sits behind --experimental-strip-types, or any runtime with it switched off.
-  try {
-    const { execSync } =
-      require("node:child_process") as typeof import("node:child_process");
-    // Handle ESM/CJS double-default: m.default may itself have a .default
-    const script = `import(${JSON.stringify(fullPath)}).then(m => { const d = m.default?.default ?? m.default; console.log(JSON.stringify(d)); })`;
-    const output = execSync(`npx tsx -e '${script.replace(/'/g, "'\\''")}'`, {
-      encoding: "utf-8",
-      cwd: process.cwd(),
-      stdio: ["pipe", "pipe", "pipe"],
-      timeout: 15000,
+    const timer = setTimeout(() => {
+      finish("timeout");
+    }, SPEC_DEADLINE_MS);
+    h.pending = finish;
+    h.child.once("exit", () => {
+      finish("died");
     });
-    return JSON.parse(output.trim()) as AnySpec;
-  } catch (err) {
-    lastSpecLoadFailure = describeLoadFailure(nativeError, err);
+    h.child.stdin.write(JSON.stringify({ path: fullPath }) + "\n");
+  });
+
+  if (reply === "timeout") {
+    // The host's last `start` names the spec that stalled. Without it a hang
+    // produced N identical failures and no culprit.
+    const culprit = h.started ?? fullPath;
+    dropHost();
+    lastSpecLoadFailure =
+      `evaluating ${relative(process.cwd(), culprit)} exceeded ` +
+      `${SPEC_DEADLINE_MS}ms and was killed. Set VIGILES_SPEC_TIMEOUT_MS to ` +
+      `raise the limit, or look for a top-level await that never settles.`;
     return null;
   }
-}
-
-/**
- * Turn the two swallowed errors into one line a reader can act on.
- *
- * Three causes need three different fixes, and the old single message named none
- * of them: a spec that does not parse, a `tsx` that is not installed (so `npx`
- * goes to the registry), and a timeout.
- */
-/**
- * Did the native `import()` fail BEFORE the module body ran?
- *
- * That is the property that matters, not "was it a capability error". The
- * fallback re-runs the spec in a subprocess, so it is safe exactly when nothing
- * of the spec has executed yet — resolution, parsing and the missing-loader case
- * all fail before evaluation and carry no side effects. An exception thrown by
- * the module body does not, and re-running it would repeat whatever it did
- * first (write a file, send a request).
- *
- * 🔴 `ERR_MODULE_NOT_FOUND` MUST fall through, measured: tsx rewrites a `.js`
- * specifier to the `.ts` source next to it (the TypeScript ESM convention) and
- * native Node does not. This repo's own specs import `src/core/spec.js`, a file
- * that does not exist — native resolution fails, tsx resolves it. Treating that
- * as a spec failure broke 8 tests in src/cli.test.ts.
- */
-function nativeFailedBeforeEvaluating(err: unknown): boolean {
-  const code = (err as { code?: unknown } | null)?.code;
-  if (
-    code === "ERR_UNKNOWN_FILE_EXTENSION" ||
-    code === "ERR_MODULE_NOT_FOUND" ||
-    code === "ERR_PACKAGE_PATH_NOT_EXPORTED" ||
-    code === "ERR_UNSUPPORTED_DIR_IMPORT" ||
-    code === "ERR_INVALID_MODULE_SPECIFIER" ||
-    code === "ERR_UNSUPPORTED_ESM_URL_SCHEME"
-  ) {
-    return true;
+  if (reply === "died") {
+    dropHost();
+    lastSpecLoadFailure = "the spec host exited unexpectedly.";
+    return null;
   }
-  // A parse error also precedes execution. Runtimes without type stripping
-  // report TypeScript syntax this way instead of with a code.
-  if (err instanceof SyntaxError) return true;
-  const msg = err instanceof Error ? err.message : String(err);
-  return /Unknown file extension|Cannot find module|Cannot find package/i.test(
-    msg,
-  );
-}
-
-export function describeLoadFailure(
-  nativeError: unknown,
-  tsxError: unknown,
-): string {
-  const msg = (e: unknown) => (e instanceof Error ? e.message : String(e));
-  const tsxMsg = msg(tsxError);
-  const nativeMsg = msg(nativeError);
-
-  // Without type stripping the native attempt ALWAYS fails
-  // this way. It is expected noise, not a diagnosis, so it must never be the
-  // headline — the repository's own CI runs Node 20, where every load takes the
-  // fallback and this is the only thing the native attempt can say.
-  const nativeUnsupported =
-    /Unknown file extension|ERR_UNKNOWN_FILE_EXTENSION|ERR_UNSUPPORTED_/i.test(
-      nativeMsg,
-    );
-
-  const meta = tsxError as {
-    status?: number | null;
-    killed?: boolean;
-    signal?: string | null;
-    code?: unknown;
-  } | null;
-  const status = meta?.status;
-
-  // Timeout is read from exec METADATA, never from the child's output. execSync
-  // embeds the child's stderr in Error.message, so text-matching here would
-  // rewrite a spec whose own failure mentions «timed out» — a network call it
-  // makes, say — into fallback-timeout plus advice to install tsx, which is
-  // already installed. Same defect as the `not found` match below, reported in
-  // review on #178 and fixed there first; this is the other half of it.
-  const timedOut =
-    meta?.killed === true ||
-    meta?.code === "ETIMEDOUT" ||
-    meta?.signal === "SIGTERM";
-
-  if (timedOut) {
-    return (
-      "the `npx tsx` fallback timed out after 15s. Install tsx locally " +
-      "(`npm i -D tsx`) so npx does not fetch it over the network, or run on " +
-      "Node >= 22.18 (or >= 23.6), where type stripping is on by default and no " +
-      "subprocess is needed. On 22.6-22.17 it needs --experimental-strip-types."
-    );
+  if (!("ok" in reply) || !reply.ok) {
+    lastSpecLoadFailure = `the spec did not load. ${
+      "error" in reply ? reply.error : "no reason given"
+    }`;
+    return null;
   }
-
-  // 127 is the shell's "command not found". Matching the child's stderr text
-  // instead would misread a SPEC that happens to mention "not found" — e.g. a
-  // missing config it requires — as a missing runner.
-  if (status === 127) {
-    return (
-      "neither native import nor `npx tsx` could run this spec: tsx is not " +
-      "installed. Install it locally (`npm i -D tsx`), or upgrade to " +
-      "Node >= 22.18 (or >= 23.6) for native type stripping — 22.6-22.17 have it " +
-      "only behind --experimental-strip-types."
-    );
-  }
-
-  // tsx ran and the spec itself failed: its error is the actionable one.
-  const detail = nativeUnsupported
-    ? tsxMsg
-    : `${nativeMsg} · tsx said: ${tsxMsg}`;
-  return `the spec did not load. ${detail}`;
+  return reply.value;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/spec-hooks.mts
+++ b/src/spec-hooks.mts
@@ -1,0 +1,95 @@
+/**
+ * Module customization hooks for the spec host — vigiles' OWN loader for `.ts`
+ * specs, replacing "whichever loader happens to be installed".
+ *
+ * Why vigiles owns this rather than shelling to `tsx`:
+ *
+ *   - **No install, no network.** `typescript` is already a runtime dependency
+ *     of this package (`dependencies`, and `core/compile-generator.ts` uses it),
+ *     so `ts.transpileModule` costs nothing extra. The bug that started this
+ *     work was a consuming repo without `tsx`, where `npx tsx` went to the
+ *     registry and every one of 50 specs blew a 15s budget.
+ *   - **One resolution contract.** Before this, a spec's module resolution
+ *     depended on the user's Node version and on which loader won — so a spec
+ *     could load locally and fail in CI under different rules. A tool that
+ *     audits other tools for that kind of quiet divergence should not have it.
+ *
+ * Scope is deliberately small and documented as such: `.ts`/`.mts` sources, the
+ * `./x.js` → `./x.ts` specifier rewrite, and bare specifiers. NOT tsconfig
+ * `paths`, JSX, or decorator configuration — specs are configuration modules,
+ * not applications.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+type ResolveContext = { parentURL?: string; conditions: string[] };
+type Resolved = { url: string; format?: string | null; shortCircuit?: boolean };
+type NextResolve = (
+  specifier: string,
+  context: ResolveContext,
+) => Resolved | Promise<Resolved>;
+
+type LoadContext = { format?: string | null; conditions: string[] };
+type Loaded = {
+  format: string;
+  source?: string | ArrayBuffer;
+  shortCircuit?: boolean;
+};
+type NextLoad = (url: string, context: LoadContext) => Loaded | Promise<Loaded>;
+
+const TS_SOURCE = /\.m?ts$/;
+
+/**
+ * `./x.js` → `./x.ts` when the sibling exists.
+ *
+ * This is the TypeScript ESM convention (`tsc` under `nodenext` requires the
+ * `.js` extension in the source), which `tsx` implements and native Node does
+ * not. It is the ONE divergence that matters in practice: this repository's own
+ * dogfood specs import `src/core/spec.js`, a file that does not exist on disk.
+ * Attempted only AFTER normal resolution fails, so it can never shadow a real
+ * `.js` file.
+ */
+export async function resolve(
+  specifier: string,
+  context: ResolveContext,
+  nextResolve: NextResolve,
+): Promise<Resolved> {
+  try {
+    return await nextResolve(specifier, context);
+  } catch (err) {
+    if (specifier.endsWith(".js") && context.parentURL) {
+      const candidate = new URL(
+        specifier.slice(0, -3) + ".ts",
+        context.parentURL,
+      );
+      if (existsSync(fileURLToPath(candidate))) {
+        return { url: candidate.href, format: "module", shortCircuit: true };
+      }
+    }
+    throw err;
+  }
+}
+
+/** Transpile `.ts`/`.mts` with the TypeScript this package already ships. */
+export async function load(
+  url: string,
+  context: LoadContext,
+  nextLoad: NextLoad,
+): Promise<Loaded> {
+  if (!TS_SOURCE.test(new URL(url).pathname)) return nextLoad(url, context);
+
+  const fileName = fileURLToPath(url);
+  const { outputText } = ts.transpileModule(readFileSync(fileName, "utf-8"), {
+    fileName,
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2022,
+      // Erasing types is the whole job; anything that changes SEMANTICS is not
+      // ours to decide for a spec.
+      verbatimModuleSyntax: false,
+      isolatedModules: true,
+    },
+  });
+  return { format: "module", source: outputText, shortCircuit: true };
+}

--- a/src/spec-host.mts
+++ b/src/spec-host.mts
@@ -1,0 +1,84 @@
+/**
+ * The spec host — a child process that loads specs and streams results as NDJSON.
+ *
+ * ONE host per CLI command, not one per spec: Node startup and the TypeScript
+ * load are paid once, then each spec costs a transpile.
+ *
+ * 🔴 **Why a child process at all, when `import()` works in-process.** Because a
+ * module evaluation cannot be cancelled once started. `Promise.race` returns
+ * control to the caller but the evaluation keeps running and holds the event
+ * loop, so a spec that stalls at top level hangs `compile`, `test` and `audit`
+ * with no bound. A child can be killed. That is the entire argument, and it is
+ * why the in-process loader this replaced could not be repaired: it also had to
+ * answer "did the module body already run?" to know whether re-running was
+ * safe, and Node does not expose that bit — `ERR_MODULE_NOT_FOUND` and
+ * `SyntaxError` each occur both before and during evaluation.
+ *
+ * Protocol, one JSON object per line each way:
+ *   in   {"path":"<abs path to spec>"}
+ *   out  {"path":"…","phase":"start"}          — emitted BEFORE evaluation
+ *   out  {"path":"…","ok":true,"value":{…}}
+ *   out  {"path":"…","ok":false,"error":"…"}
+ *
+ * The `start` line is what makes a hang diagnosable: when the parent's deadline
+ * fires, the last `start` without a result NAMES the spec that stalled. Before
+ * this, a stalled load produced N identical failures and no culprit.
+ *
+ * Values cross as JSON, which is not a new constraint — the previous `npx tsx`
+ * path already did `JSON.stringify` in the child and `JSON.parse` in the parent,
+ * so every spec that has ever loaded survived this round trip. Spec types carry
+ * no functions; TypeScript is the authoring layer, the value is data.
+ */
+import { register } from "node:module";
+import { pathToFileURL } from "node:url";
+
+register(new URL("./spec-hooks.mjs", import.meta.url));
+
+function say(line: unknown): void {
+  process.stdout.write(JSON.stringify(line) + "\n");
+}
+
+async function loadOne(path: string): Promise<void> {
+  say({ path, phase: "start" });
+  try {
+    const mod = (await import(pathToFileURL(path).href)) as {
+      default?: unknown;
+    };
+    // CJS interop can nest the default one level deeper.
+    const raw = mod.default as { default?: unknown } | undefined;
+    const value =
+      raw && typeof raw === "object" && "default" in raw ? raw.default : raw;
+    if (value === undefined) {
+      say({ path, ok: false, error: "the spec has no default export." });
+      return;
+    }
+    say({ path, ok: true, value });
+  } catch (err) {
+    say({
+      path,
+      ok: false,
+      error: err instanceof Error ? (err.stack ?? err.message) : String(err),
+    });
+  }
+}
+
+// Requests are serialised: a spec may depend on module state a previous one set
+// up, and interleaving would make a hang impossible to attribute.
+let queue: Promise<void> = Promise.resolve();
+let buffered = "";
+
+process.stdin.setEncoding("utf-8");
+process.stdin.on("data", (chunk: string) => {
+  buffered += chunk;
+  let nl: number;
+  while ((nl = buffered.indexOf("\n")) >= 0) {
+    const line = buffered.slice(0, nl).trim();
+    buffered = buffered.slice(nl + 1);
+    if (!line) continue;
+    const { path } = JSON.parse(line) as { path: string };
+    queue = queue.then(() => loadOne(path));
+  }
+});
+process.stdin.on("end", () => {
+  queue.then(() => process.exit(0));
+});

--- a/src/spec-loader.test.ts
+++ b/src/spec-loader.test.ts
@@ -46,20 +46,31 @@ const CLI = resolve(ROOT, "dist", "cli.js");
 let dir: string;
 
 /**
- * Can THIS runtime import a .ts file directly?
+ * Can the runtime the CLI ACTUALLY RUNS IN import a .ts file directly?
  *
- * Probed, not inferred from `process.version`: native type stripping depends on
- * the major/minor AND on flags (`--no-strip-types` turns it off on a runtime
- * that otherwise supports it), so a version comparison would be wrong in both
- * directions. The repository's own CI runs Node 20, where the answer is no —
- * see .github/workflows/ci.yml (`node-version: "20"`).
+ * 🔴 Probed in a CHILD `node` process, not with `import()` here. The first
+ * version of this probe called `import()` inside the test and was WRONG in a way
+ * CI caught: vitest intercepts dynamic import and hands it to Vite, which
+ * transpiles TypeScript regardless of the Node version. So the probe answered
+ * "can Vite load .ts" — always yes — instead of "can Node". On the Node 20 CI
+ * runner the gated test therefore did not skip, ran, and failed.
+ *
+ * The child process is also the RIGHT scope: the assertions below spawn
+ * `node dist/cli.js`, so the capability that matters is that child's, not this
+ * test process's.
+ *
+ * Probed rather than compared against `process.version` because stripping also
+ * depends on flags (`--no-strip-types` turns it off where it is otherwise on).
  */
-async function nativeTypeStripping(): Promise<boolean> {
+function nativeTypeStripping(): boolean {
   const probeDir = mkdtempSync(join(tmpdir(), "vigiles-strip-probe-"));
   const probe = join(probeDir, "probe.ts");
   writeFileSync(probe, "export default 1 as number;\n");
   try {
-    await import(probe);
+    execSync(
+      `node --input-type=module -e ${JSON.stringify(`import(${JSON.stringify(probe)})`)}`,
+      { stdio: ["pipe", "pipe", "pipe"], timeout: 20_000 },
+    );
     return true;
   } catch {
     return false;
@@ -122,13 +133,13 @@ afterAll(() => {
 });
 
 describe("loadSpec", () => {
-  it("compiles a spec with npm and npx REMOVED FROM PATH", async (ctx) => {
+  it("compiles a spec with npm and npx REMOVED FROM PATH", (ctx) => {
     // P1 from review on #178, and it was right: without this gate the assertion
     // below breaks CI deterministically. On a runtime with no type stripping the
     // native path cannot work, the stubs make the fallback unusable on purpose,
     // and «failed to load» is then the CORRECT outcome — the test would be
     // asserting a capability the runtime does not have.
-    if (!(await nativeTypeStripping())) {
+    if (!nativeTypeStripping()) {
       ctx.skip();
       return;
     }
@@ -166,12 +177,12 @@ describe("loadSpec", () => {
     assert.doesNotMatch(out, /failed to load/, `no spec should fail:\n${out}`);
   });
 
-  it("evaluates a throwing spec EXACTLY ONCE, not once per loader", async (ctx) => {
+  it("evaluates a throwing spec EXACTLY ONCE, not once per loader", (ctx) => {
     // Reported in review on #178. `import()` both loads and evaluates, so a spec
     // that throws AFTER a side effect used to fall through to the tsx fallback
     // and run again — writing the file, making the request, or sending the event
     // a second time. Only a capability failure may reach the subprocess now.
-    if (!(await nativeTypeStripping())) {
+    if (!nativeTypeStripping()) {
       ctx.skip();
       return;
     }

--- a/src/spec-loader.test.ts
+++ b/src/spec-loader.test.ts
@@ -14,7 +14,8 @@
  *
  * After installing tsx locally: `npx tsx` 0.712s, compile 0 ✓ / 39 ✗ → 48 ✓ / 2 ✗.
  *
- * The fix tries a NATIVE `import()` first (Node >= 22.6 strips types itself), so
+ * The fix tries a NATIVE `import()` first (Node strips types itself from 22.18 on
+ * the 22 line and 23.6 on 23; 22.6-22.17 need --experimental-strip-types), so
  * the subprocess and the network are not on the happy path at all. The first test
  * below is the one that matters: it removes npm/npx from PATH entirely and
  * asserts compile still works. If someone reverts to tsx-first, that test fails.
@@ -231,7 +232,7 @@ describe("describeLoadFailure", () => {
   });
 
   it("keeps the tsx error when native loading is merely unsupported", () => {
-    // P2 from the same review: on Node < 22.6 the native attempt can only ever
+    // P2 from the same review: without type stripping the native attempt can only ever
     // say «Unknown file extension», so leading with it discards the one message
     // that came from actually running the spec. The repo's CI is Node 20, so
     // this is the COMMON path there, not an edge case.

--- a/src/spec-loader.test.ts
+++ b/src/spec-loader.test.ts
@@ -38,6 +38,29 @@ const CLI = resolve(ROOT, "dist", "cli.js");
 
 let dir: string;
 
+/**
+ * Can THIS runtime import a .ts file directly?
+ *
+ * Probed, not inferred from `process.version`: native type stripping depends on
+ * the major/minor AND on flags (`--no-strip-types` turns it off on a runtime
+ * that otherwise supports it), so a version comparison would be wrong in both
+ * directions. The repository's own CI runs Node 20, where the answer is no —
+ * see .github/workflows/ci.yml (`node-version: "20"`).
+ */
+async function nativeTypeStripping(): Promise<boolean> {
+  const probeDir = mkdtempSync(join(tmpdir(), "vigiles-strip-probe-"));
+  const probe = join(probeDir, "probe.ts");
+  writeFileSync(probe, "export default 1 as number;\n");
+  try {
+    await import(probe);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    rmSync(probeDir, { recursive: true, force: true });
+  }
+}
+
 /** A minimal, valid skill spec that imports the package's own entrypoint. */
 function writeSpec(at: string, name: string): void {
   mkdirSync(dirname(at), { recursive: true });
@@ -92,7 +115,16 @@ afterAll(() => {
 });
 
 describe("loadSpec", () => {
-  it("compiles a spec with npm and npx REMOVED FROM PATH", () => {
+  it("compiles a spec with npm and npx REMOVED FROM PATH", async (ctx) => {
+    // P1 from review on #178, and it was right: without this gate the assertion
+    // below breaks CI deterministically. On a runtime with no type stripping the
+    // native path cannot work, the stubs make the fallback unusable on purpose,
+    // and «failed to load» is then the CORRECT outcome — the test would be
+    // asserting a capability the runtime does not have.
+    if (!(await nativeTypeStripping())) {
+      ctx.skip();
+      return;
+    }
     // This is the load-bearing assertion. Before the fix the loader could only
     // read a .ts spec by shelling out to `npx tsx`; with npx unreachable every
     // spec failed. Native type stripping needs no subprocess, so this passes.
@@ -171,26 +203,62 @@ describe("describeLoadFailure", () => {
     assert.match(msg, /npm i -D tsx/, "must name the actual remedy");
   });
 
-  it("names the install when tsx cannot be found at all", () => {
+  it("reads exit status 127 — not stderr text — as a missing tsx", () => {
+    const notFound = Object.assign(new Error("Command failed: npx tsx"), {
+      status: 127,
+    });
     const msg = describeLoadFailure(
-      new Error("Unknown file extension"),
-      new Error("npx: command not found"),
+      new Error('Unknown file extension ".ts"'),
+      notFound,
     );
-    assert.match(msg, /Install tsx locally/);
-    assert.match(
+    assert.match(msg, /tsx is not\s+installed/);
+  });
+
+  it("does NOT read a spec's own 'not found' as a missing tsx", () => {
+    // P2 from review on #178: matching the child's stderr misdiagnoses a spec
+    // that fails for its own reasons — e.g. a config it requires is absent —
+    // as a missing runner, and then advises installing something already there.
+    const specFailed = Object.assign(
+      new Error("Command failed: Error: config not found: ./missing.json"),
+      { status: 1 },
+    );
+    const msg = describeLoadFailure(
+      new Error('Unknown file extension ".ts"'),
+      specFailed,
+    );
+    assert.doesNotMatch(msg, /tsx is not installed/);
+    assert.match(msg, /config not found/, "the spec's own error must survive");
+  });
+
+  it("keeps the tsx error when native loading is merely unsupported", () => {
+    // P2 from the same review: on Node < 22.6 the native attempt can only ever
+    // say «Unknown file extension», so leading with it discards the one message
+    // that came from actually running the spec. The repo's CI is Node 20, so
+    // this is the COMMON path there, not an edge case.
+    const msg = describeLoadFailure(
+      new Error('Unknown file extension ".ts" for /tmp/x/SKILL.md.spec.ts'),
+      Object.assign(new Error("SyntaxError: Unexpected token '('"), {
+        status: 1,
+      }),
+    );
+    assert.match(msg, /Unexpected token/, "the actionable error must be shown");
+    assert.doesNotMatch(
       msg,
       /Unknown file extension/,
-      "must carry the native error too",
+      "the expected native-loader noise must not be the headline",
     );
   });
 
-  it("blames the spec when both loaders report a parse error", () => {
+  it("shows BOTH when the native error is informative", () => {
     const msg = describeLoadFailure(
       new SyntaxError("Unexpected token '('"),
-      new Error("exited with 1"),
+      Object.assign(new Error("exited with 1"), { status: 1 }),
     );
-    assert.match(msg, /spec did not load/);
     assert.match(msg, /Unexpected token/);
-    assert.doesNotMatch(msg, /tsx/, "a broken spec is not a tsx problem");
+    assert.match(
+      msg,
+      /tsx said/,
+      "both sides matter when neither is boilerplate",
+    );
   });
 });

--- a/src/spec-loader.test.ts
+++ b/src/spec-loader.test.ts
@@ -36,7 +36,7 @@ import {
 } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { tmpdir } from "node:os";
-import { execSync } from "node:child_process";
+import { execSync, spawnSync } from "node:child_process";
 
 // NB: `__dirname`, not `import.meta` — this package builds to CommonJS and tsc
 // rejects import.meta here (TS1470). The idiom is legal in scripts/ next door,
@@ -50,22 +50,17 @@ function run(
   cwd: string,
   env: NodeJS.ProcessEnv = process.env,
 ): { out: string; code: number } {
-  try {
-    const out = execSync(`node ${JSON.stringify(CLI)} compile`, {
-      cwd,
-      encoding: "utf-8",
-      env,
-      stdio: ["pipe", "pipe", "pipe"],
-      timeout: 120_000,
-    });
-    return { out, code: 0 };
-  } catch (e) {
-    const err = e as { stdout?: string; stderr?: string; status?: number };
-    return {
-      out: (err.stdout ?? "") + (err.stderr ?? ""),
-      code: err.status ?? 1,
-    };
-  }
+  // 🔴 spawnSync, not execSync: on SUCCESS execSync returns stdout only, so a
+  // warning printed to stderr is invisible to assertions. That silently made
+  // the listener-leak test below pass under a mutation that reinstated the leak
+  // — a green mutation is a finding about the TEST, not proof of the fix.
+  const r = spawnSync("node", [CLI, "compile"], {
+    cwd,
+    encoding: "utf-8",
+    env,
+    timeout: 120_000,
+  });
+  return { out: (r.stdout ?? "") + (r.stderr ?? ""), code: r.status ?? 1 };
 }
 
 /** Write a spec at `<dir>/.claude/skills/<name>/SKILL.md.spec.ts`. */
@@ -224,6 +219,28 @@ describe("spec host", () => {
     const { out } = run(dir);
     assert.match(out, /no default export/, `got:\n${out}`);
     rmSync(at, { recursive: true, force: true });
+  });
+
+  it("leaks no listeners across many specs in one run", () => {
+    // Found by dogfooding, not by a fixture: the host gets ONE exit listener per
+    // request, and `once` stays registered until it fires, so they accumulated
+    // for the life of the host. `vigiles lint` on this repo printed
+    //   MaxListenersExceededWarning: 11 exit listeners added to [ChildProcess]
+    // Twelve specs crosses Node's default threshold of ten; a fixture with two
+    // or three never would, which is exactly why no existing test caught it.
+    const made: string[] = [];
+    for (let i = 0; i < 12; i++) {
+      made.push(skill(`many${i}`, validSpec(`many${i}`)));
+    }
+
+    const { out } = run(dir);
+    assert.doesNotMatch(
+      out,
+      /MaxListenersExceededWarning/,
+      `listeners must be released as each request settles:\n${out}`,
+    );
+    assert.doesNotMatch(out, /failed to load/, `all 12 must load:\n${out}`);
+    for (const at of made) rmSync(at, { recursive: true, force: true });
   });
 
   it("never advises `npm run build` when a spec fails to load", () => {

--- a/src/spec-loader.test.ts
+++ b/src/spec-loader.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Regression tests for `loadSpec` — the spec loader that compile/test/audit all
+ * go through.
+ *
+ * THE MEASURED FAILURE (2026-08-31, in a consuming repo). `npx vigiles compile`
+ * printed `✗ … failed to load` for ALL 50 specs and advised «run `npm run build`
+ * first». Both halves were wrong:
+ *
+ *   - the CAUSE was that `tsx` was not installed locally, so the fallback's
+ *     `npx tsx` went to the npm registry; measured `npx tsx -e 'console.log(1)'`
+ *     took >60s against the loader's 15s budget, so every spec timed out;
+ *   - the ADVICE named a build step that does not exist in a consumer install,
+ *     and `catch { return null }` had already erased the real reason.
+ *
+ * After installing tsx locally: `npx tsx` 0.712s, compile 0 ✓ / 39 ✗ → 48 ✓ / 2 ✗.
+ *
+ * The fix tries a NATIVE `import()` first (Node >= 22.6 strips types itself), so
+ * the subprocess and the network are not on the happy path at all. The first test
+ * below is the one that matters: it removes npm/npx from PATH entirely and
+ * asserts compile still works. If someone reverts to tsx-first, that test fails.
+ *
+ * Deterministic, model-free, offline → free unit tier.
+ */
+import { describe, it, beforeAll, afterAll } from "vitest";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { execSync } from "node:child_process";
+
+import { describeLoadFailure } from "./cli.js";
+
+// NB: `__dirname`, not `import.meta` — this package builds to CommonJS and tsc
+// rejects import.meta here (TS1470). The idiom is legal in scripts/ next door,
+// which is outside the tsc project; copying it into src/ does not compile.
+const ROOT = resolve(__dirname, "..");
+const CLI = resolve(ROOT, "dist", "cli.js");
+
+let dir: string;
+
+/** A minimal, valid skill spec that imports the package's own entrypoint. */
+function writeSpec(at: string, name: string): void {
+  mkdirSync(dirname(at), { recursive: true });
+  writeFileSync(
+    at,
+    `import { experimental_skill } from "vigiles/spec";\n` +
+      `export default experimental_skill({\n` +
+      `  name: ${JSON.stringify(name)},\n` +
+      `  description: "A fixture skill. Use when testing the spec loader.",\n` +
+      `  body: "# ${name}\\n\\nFixture body.\\n",\n` +
+      `});\n`,
+  );
+}
+
+function run(
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+): { out: string; code: number } {
+  try {
+    const out = execSync(`node ${JSON.stringify(CLI)} compile`, {
+      cwd,
+      encoding: "utf-8",
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 120_000,
+    });
+    return { out, code: 0 };
+  } catch (e) {
+    const err = e as { stdout?: string; stderr?: string; status?: number };
+    return {
+      out: (err.stdout ?? "") + (err.stderr ?? ""),
+      code: err.status ?? 1,
+    };
+  }
+}
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), "vigiles-spec-loader-"));
+  // The fixture repo resolves `vigiles/spec` through a link back to this checkout.
+  mkdirSync(join(dir, "node_modules"), { recursive: true });
+  execSync(
+    `ln -s ${JSON.stringify(ROOT)} ${JSON.stringify(join(dir, "node_modules", "vigiles"))}`,
+  );
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify({ name: "fixture", type: "module", private: true }, null, 2),
+  );
+});
+
+afterAll(() => {
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("loadSpec", () => {
+  it("compiles a spec with npm and npx REMOVED FROM PATH", () => {
+    // This is the load-bearing assertion. Before the fix the loader could only
+    // read a .ts spec by shelling out to `npx tsx`; with npx unreachable every
+    // spec failed. Native type stripping needs no subprocess, so this passes.
+    writeSpec(
+      join(dir, ".claude", "skills", "alpha", "SKILL.md.spec.ts"),
+      "alpha",
+    );
+
+    // Shadow npm/npx with stubs that always fail, PREPENDED to PATH. Deleting
+    // PATH entries instead would also remove `node` (they share a directory),
+    // so the test would pass for the wrong reason — «node: not found».
+    const shadow = join(dir, "no-npx");
+    mkdirSync(shadow, { recursive: true });
+    for (const bin of ["npx", "npm"]) {
+      const f = join(shadow, bin);
+      writeFileSync(
+        f,
+        `#!/bin/sh\necho "${bin} is unavailable in this test" >&2\nexit 127\n`,
+      );
+      execSync(`chmod +x ${JSON.stringify(f)}`);
+    }
+
+    const { out } = run(dir, {
+      ...process.env,
+      PATH: `${shadow}:${process.env.PATH ?? ""}`,
+    });
+    assert.match(
+      out,
+      /✓ .*alpha\/SKILL\.md\.spec\.ts/,
+      `compile must succeed without npx on PATH, got:\n${out}`,
+    );
+    assert.doesNotMatch(out, /failed to load/, `no spec should fail:\n${out}`);
+  });
+
+  it("never advises `npm run build` when a spec fails to load", () => {
+    // The old message said exactly this for every failure, including the ones it
+    // could not possibly fix. A build step does not exist in a consumer install.
+    writeSpec(
+      join(dir, ".claude", "skills", "broken", "SKILL.md.spec.ts"),
+      "broken",
+    );
+    writeFileSync(
+      join(dir, ".claude", "skills", "broken", "SKILL.md.spec.ts"),
+      `import { experimental_skill } from "vigiles/spec";\nthis is not valid typescript(((\n`,
+    );
+
+    const { out } = run(dir, process.env);
+    assert.match(
+      out,
+      /failed to load/,
+      `the broken spec must be reported:\n${out}`,
+    );
+    assert.doesNotMatch(
+      out,
+      /npm run build/,
+      `the retired misleading advice must not come back:\n${out}`,
+    );
+    assert.match(
+      out,
+      /spec did not load|tsx|Node >= 22\.6/,
+      `the message must name an actionable cause:\n${out}`,
+    );
+
+    rmSync(join(dir, ".claude", "skills", "broken"), {
+      recursive: true,
+      force: true,
+    });
+  });
+});
+
+describe("describeLoadFailure", () => {
+  it("names the timeout, and the fix, when the tsx fallback is killed", () => {
+    const killed = Object.assign(new Error("Command failed"), { killed: true });
+    const msg = describeLoadFailure(new Error("unsupported"), killed);
+    assert.match(msg, /timed out after 15s/);
+    assert.match(msg, /npm i -D tsx/, "must name the actual remedy");
+  });
+
+  it("names the install when tsx cannot be found at all", () => {
+    const msg = describeLoadFailure(
+      new Error("Unknown file extension"),
+      new Error("npx: command not found"),
+    );
+    assert.match(msg, /Install tsx locally/);
+    assert.match(
+      msg,
+      /Unknown file extension/,
+      "must carry the native error too",
+    );
+  });
+
+  it("blames the spec when both loaders report a parse error", () => {
+    const msg = describeLoadFailure(
+      new SyntaxError("Unexpected token '('"),
+      new Error("exited with 1"),
+    );
+    assert.match(msg, /spec did not load/);
+    assert.match(msg, /Unexpected token/);
+    assert.doesNotMatch(msg, /tsx/, "a broken spec is not a tsx problem");
+  });
+});

--- a/src/spec-loader.test.ts
+++ b/src/spec-loader.test.ts
@@ -1,24 +1,27 @@
 /**
- * Regression tests for `loadSpec` — the spec loader that compile/test/audit all
- * go through.
+ * The spec host, end to end — driving the REAL built CLI the way a user does.
  *
- * THE MEASURED FAILURE (2026-08-31, in a consuming repo). `npx vigiles compile`
- * printed `✗ … failed to load` for ALL 50 specs and advised «run `npm run build`
- * first». Both halves were wrong:
+ * WHAT THIS REPLACED, and why the shape of these tests changed. `loadSpec` used
+ * to try a native `import()` and fall back to `execSync("npx tsx …")`. Two
+ * defects made that arrangement unfixable rather than merely buggy:
  *
- *   - the CAUSE was that `tsx` was not installed locally, so the fallback's
- *     `npx tsx` went to the npm registry; measured `npx tsx -e 'console.log(1)'`
- *     took >60s against the loader's 15s budget, so every spec timed out;
- *   - the ADVICE named a build step that does not exist in a consumer install,
- *     and `catch { return null }` had already erased the real reason.
+ *   1. a spec that threw was evaluated TWICE — once natively, once by the
+ *      fallback — so any side effect before the throw happened twice. Guarding
+ *      it requires answering "did the module body run?", and Node does not
+ *      expose that: `ERR_MODULE_NOT_FOUND` and `SyntaxError` both occur before
+ *      AND during evaluation;
+ *   2. the native path had NO time bound. An in-flight module evaluation cannot
+ *      be cancelled — `Promise.race` returns control but the evaluation keeps
+ *      running — so a stalled spec hung `compile`, `test` and `audit` forever.
  *
- * After installing tsx locally: `npx tsx` 0.712s, compile 0 ✓ / 39 ✗ → 48 ✓ / 2 ✗.
+ * One host process fixes both by construction: one loader means nothing to
+ * re-run, and a child can be killed. The tests below assert exactly those two
+ * properties, plus the resolution contract vigiles now owns.
  *
- * The fix tries a NATIVE `import()` first (Node strips types itself from 22.18 on
- * the 22 line and 23.6 on 23; 22.6-22.17 need --experimental-strip-types), so
- * the subprocess and the network are not on the happy path at all. The first test
- * below is the one that matters: it removes npm/npx from PATH entirely and
- * asserts compile still works. If someone reverts to tsx-first, that test fails.
+ * The measured bug that started all of it: a consuming repo without `tsx`, where
+ * `npx tsx` went to the registry — `npx tsx -e 'console.log(1)'` took >60s
+ * against a 15s budget, so all 50 specs failed at once with advice to run
+ * `npm run build`, a step that does not exist in a consumer install.
  *
  * Deterministic, model-free, offline → free unit tier.
  */
@@ -35,8 +38,6 @@ import { join, resolve, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
 
-import { describeLoadFailure } from "./cli.js";
-
 // NB: `__dirname`, not `import.meta` — this package builds to CommonJS and tsc
 // rejects import.meta here (TS1470). The idiom is legal in scripts/ next door,
 // which is outside the tsc project; copying it into src/ does not compile.
@@ -45,57 +46,9 @@ const CLI = resolve(ROOT, "dist", "cli.js");
 
 let dir: string;
 
-/**
- * Can the runtime the CLI ACTUALLY RUNS IN import a .ts file directly?
- *
- * 🔴 Probed in a CHILD `node` process, not with `import()` here. The first
- * version of this probe called `import()` inside the test and was WRONG in a way
- * CI caught: vitest intercepts dynamic import and hands it to Vite, which
- * transpiles TypeScript regardless of the Node version. So the probe answered
- * "can Vite load .ts" — always yes — instead of "can Node". On the Node 20 CI
- * runner the gated test therefore did not skip, ran, and failed.
- *
- * The child process is also the RIGHT scope: the assertions below spawn
- * `node dist/cli.js`, so the capability that matters is that child's, not this
- * test process's.
- *
- * Probed rather than compared against `process.version` because stripping also
- * depends on flags (`--no-strip-types` turns it off where it is otherwise on).
- */
-function nativeTypeStripping(): boolean {
-  const probeDir = mkdtempSync(join(tmpdir(), "vigiles-strip-probe-"));
-  const probe = join(probeDir, "probe.ts");
-  writeFileSync(probe, "export default 1 as number;\n");
-  try {
-    execSync(
-      `node --input-type=module -e ${JSON.stringify(`import(${JSON.stringify(probe)})`)}`,
-      { stdio: ["pipe", "pipe", "pipe"], timeout: 20_000 },
-    );
-    return true;
-  } catch {
-    return false;
-  } finally {
-    rmSync(probeDir, { recursive: true, force: true });
-  }
-}
-
-/** A minimal, valid skill spec that imports the package's own entrypoint. */
-function writeSpec(at: string, name: string): void {
-  mkdirSync(dirname(at), { recursive: true });
-  writeFileSync(
-    at,
-    `import { experimental_skill } from "vigiles/spec";\n` +
-      `export default experimental_skill({\n` +
-      `  name: ${JSON.stringify(name)},\n` +
-      `  description: "A fixture skill. Use when testing the spec loader.",\n` +
-      `  body: "# ${name}\\n\\nFixture body.\\n",\n` +
-      `});\n`,
-  );
-}
-
 function run(
   cwd: string,
-  env: NodeJS.ProcessEnv,
+  env: NodeJS.ProcessEnv = process.env,
 ): { out: string; code: number } {
   try {
     const out = execSync(`node ${JSON.stringify(CLI)} compile`, {
@@ -115,9 +68,28 @@ function run(
   }
 }
 
+/** Write a spec at `<dir>/.claude/skills/<name>/SKILL.md.spec.ts`. */
+function skill(name: string, body: string): string {
+  const at = join(dir, ".claude", "skills", name, "SKILL.md.spec.ts");
+  mkdirSync(dirname(at), { recursive: true });
+  writeFileSync(at, body);
+  return dirname(at);
+}
+
+function validSpec(name: string, extra = ""): string {
+  return (
+    `import { experimental_skill } from "vigiles/spec";\n` +
+    extra +
+    `export default experimental_skill({\n` +
+    `  name: ${JSON.stringify(name)},\n` +
+    `  description: "A fixture skill. Use when testing the spec loader.",\n` +
+    `  body: "# ${name}\\n\\nFixture body.\\n",\n` +
+    `});\n`
+  );
+}
+
 beforeAll(() => {
-  dir = mkdtempSync(join(tmpdir(), "vigiles-spec-loader-"));
-  // The fixture repo resolves `vigiles/spec` through a link back to this checkout.
+  dir = mkdtempSync(join(tmpdir(), "vigiles-spec-host-"));
   mkdirSync(join(dir, "node_modules"), { recursive: true });
   execSync(
     `ln -s ${JSON.stringify(ROOT)} ${JSON.stringify(join(dir, "node_modules", "vigiles"))}`,
@@ -132,28 +104,18 @@ afterAll(() => {
   if (dir) rmSync(dir, { recursive: true, force: true });
 });
 
-describe("loadSpec", () => {
-  it("compiles a spec with npm and npx REMOVED FROM PATH", (ctx) => {
-    // P1 from review on #178, and it was right: without this gate the assertion
-    // below breaks CI deterministically. On a runtime with no type stripping the
-    // native path cannot work, the stubs make the fallback unusable on purpose,
-    // and «failed to load» is then the CORRECT outcome — the test would be
-    // asserting a capability the runtime does not have.
-    if (!nativeTypeStripping()) {
-      ctx.skip();
-      return;
-    }
-    // This is the load-bearing assertion. Before the fix the loader could only
-    // read a .ts spec by shelling out to `npx tsx`; with npx unreachable every
-    // spec failed. Native type stripping needs no subprocess, so this passes.
-    writeSpec(
-      join(dir, ".claude", "skills", "alpha", "SKILL.md.spec.ts"),
-      "alpha",
-    );
+describe("spec host", () => {
+  it("compiles a spec with npm and npx REMOVED FROM PATH, on any Node", () => {
+    // The load-bearing assertion. The original bug was `npx tsx` reaching for
+    // the network; the host spawns `process.execPath` and transpiles with the
+    // TypeScript already in `dependencies`, so nothing is fetched.
+    //
+    // Note what is NOT here any more: a Node-version gate. The previous design
+    // needed native type stripping (22.18+), so this test had to skip on the
+    // Node 20 that this repo's own CI runs. vigiles now owns the transpile, so
+    // the assertion holds on every supported runtime.
+    const at = skill("alpha", validSpec("alpha"));
 
-    // Shadow npm/npx with stubs that always fail, PREPENDED to PATH. Deleting
-    // PATH entries instead would also remove `node` (they share a directory),
-    // so the test would pass for the wrong reason — «node: not found».
     const shadow = join(dir, "no-npx");
     mkdirSync(shadow, { recursive: true });
     for (const bin of ["npx", "npm"]) {
@@ -175,34 +137,42 @@ describe("loadSpec", () => {
       `compile must succeed without npx on PATH, got:\n${out}`,
     );
     assert.doesNotMatch(out, /failed to load/, `no spec should fail:\n${out}`);
+    rmSync(at, { recursive: true, force: true });
   });
 
-  it("evaluates a throwing spec EXACTLY ONCE, not once per loader", (ctx) => {
-    // Reported in review on #178. `import()` both loads and evaluates, so a spec
-    // that throws AFTER a side effect used to fall through to the tsx fallback
-    // and run again — writing the file, making the request, or sending the event
-    // a second time. Only a capability failure may reach the subprocess now.
-    if (!nativeTypeStripping()) {
-      ctx.skip();
-      return;
-    }
-    const marks = join(dir, "side-effects.log");
-    const skill = join(
-      dir,
-      ".claude",
-      "skills",
-      "sideeffect",
-      "SKILL.md.spec.ts",
+  it("resolves a `./x.js` import to the `.ts` beside it", () => {
+    // The one resolution rule vigiles deliberately owns: `tsc` under nodenext
+    // requires the `.js` extension in source, so a spec that imports a local
+    // helper writes `./helper.js` while only `./helper.ts` exists. Native Node
+    // does not do this rewrite; tsx does. Now it is OUR documented contract
+    // instead of a property of whichever loader happened to be installed.
+    const at = skill(
+      "sibling",
+      validSpec("sibling", `import "./helper.js";\n`),
     );
-    mkdirSync(dirname(skill), { recursive: true });
-    writeFileSync(
-      skill,
+    writeFileSync(join(at, "helper.ts"), "export const unused: number = 1;\n");
+
+    const { out } = run(dir);
+    assert.match(
+      out,
+      /✓ .*sibling\/SKILL\.md\.spec\.ts/,
+      `the .js -> .ts rewrite must resolve:\n${out}`,
+    );
+    rmSync(at, { recursive: true, force: true });
+  });
+
+  it("evaluates a throwing spec EXACTLY ONCE", () => {
+    // With one loader there is nothing to re-run. Under the old two-loader
+    // arrangement this reported «ran 2 time(s)».
+    const marks = join(dir, "side-effects.log");
+    const at = skill(
+      "sideeffect",
       `import { appendFileSync } from "node:fs";\n` +
         `appendFileSync(${JSON.stringify(marks)}, "ran\\n");\n` +
         `throw new Error("spec blew up after its side effect");\n`,
     );
 
-    const { out } = run(dir, process.env);
+    const { out } = run(dir);
     const ran = readFileSync(marks, "utf-8").trim().split("\n").length;
     assert.equal(ran, 1, `the spec must run once, ran ${ran} time(s):\n${out}`);
     assert.match(
@@ -210,24 +180,58 @@ describe("loadSpec", () => {
       /spec blew up after its side effect/,
       `and its own error must be reported:\n${out}`,
     );
-
-    rmSync(dirname(skill), { recursive: true, force: true });
+    rmSync(at, { recursive: true, force: true });
     rmSync(marks, { force: true });
   });
 
-  it("never advises `npm run build` when a spec fails to load", () => {
-    // The old message said exactly this for every failure, including the ones it
-    // could not possibly fix. A build step does not exist in a consumer install.
-    writeSpec(
-      join(dir, ".claude", "skills", "broken", "SKILL.md.spec.ts"),
-      "broken",
-    );
-    writeFileSync(
-      join(dir, ".claude", "skills", "broken", "SKILL.md.spec.ts"),
-      `import { experimental_skill } from "vigiles/spec";\nthis is not valid typescript(((\n`,
+  it("KILLS a spec that stalls, and names it", () => {
+    // This test could not exist before. The native path had no bound, and an
+    // in-flight evaluation cannot be cancelled, so a spec like this one hung
+    // compile forever. The host is killable, and its `start` line tells the
+    // parent WHICH spec stalled — previously a hang gave N identical failures
+    // and no culprit.
+    const at = skill(
+      "stalls",
+      `await new Promise(() => {}); // never settles\n` + validSpec("stalls"),
     );
 
-    const { out } = run(dir, process.env);
+    const started = Date.now();
+    const { out } = run(dir, {
+      ...process.env,
+      VIGILES_SPEC_TIMEOUT_MS: "3000",
+    });
+    const elapsed = Date.now() - started;
+
+    assert.ok(
+      elapsed < 60_000,
+      `compile must not hang; took ${elapsed}ms:\n${out}`,
+    );
+    assert.match(
+      out,
+      /exceeded 3000ms/,
+      `the deadline must be reported:\n${out}`,
+    );
+    assert.match(
+      out,
+      /stalls\/SKILL\.md\.spec\.ts/,
+      `the STALLED spec must be named, not just 'a spec':\n${out}`,
+    );
+    rmSync(at, { recursive: true, force: true });
+  });
+
+  it("reports a spec with no default export, without re-running it", () => {
+    const at = skill("nodefault", `export const notDefault = 1;\n`);
+    const { out } = run(dir);
+    assert.match(out, /no default export/, `got:\n${out}`);
+    rmSync(at, { recursive: true, force: true });
+  });
+
+  it("never advises `npm run build` when a spec fails to load", () => {
+    // The retired message: it named a build step that does not exist in a
+    // consumer install, and it was printed for EVERY failure because the real
+    // reason had been erased by a bare `catch`.
+    const at = skill("broken", `this is not valid typescript(((\n`);
+    const { out } = run(dir);
     assert.match(
       out,
       /failed to load/,
@@ -238,114 +242,6 @@ describe("loadSpec", () => {
       /npm run build/,
       `the retired misleading advice must not come back:\n${out}`,
     );
-    assert.match(
-      out,
-      /spec did not load|tsx|Node >= 22\.6/,
-      `the message must name an actionable cause:\n${out}`,
-    );
-
-    rmSync(join(dir, ".claude", "skills", "broken"), {
-      recursive: true,
-      force: true,
-    });
-  });
-});
-
-describe("describeLoadFailure", () => {
-  it("names the timeout, and the fix, when the tsx fallback is killed", () => {
-    const killed = Object.assign(new Error("Command failed"), { killed: true });
-    const msg = describeLoadFailure(new Error("unsupported"), killed);
-    assert.match(msg, /timed out after 15s/);
-    assert.match(msg, /npm i -D tsx/, "must name the actual remedy");
-  });
-
-  it("does NOT read a spec's own 'timed out' as the fallback timing out", () => {
-    // The other half of the stderr-matching defect (review on #178). execSync
-    // embeds the child's stderr in Error.message, so a spec whose own network
-    // call times out used to be reported as «the npx tsx fallback timed out»
-    // plus advice to install tsx — which is already installed and ran it.
-    const specTimedOut = Object.assign(
-      new Error("Command failed: Error: request to api.example timed out"),
-      { status: 1, killed: false, signal: null },
-    );
-    const msg = describeLoadFailure(
-      new Error('Unknown file extension ".ts"'),
-      specTimedOut,
-    );
-    assert.doesNotMatch(msg, /fallback timed out/);
-    assert.match(
-      msg,
-      /request to api\.example timed out/,
-      "the spec's error must survive",
-    );
-  });
-
-  it("reads a real subprocess timeout from exec metadata", () => {
-    const killed = Object.assign(new Error("Command failed"), {
-      killed: true,
-      signal: "SIGTERM",
-      status: null,
-    });
-    const msg = describeLoadFailure(new Error("unsupported"), killed);
-    assert.match(msg, /timed out after 15s/);
-  });
-
-  it("reads exit status 127 — not stderr text — as a missing tsx", () => {
-    const notFound = Object.assign(new Error("Command failed: npx tsx"), {
-      status: 127,
-    });
-    const msg = describeLoadFailure(
-      new Error('Unknown file extension ".ts"'),
-      notFound,
-    );
-    assert.match(msg, /tsx is not\s+installed/);
-  });
-
-  it("does NOT read a spec's own 'not found' as a missing tsx", () => {
-    // P2 from review on #178: matching the child's stderr misdiagnoses a spec
-    // that fails for its own reasons — e.g. a config it requires is absent —
-    // as a missing runner, and then advises installing something already there.
-    const specFailed = Object.assign(
-      new Error("Command failed: Error: config not found: ./missing.json"),
-      { status: 1 },
-    );
-    const msg = describeLoadFailure(
-      new Error('Unknown file extension ".ts"'),
-      specFailed,
-    );
-    assert.doesNotMatch(msg, /tsx is not installed/);
-    assert.match(msg, /config not found/, "the spec's own error must survive");
-  });
-
-  it("keeps the tsx error when native loading is merely unsupported", () => {
-    // P2 from the same review: without type stripping the native attempt can only ever
-    // say «Unknown file extension», so leading with it discards the one message
-    // that came from actually running the spec. The repo's CI is Node 20, so
-    // this is the COMMON path there, not an edge case.
-    const msg = describeLoadFailure(
-      new Error('Unknown file extension ".ts" for /tmp/x/SKILL.md.spec.ts'),
-      Object.assign(new Error("SyntaxError: Unexpected token '('"), {
-        status: 1,
-      }),
-    );
-    assert.match(msg, /Unexpected token/, "the actionable error must be shown");
-    assert.doesNotMatch(
-      msg,
-      /Unknown file extension/,
-      "the expected native-loader noise must not be the headline",
-    );
-  });
-
-  it("shows BOTH when the native error is informative", () => {
-    const msg = describeLoadFailure(
-      new SyntaxError("Unexpected token '('"),
-      Object.assign(new Error("exited with 1"), { status: 1 }),
-    );
-    assert.match(msg, /Unexpected token/);
-    assert.match(
-      msg,
-      /tsx said/,
-      "both sides matter when neither is boilerplate",
-    );
+    rmSync(at, { recursive: true, force: true });
   });
 });

--- a/src/spec-loader.test.ts
+++ b/src/spec-loader.test.ts
@@ -248,6 +248,37 @@ describe("describeLoadFailure", () => {
     assert.match(msg, /npm i -D tsx/, "must name the actual remedy");
   });
 
+  it("does NOT read a spec's own 'timed out' as the fallback timing out", () => {
+    // The other half of the stderr-matching defect (review on #178). execSync
+    // embeds the child's stderr in Error.message, so a spec whose own network
+    // call times out used to be reported as «the npx tsx fallback timed out»
+    // plus advice to install tsx — which is already installed and ran it.
+    const specTimedOut = Object.assign(
+      new Error("Command failed: Error: request to api.example timed out"),
+      { status: 1, killed: false, signal: null },
+    );
+    const msg = describeLoadFailure(
+      new Error('Unknown file extension ".ts"'),
+      specTimedOut,
+    );
+    assert.doesNotMatch(msg, /fallback timed out/);
+    assert.match(
+      msg,
+      /request to api\.example timed out/,
+      "the spec's error must survive",
+    );
+  });
+
+  it("reads a real subprocess timeout from exec metadata", () => {
+    const killed = Object.assign(new Error("Command failed"), {
+      killed: true,
+      signal: "SIGTERM",
+      status: null,
+    });
+    const msg = describeLoadFailure(new Error("unsupported"), killed);
+    assert.match(msg, /timed out after 15s/);
+  });
+
   it("reads exit status 127 — not stderr text — as a missing tsx", () => {
     const notFound = Object.assign(new Error("Command failed: npx tsx"), {
       status: 127,

--- a/src/spec-loader.test.ts
+++ b/src/spec-loader.test.ts
@@ -24,7 +24,13 @@
  */
 import { describe, it, beforeAll, afterAll } from "vitest";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
@@ -158,6 +164,44 @@ describe("loadSpec", () => {
       `compile must succeed without npx on PATH, got:\n${out}`,
     );
     assert.doesNotMatch(out, /failed to load/, `no spec should fail:\n${out}`);
+  });
+
+  it("evaluates a throwing spec EXACTLY ONCE, not once per loader", async (ctx) => {
+    // Reported in review on #178. `import()` both loads and evaluates, so a spec
+    // that throws AFTER a side effect used to fall through to the tsx fallback
+    // and run again — writing the file, making the request, or sending the event
+    // a second time. Only a capability failure may reach the subprocess now.
+    if (!(await nativeTypeStripping())) {
+      ctx.skip();
+      return;
+    }
+    const marks = join(dir, "side-effects.log");
+    const skill = join(
+      dir,
+      ".claude",
+      "skills",
+      "sideeffect",
+      "SKILL.md.spec.ts",
+    );
+    mkdirSync(dirname(skill), { recursive: true });
+    writeFileSync(
+      skill,
+      `import { appendFileSync } from "node:fs";\n` +
+        `appendFileSync(${JSON.stringify(marks)}, "ran\\n");\n` +
+        `throw new Error("spec blew up after its side effect");\n`,
+    );
+
+    const { out } = run(dir, process.env);
+    const ran = readFileSync(marks, "utf-8").trim().split("\n").length;
+    assert.equal(ran, 1, `the spec must run once, ran ${ran} time(s):\n${out}`);
+    assert.match(
+      out,
+      /spec blew up after its side effect/,
+      `and its own error must be reported:\n${out}`,
+    );
+
+    rmSync(dirname(skill), { recursive: true, force: true });
+    rmSync(marks, { force: true });
   });
 
   it("never advises `npm run build` when a spec fails to load", () => {

--- a/src/spec-loader.test.ts
+++ b/src/spec-loader.test.ts
@@ -49,12 +49,13 @@ let dir: string;
 function run(
   cwd: string,
   env: NodeJS.ProcessEnv = process.env,
+  cmd = "compile",
 ): { out: string; code: number } {
   // 🔴 spawnSync, not execSync: on SUCCESS execSync returns stdout only, so a
   // warning printed to stderr is invisible to assertions. That silently made
   // the listener-leak test below pass under a mutation that reinstated the leak
   // — a green mutation is a finding about the TEST, not proof of the fix.
-  const r = spawnSync("node", [CLI, "compile"], {
+  const r = spawnSync("node", [CLI, cmd], {
     cwd,
     encoding: "utf-8",
     env,
@@ -221,25 +222,69 @@ describe("spec host", () => {
     rmSync(at, { recursive: true, force: true });
   });
 
-  it("leaks no listeners across many specs in one run", () => {
-    // Found by dogfooding, not by a fixture: the host gets ONE exit listener per
-    // request, and `once` stays registered until it fires, so they accumulated
-    // for the life of the host. `vigiles lint` on this repo printed
-    //   MaxListenersExceededWarning: 11 exit listeners added to [ChildProcess]
-    // Twelve specs crosses Node's default threshold of ten; a fixture with two
-    // or three never would, which is exactly why no existing test caught it.
+  it("pairs CONCURRENT loads by path, and leaks no listeners", () => {
+    // 🔴 Two defects, one cause, and the second is the serious one.
+    //
+    // `--trace-warnings` on `vigiles lint` showed checkCoverageThresholds
+    // calling loadSpec through Array.map — CONCURRENTLY. The client held a
+    // single `pending` slot, so each new caller overwrote the previous one and
+    // a reply settled whichever request happened to be last: loadSpec could
+    // return ANOTHER spec's value for the path it was asked about. Silent
+    // mispairing, in a loader three commands depend on.
+    //
+    // The MaxListeners warning was only the visible symptom of the same
+    // per-request wiring. Node warns at ten, so a fixture loading specs ONE AT
+    // A TIME can never see either problem — which is exactly why the first six
+    // tests here did not.
+    //
+    // `compile` iterates serially; `lint` is the concurrent path. This asserts
+    // on both: lint for the concurrency, compile for the pairing.
     const made: string[] = [];
     for (let i = 0; i < 12; i++) {
       made.push(skill(`many${i}`, validSpec(`many${i}`)));
     }
 
+    // Compile first so every SKILL.md exists and matches its spec…
     const { out } = run(dir);
-    assert.doesNotMatch(
-      out,
-      /MaxListenersExceededWarning/,
-      `listeners must be released as each request settles:\n${out}`,
-    );
     assert.doesNotMatch(out, /failed to load/, `all 12 must load:\n${out}`);
+
+    // …then lint, which loads them CONCURRENTLY and verifies each compiled file
+    // against the spec it came from. That hash check is what makes mispairing
+    // observable end to end: hand a path another spec's value and the file no
+    // longer matches. `compile` alone cannot show this — it loads serially, so
+    // "the last pending request" and "the right one" are the same thing there.
+    const lint = run(dir, process.env, "lint");
+    assert.doesNotMatch(
+      lint.out,
+      /MaxListenersExceededWarning/,
+      `concurrent loads must not add a listener each:\n${lint.out}`,
+    );
+    // ⚠️ What this pairing check does and does NOT establish. It asserts the
+    // name loaded from each spec is reported beside the path it came from, and
+    // it passes on the serial `compile` path. It does NOT fail when dispatch is
+    // mutated to last-wins: measured, both this fixture and a real `vigiles
+    // lint` on the vigiles repo produce byte-identical output either way,
+    // because the one concurrent caller aggregates and never asks which spec it
+    // got. Keying by path is correct by construction; this is the honest limit
+    // of the coverage, recorded rather than papered over.
+    for (let i = 0; i < 12; i++) {
+      assert.match(
+        lint.out,
+        new RegExp(`"many${i}" \\(\\.claude/skills/many${i}/SKILL\\.md\\)`),
+        `many${i}'s name must be reported against its OWN path:\n${lint.out}`,
+      );
+    }
+    assert.doesNotMatch(out, /failed to load/, `all 12 must load:\n${out}`);
+    // Each compiled file must carry ITS OWN body. A mispaired reply shows up
+    // here as one skill's markdown written under another's name.
+    for (let i = 0; i < 12; i++) {
+      const md = readFileSync(join(made[i], "SKILL.md"), "utf-8");
+      assert.match(
+        md,
+        new RegExp(`many${i}\\b`),
+        `many${i}/SKILL.md must contain its own spec, not another's:\n${md}`,
+      );
+    }
     for (const at of made) rmSync(at, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
## What and why

`loadSpec` used to try a native `import()` of the `.ts` and fall back to `execSync("npx tsx …")` with a 15s budget, swallowing every failure in `catch { return null }` and printing one message for all of them: *«Ensure the spec is compiled: run `npm run build` first»*.

**The measured bug.** A consuming repo did not have `tsx` installed, so `npx tsx` went to the npm registry — `npx tsx -e 'console.log(1)'` took **>60s** against the 15s budget, so **all 50 specs failed at once**, advised to run a build step that does not exist in a consumer install. After `npm i -D tsx`: 0.712s per spec, compile 0 ✓ / 39 ✗ → 48 ✓ / 2 ✗.

**Why this ended up a redesign rather than a patch.** Review here established that the seam between two loaders cannot be made correct: the fallthrough guard has to answer *"did the module body already run?"*, and Node does not expose that bit — `ERR_MODULE_NOT_FOUND` and `SyntaxError` each occur **both before and during** evaluation. Separately, the native path had no time bound, and an in-flight evaluation **cannot be cancelled** (`Promise.race` returns control while the evaluation keeps running), so a stalled spec hung `compile`/`test`/`audit` forever. A seam that cannot be made correct gets deleted, not guarded.

### The design

One loader: a **spec host** child process, one per CLI command, that registers vigiles' own module hooks and streams NDJSON.

Three facts made it cheap, none of which were in my original analysis:

1. **`typescript` is already a runtime dependency** (`dependencies`, not dev) and already used at runtime by `core/compile-generator.ts`. `ts.transpileModule` costs nothing extra — the whole "should we depend on `tsx`" question was moot.
2. **Specs are already data.** The old `tsx` path did `JSON.stringify` in the child and `JSON.parse` in the parent, so every spec that ever loaded survived that round trip; the spec types carry no functions. TypeScript is the authoring layer; the value is data. That boundary is now a documented contract instead of an accident.
3. **The `.js` → `.ts` divergence is ours to define.** Only this repo's dogfood specs and `cli.test.ts` fixtures rely on it; the one real consumer imports the bare specifier. It is now a `resolve` hook we own and can point at.

### What it fixes, at once

| | |
|---|---|
| the original bug | no `npx`, no network, nothing to install |
| **the hang** | `child.kill()` is real cancellation, and the host's `start` line **names** the spec that stalled — previously N identical failures and no culprit |
| double evaluation | one loader, nothing to re-run; the guard is deleted rather than tuned |
| **determinism** | resolution no longer depends on the user's Node version or on which loader won. A tool that audits others for quiet divergence should not ship one. |
| Windows | the `npx -e '…'` invocation is gone — single quotes are not quoting in `cmd.exe`, so the fallback was broken there independently of everything else |
| speed | ~250ms once + ~10ms/spec, against ~0.7s **per spec** with `tsx` installed and unbounded without |

**Deleted:** the native import path, the `npx tsx` fallback, `nativeFailedBeforeEvaluating`, `describeLoadFailure`'s two-error gymnastics, and the three-way `dist/` candidate guessing.

Deadline is `VIGILES_SPEC_TIMEOUT_MS` (default 15s) — a number a repo with genuinely slow specs can raise, rather than discover by hitting it.

## Safety impact

**This restores a property the intermediate revisions of this PR had removed, and states the new boundary explicitly.**

- **Isolation is back, and stronger than before the PR.** Spec evaluation happens in a child process that is killable. The intermediate native-first design ran specs in the CLI's own process, where a spec could reach the CLI's globals and lifecycle and could not be time-bounded; that is gone.
- **Single evaluation is now structural, not heuristic.** With one loader there is no "should I re-run this?" question, so a spec cannot side-effect twice by construction rather than by a predicate Node cannot support.
- **Unchanged:** nothing about hooks, compiled guards, `interceptTools`, the sandbox, or `sandboxAvailable()`. ⚠️ Note the asymmetry deliberately **not** unified here: `loadHook` must stay in-process because hooks export *functions* (`decide`) and are not JSON-serializable. This design does not and cannot cover them.
- **New, and worth naming:** vigiles now owns spec module resolution. Scope is deliberately small — `.ts`/`.mts` sources, the `./x.js` → `./x.ts` rewrite, bare specifiers. NOT tsconfig `paths`, JSX, or decorator configuration. `transpileModule` in fact accepts *more* than native type stripping (which refuses enums and namespaces), so this is not a narrowing for existing specs.

## Checks

- [x] `npm test` passes locally, or CI is green
- [x] New behaviour has a test
- [x] Docs updated if this changes a rule, a CLI surface, or a documented guarantee — the loader contract is documented in `src/spec-hooks.mts` and `src/spec-host.mts` module comments; no user-facing CLI surface changed

**Tests** — `src/spec-loader.test.ts`, 6 end-to-end assertions driving the real built CLI:

- compiles with **`npm` and `npx` shadowed by failing stubs on `PATH`**, on any Node — note what is gone: the Node-version gate. The previous design needed native stripping (22.18+), so the test had to skip on the Node 20 this repo's own CI runs.
- the `./x.js` → `./x.ts` rewrite resolves
- **a spec that stalls is killed and named** — this test could not exist before
- a throwing spec is evaluated exactly once
- a spec with no default export is reported without re-running
- the retired `npm run build` advice never returns

**Mutations:** remove the `.js`→`.ts` hook → the resolution test fails on its own assertion. Remove the deadline → the suite hangs until killed, which is the defect itself.

**Gates:** `npm run check` **18/18**; unit suite **3282 passed**. The 4 remaining failures are `src/core/spec.test.ts`, environmental — `pylint` and `rubocop` are not installed in my container; CI installs them.

⚠️ One defect worth recording because no test caught it: the host must be **`unref`'d**. Without it the CLI finished its work and then hung forever — a piped child and its three streams each hold the event loop open. Found by running the CLI by hand.

## Earlier review findings, all closed

Six findings were fixed before this redesign and their tests survive it where still applicable: the CI-breaking test gate, `not found` matched against child stderr → exit status 127, `timed out` matched the same way → exec metadata, the discarded `tsx` error, wrong Node-version advice (22.6 vs 22.18/23.6), and double evaluation. The three that remained open — `ERR_MODULE_NOT_FOUND` ambiguity, `SyntaxError` ambiguity, and the missing time bound — are the ones this redesign removes rather than guards.

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Features**
- load specs in a vigiles-owned spec host, not a two-loader guess

**Fixes**
- load specs natively, and say why loading actually failed
- regenerate .vigiles/generated.d.ts for the new test file
- address review — gate the native test, and stop misreading tsx errors
- do not re-run a spec that already started executing
- read the subprocess timeout from exec metadata, not spec output
- probe the CHILD runtime for type stripping, not vitest's loader
- release the host's exit listener when a request settles
- pair host replies BY PATH — a single slot mispairs concurrent loads

**Docs**
- name the Node releases where type stripping is actually on
<!-- vigiles:pr-summary:end -->

