### PR TITLE
feat(skills): add an optional Atlas provider to the logo skill

### DIFF
--- a/.claude/skills/generate-logo/SKILL.md
+++ b/.claude/skills/generate-logo/SKILL.md
@@ -1,15 +1,26 @@
 ---
 name: generate-logo
-description: Generate or iterate on the vigiles logo using ImageRouter API
+description: Generate or iterate on the vigiles logo using ImageRouter or the optional Atlas Cloud provider
 ---
 
 # Generate Logo
 
-Generate logo variations for vigiles using the ImageRouter API (imagerouter.io).
+Generate logo variations for vigiles. ImageRouter remains the default provider;
+Atlas Cloud is an explicit opt-in alternative for contributors who already use
+it.
 
 ## Setup
 
-Get an API key from https://imagerouter.io/api-keys. Pass it as an argument or set `IMAGEROUTER_API_KEY` env var. Do NOT commit the key.
+Set the key for the selected provider in the environment. Do NOT pass keys as
+arguments or commit them.
+
+| Provider    | Environment variable  | Use when                                       |
+| ----------- | --------------------- | ---------------------------------------------- |
+| ImageRouter | `IMAGEROUTER_API_KEY` | Default workflow below                         |
+| Atlas Cloud | `ATLASCLOUD_API_KEY`  | The contributor explicitly selects Atlas Cloud |
+
+Before a paid request, run the provider's dry run, review the current model
+price, and confirm that the prompt contains no confidential information.
 
 ## API
 
@@ -56,6 +67,31 @@ Known good models:
 
 Download the image from the URL in `data[0].url`.
 
+## Optional Atlas Cloud provider
+
+The bundled helper validates the selected model against Atlas Cloud's live
+public catalog and schema before submitting anything. It sends the potentially
+billable generation `POST` exactly once, never retries an ambiguous submission,
+and only uses bounded retries for prediction `GET` requests.
+
+```bash
+node .claude/skills/generate-logo/scripts/generate-atlas-logo.mjs \
+  --prompt "YOUR PROMPT HERE" \
+  --aspect-ratio 1:1 \
+  --resolution 1k \
+  --output logo-atlas \
+  --dry-run
+```
+
+Remove `--dry-run` only after reviewing the payload and current price. The
+default model is `google/nano-banana-2/text-to-image-developer`, which matches
+the existing Nano Banana 2 workflow. It was available at $0.04 per image in the
+live Atlas Cloud catalog on 2026-08-31; availability and pricing can change.
+
+The helper detects PNG, JPEG, or WebP bytes and appends the matching extension
+to the output path. Convert the chosen variation to `logo.png` only after visual
+review.
+
 ## Current logo
 
 The current logo (`logo.png`) is v6: overlapping translucent flame petals on dark background, amber-orange palette. Generated with `google/nano-banana-2`.
@@ -97,7 +133,10 @@ curl 'https://api.imagerouter.io/v1/openai/images/generations' \
 
 ## Workflow
 
-1. Generate variations with different prompts
-2. Save as `logo-v*.png` (gitignored)
-3. Pick the best, copy to `logo.png`
-4. Commit `logo.png` only
+1. Select ImageRouter, or explicitly opt in to Atlas Cloud
+2. Dry-run and review the provider payload and current price
+3. Generate variations with different prompts
+4. Save as `logo-v*` using the actual image extension (gitignored)
+5. Inspect the image dimensions, format, and visual result
+6. Pick the best, convert/copy it to `logo.png`
+7. Commit `logo.png` only

--- a/.claude/skills/generate-logo/scripts/generate-atlas-logo.mjs
+++ b/.claude/skills/generate-logo/scripts/generate-atlas-logo.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, extname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const CATALOG_URL = "https://api.atlascloud.ai/api/v1/models";
+export const DEFAULT_API_BASE = "https://api.atlascloud.ai/api/v1";
+export const DEFAULT_MODEL = "google/nano-banana-2/text-to-image-developer";
+
+const SUCCESS = new Set(["completed", "succeeded", "success"]);
+const FAILURE = new Set(["failed", "canceled", "cancelled"]);
+const EXTENSIONS = { PNG: ".png", JPEG: ".jpg", WebP: ".webp" };
+
+const delay = (milliseconds) =>
+  new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
+
+function assertResponse(response, url) {
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} from ${url}`);
+  }
+  return response;
+}
+
+export async function getJson(
+  url,
+  { headers = {}, attempts = 3, fetchImpl = fetch, sleep = delay } = {},
+) {
+  let lastError;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      const response = await fetchImpl(url, { method: "GET", headers });
+      return await assertResponse(response, url).json();
+    } catch (error) {
+      lastError = error;
+      if (attempt + 1 < attempts) {
+        await sleep(500 * 2 ** attempt);
+      }
+    }
+  }
+  throw new Error(`GET failed after ${attempts} attempts: ${url}`, {
+    cause: lastError,
+  });
+}
+
+export async function validateLiveModel(
+  modelId,
+  requestedFields,
+  { fetchImpl = fetch, sleep = delay } = {},
+) {
+  const catalog = await getJson(CATALOG_URL, { fetchImpl, sleep });
+  const model = (catalog.data ?? []).find((item) => item.model === modelId);
+  if (!model)
+    throw new Error(`Model is missing from the live catalog: ${modelId}`);
+  if (model.display_console !== true)
+    throw new Error(`Model is not public: ${modelId}`);
+  if (model.type !== "Image")
+    throw new Error(`Model is not an image model: ${modelId}`);
+  if (!model.schema) throw new Error(`Model has no live schema: ${modelId}`);
+
+  const schema = await getJson(model.schema, { fetchImpl, sleep });
+  const properties =
+    schema.components?.schemas?.Input?.properties ?? Object.create(null);
+  const missing = [...requestedFields].filter(
+    (field) => !(field in properties),
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `Live model schema does not support: ${missing.join(", ")}`,
+    );
+  }
+  return model;
+}
+
+function firstOutputUrl(data) {
+  const outputs = data.outputs ?? data.output ?? [];
+  if (typeof outputs === "string") return outputs;
+  const first = Array.isArray(outputs) ? outputs[0] : undefined;
+  if (typeof first === "string") return first;
+  if (first && typeof first === "object") {
+    if (typeof first.url === "string") return first.url;
+    if (typeof first.image_url === "string") return first.image_url;
+  }
+  throw new Error("Atlas prediction completed without an output URL");
+}
+
+export function detectImage(bytes) {
+  if (bytes.subarray(0, 8).equals(Buffer.from("89504e470d0a1a0a", "hex"))) {
+    return "PNG";
+  }
+  if (bytes.subarray(0, 3).equals(Buffer.from("ffd8ff", "hex"))) return "JPEG";
+  if (
+    bytes.length >= 12 &&
+    bytes.subarray(0, 4).toString("ascii") === "RIFF" &&
+    bytes.subarray(8, 12).toString("ascii") === "WEBP"
+  ) {
+    return "WebP";
+  }
+  throw new Error("Downloaded output is not a PNG, JPEG, or WebP image");
+}
+
+function outputPathFor(requestedPath, imageType) {
+  const expected = EXTENSIONS[imageType];
+  const current = extname(requestedPath).toLowerCase();
+  if ([".png", ".jpg", ".jpeg", ".webp"].includes(current)) {
+    return requestedPath.slice(0, -current.length) + expected;
+  }
+  return requestedPath + expected;
+}
+
+export async function generateAtlasLogo({
+  apiKey,
+  payload,
+  output,
+  apiBase = DEFAULT_API_BASE,
+  pollIntervalMs = 5_000,
+  timeoutMs = 600_000,
+  fetchImpl = fetch,
+  sleep = delay,
+}) {
+  await validateLiveModel(payload.model, new Set(Object.keys(payload)), {
+    fetchImpl,
+    sleep,
+  });
+
+  const authorization = { Authorization: `Bearer ${apiKey}` };
+  const submitUrl = `${apiBase.replace(/\/$/, "")}/model/generateImage`;
+
+  // This request may be billable and is intentionally never retried.
+  const submissionResponse = await fetchImpl(submitUrl, {
+    method: "POST",
+    headers: { ...authorization, "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  const submission = await assertResponse(submissionResponse, submitUrl).json();
+  if (![undefined, null, 200, "200"].includes(submission.code)) {
+    throw new Error(
+      submission.msg ?? submission.message ?? "Atlas submission failed",
+    );
+  }
+  const predictionId = submission.data?.id;
+  if (!predictionId) throw new Error("Atlas submission did not return data.id");
+
+  const predictionUrl = `${apiBase.replace(/\/$/, "")}/model/prediction/${encodeURIComponent(predictionId)}`;
+  const deadline = Date.now() + timeoutMs;
+  let imageUrl;
+  while (Date.now() < deadline) {
+    const prediction = await getJson(predictionUrl, {
+      headers: authorization,
+      fetchImpl,
+      sleep,
+    });
+    const data = prediction.data ?? {};
+    const status = String(data.status ?? "").toLowerCase();
+    if (SUCCESS.has(status)) {
+      imageUrl = firstOutputUrl(data);
+      break;
+    }
+    if (FAILURE.has(status)) {
+      throw new Error(
+        `Atlas generation failed: ${data.error ?? data.message ?? status}`,
+      );
+    }
+    await sleep(pollIntervalMs);
+  }
+  if (!imageUrl)
+    throw new Error(`Timed out waiting for prediction ${predictionId}`);
+
+  const imageResponse = await fetchImpl(imageUrl, { method: "GET" });
+  const imageBytes = Buffer.from(
+    await assertResponse(imageResponse, imageUrl).arrayBuffer(),
+  );
+  const imageType = detectImage(imageBytes);
+  const finalPath = resolve(outputPathFor(output, imageType));
+  await mkdir(dirname(finalPath), { recursive: true });
+  await writeFile(finalPath, imageBytes);
+  return { output: finalPath, imageType, model: payload.model };
+}
+
+function parseArgs(argv) {
+  const options = {
+    model: DEFAULT_MODEL,
+    output: "logo-atlas",
+    pollIntervalMs: 5_000,
+    timeoutMs: 600_000,
+    dryRun: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    const value = argv[index + 1];
+    if (!value) throw new Error(`Missing value for ${argument}`);
+    index += 1;
+    if (argument === "--prompt") options.prompt = value;
+    else if (argument === "--model") options.model = value;
+    else if (argument === "--aspect-ratio") options.aspectRatio = value;
+    else if (argument === "--resolution") options.resolution = value;
+    else if (argument === "--seed") options.seed = Number.parseInt(value, 10);
+    else if (argument === "--output") options.output = value;
+    else if (argument === "--poll-interval") {
+      options.pollIntervalMs = Number(value) * 1_000;
+    } else if (argument === "--timeout") {
+      options.timeoutMs = Number(value) * 1_000;
+    } else throw new Error(`Unknown argument: ${argument}`);
+  }
+  if (!options.prompt) throw new Error("--prompt is required");
+  return options;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const payload = { model: options.model, prompt: options.prompt };
+  if (options.aspectRatio) payload.aspect_ratio = options.aspectRatio;
+  if (options.resolution) payload.resolution = options.resolution;
+  if (Number.isInteger(options.seed)) payload.seed = options.seed;
+
+  if (options.dryRun) {
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  const apiKey = process.env.ATLASCLOUD_API_KEY?.trim();
+  if (!apiKey)
+    throw new Error("ATLASCLOUD_API_KEY is required unless --dry-run is used");
+  const result = await generateAtlasLogo({
+    apiKey,
+    payload,
+    output: options.output,
+    apiBase: process.env.ATLASCLOUD_API_BASE_URL ?? DEFAULT_API_BASE,
+    pollIntervalMs: options.pollIntervalMs,
+    timeoutMs: options.timeoutMs,
+  });
+  console.log(`${result.output} (${result.imageType}, ${result.model})`);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/.claude/skills/generate-logo/scripts/generate-atlas-logo.test.mjs
+++ b/.claude/skills/generate-logo/scripts/generate-atlas-logo.test.mjs
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import {
+  DEFAULT_MODEL,
+  detectImage,
+  generateAtlasLogo,
+} from "./generate-atlas-logo.mjs";
+
+function jsonResponse(payload) {
+  return {
+    ok: true,
+    status: 200,
+    async json() {
+      return payload;
+    },
+  };
+}
+
+test("submits one paid request, polls with auth, and writes detected image", async () => {
+  const calls = [];
+  const png = Buffer.from("89504e470d0a1a0a00000000", "hex");
+  const fetchImpl = async (url, options = {}) => {
+    calls.push({ url, options });
+    if (url.endsWith("/models")) {
+      return jsonResponse({
+        data: [
+          {
+            model: DEFAULT_MODEL,
+            display_console: true,
+            type: "Image",
+            schema: "https://example.test/schema.json",
+          },
+        ],
+      });
+    }
+    if (url.endsWith("/schema.json")) {
+      return jsonResponse({
+        components: {
+          schemas: {
+            Input: {
+              properties: { model: {}, prompt: {}, aspect_ratio: {} },
+            },
+          },
+        },
+      });
+    }
+    if (options.method === "POST") {
+      return jsonResponse({ code: 200, data: { id: "prediction-test" } });
+    }
+    if (url.includes("/model/prediction/")) {
+      return jsonResponse({
+        code: 200,
+        data: {
+          status: "completed",
+          outputs: ["https://example.test/logo"],
+        },
+      });
+    }
+    return {
+      ok: true,
+      status: 200,
+      async arrayBuffer() {
+        return png;
+      },
+    };
+  };
+
+  const directory = await mkdtemp(join(tmpdir(), "vigiles-atlas-logo-"));
+  const result = await generateAtlasLogo({
+    apiKey: "test-key",
+    payload: {
+      model: DEFAULT_MODEL,
+      prompt: "amber torch",
+      aspect_ratio: "1:1",
+    },
+    output: join(directory, "logo-v7"),
+    pollIntervalMs: 0,
+    timeoutMs: 100,
+    fetchImpl,
+    sleep: async () => {},
+  });
+
+  assert.equal(result.imageType, "PNG");
+  assert.equal(result.output, join(directory, "logo-v7.png"));
+  assert.deepEqual(await readFile(result.output), png);
+  assert.equal(
+    calls.filter((call) => call.options.method === "POST").length,
+    1,
+  );
+  const poll = calls.find((call) => call.url.includes("/model/prediction/"));
+  assert.equal(poll.options.headers.Authorization, "Bearer test-key");
+});
+
+test("detects supported image signatures", () => {
+  assert.equal(detectImage(Buffer.from("89504e470d0a1a0a", "hex")), "PNG");
+  assert.equal(detectImage(Buffer.from("ffd8ff00", "hex")), "JPEG");
+  assert.equal(detectImage(Buffer.from("RIFF0000WEBP", "ascii")), "WebP");
+});


### PR DESCRIPTION
## Summary

- keep ImageRouter as the default logo-generation provider
- add an explicitly selected Atlas Cloud route for the internal `generate-logo` skill
- validate the selected model against the live public catalog and schema
- submit the potentially billable generation POST exactly once, with bounded retries only for prediction GETs
- detect PNG, JPEG, and WebP bytes and preserve the actual output format

## Verification

- `node --test .claude/skills/generate-logo/scripts/generate-atlas-logo.test.mjs` (2 passed)
- `npm run fmt:check`
- `npx tsc --noEmit`
- `npm run build`
- one live 1K Atlas smoke generation completed and produced a valid JPEG

The full `npm test` run reached 3,273 passing tests and 13 failures. The same 13 failures reproduce on the unmodified base commit in this environment: missing Ruff/Pylint/RuboCop CLIs, unavailable real Codex/Claude harness paths, and existing absolute-path hook assertions.