### PR TITLE
feat(hook,cli)!: close five adopter-reported issues — halted-turn guards, dead-ref artifacts, centralized tests

### DIFF
--- a/.vigiles/generated.d.ts
+++ b/.vigiles/generated.d.ts
@@ -101,7 +101,7 @@ declare module "vigiles/generated" {
     | "internal:check"
     | "docs:api";
 
-  /** 396 project files. */
+  /** 400 project files. */
   export type ProjectFile = 
     | "src/CLAUDE.md"
     | "src/CLAUDE.md.spec.ts"
@@ -187,7 +187,9 @@ declare module "vigiles/generated" {
     | "src/check.ts"
     | "src/ci-path-filter.test.ts"
     | "src/claude-code.ts"
+    | "src/cli-adopter-reports.test.ts"
     | "src/cli-commands.ts"
+    | "src/cli-compile-gate.test.ts"
     | "src/cli-coverage-record.test.ts"
     | "src/cli-flag-check.test.ts"
     | "src/cli-flag-check.ts"
@@ -428,6 +430,7 @@ declare module "vigiles/generated" {
     | "src/rule-routing.test.ts"
     | "src/rule-routing.ts"
     | "src/rule-signals.ts"
+    | "src/rules-layer.test.ts"
     | "src/run-hook.e2e.test.ts"
     | "src/run-hook.test.ts"
     | "src/run-hook.ts"
@@ -483,6 +486,7 @@ declare module "vigiles/generated" {
     | "src/spec-hooks.mts"
     | "src/spec-host.mts"
     | "src/spec-loader.test.ts"
+    | "src/stability-verbs.test.ts"
     | "src/stats.test.ts"
     | "src/stats.ts"
     | "src/subagent-delivery.test.ts"
@@ -655,7 +659,9 @@ declare module "vigiles/spec" {
       | "src/check.ts"
       | "src/ci-path-filter.test.ts"
       | "src/claude-code.ts"
+      | "src/cli-adopter-reports.test.ts"
       | "src/cli-commands.ts"
+      | "src/cli-compile-gate.test.ts"
       | "src/cli-coverage-record.test.ts"
       | "src/cli-flag-check.test.ts"
       | "src/cli-flag-check.ts"
@@ -896,6 +902,7 @@ declare module "vigiles/spec" {
       | "src/rule-routing.test.ts"
       | "src/rule-routing.ts"
       | "src/rule-signals.ts"
+      | "src/rules-layer.test.ts"
       | "src/run-hook.e2e.test.ts"
       | "src/run-hook.test.ts"
       | "src/run-hook.ts"
@@ -951,6 +958,7 @@ declare module "vigiles/spec" {
       | "src/spec-hooks.mts"
       | "src/spec-host.mts"
       | "src/spec-loader.test.ts"
+      | "src/stability-verbs.test.ts"
       | "src/stats.test.ts"
       | "src/stats.ts"
       | "src/subagent-delivery.test.ts"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,10 @@ npm run build        # Compile TypeScript → dist/
 npm test             # Build + run all tests
 ```
 
-Tests use Node.js built-in test runner (`node:test`) and `node:assert/strict`. No extra test framework needed.
+Tests run under **vitest** (`npm test` = build + `vitest run`), with assertions from
+`node:assert/strict`. Unit tests live beside their source as `src/**/*.test.ts`.
+Optional `vitest` / `jest` matcher adapters ship for CONSUMERS (`vigiles/vitest`,
+`vigiles/jest`); they are not what this repo's own suite uses.
 
 ### Format
 
@@ -67,10 +70,13 @@ npx tsc --noEmit     # Type-check without emitting
 ### Run locally
 
 ```bash
-npx vigiles CLAUDE.md                          # Validate a file
-npx vigiles --markers=headings,checkboxes .    # Custom markers
-npx vigiles                                    # Auto-discover instruction files
+node dist/cli.js audit .     # The zero-config report (build first)
+node dist/cli.js lint .      # The deterministic gate CI runs
+node dist/cli.js --help      # Every verb and its flags
 ```
+
+There is no bare `npx vigiles <file>` form — the CLI dispatches on a VERB, and an
+unknown one exits 2.
 
 ## TypeScript conventions
 
@@ -87,15 +93,38 @@ This project uses **TypeScript strict mode** with these compiler options enabled
 - **No `any`** — use `unknown` and narrow with type guards when the type is truly unknown.
 - Import types with `import type { ... }` when only used in type positions.
 - Use `.js` extensions in import paths (required by Node16 module resolution).
-- Keep the single-file core architecture — `validate.ts` contains all validation logic.
+- Respect the hexagonal boundary: `src/core/` is the harness-agnostic domain,
+  `src/adapters/<harness>/` holds per-harness facts, and core must never import an
+  adapter (enforced by `eslint-plugin-boundaries`, not by convention).
 
 ## Adding a new validation rule
 
-1. Add the rule name and default value to `RulesConfig` in `src/types.ts`.
-2. Add the default to `RULE_PACKS` in `src/validate.ts`.
-3. Implement the check inside the `validate()` function.
-4. Add tests in `src/validate.test.ts`.
-5. Document the rule in `README.md` and `CLAUDE.md`.
+Every step below names a file that exists; the previous version of this section
+pointed at `src/types.ts`, `src/validate.ts` and a `validate()` function, none of
+which have existed for a long time (reported in #176).
+
+A rule is a PURE DETECTOR plus registrations. The detector has ONE home and is
+reused by both `lint` (the gate) and `audit` (the report), so the two can never
+disagree — see the `one-detector-no-drift` rule in `CLAUDE.md`.
+
+1. Write the detector in `src/core/<name>.ts` — pure, IO injected, no `node:fs`
+   import, no Claude Code literals (the core is harness-agnostic; read tool and
+   event catalogs from the injected dialect). Unit-test it beside itself.
+2. Add the rule name to `RulesConfig` in `src/core/types.ts`.
+3. Add its default severity to the rule GROUPS in `src/setup-plan.ts`
+   (`STRUCTURAL_RULES` / `WORKFLOW_RULES` / `NUDGE_RULES`) — severity tracks
+   CONFIDENCE, not importance.
+4. Declare it in `src/core/rule-meta.ts` with its decidability bucket, surface and
+   detector. `Record<RuleName, RuleMeta>` makes a missing entry a `tsc` error, and
+   `src/core/rule-meta.test.ts` binds the registry to `docs/rules/*.md` as an exact
+   set match.
+5. Call the same detector from `src/scan.ts` and wire the severity in `src/cli.ts`.
+6. Write `docs/rules/<name>.md` and add its row to the matrix in
+   `docs/verifying-instruction-files.md`.
+
+For a rule that can be wired at `error`, a FALSE POSITIVE is worse than a miss: a
+miss costs a detection, a false positive costs the build — and a rule that fails
+correct code gets switched off rather than fixed. Err toward silence.
 
 ## Adding a new linter
 
@@ -124,7 +153,9 @@ step-by-step lives in the `add-a-linter` contributor skill
 
 ## Architecture decisions
 
-- **Single-file core**: All validation logic lives in `validate.ts` for portability and minimal dependency surface.
+- **Hexagonal core**: the domain (`src/core/`) knows nothing about how an agent runs;
+  every harness-specific fact sits behind one of five injectable ports. Adding a
+  harness is writing one adapter object, not editing the core.
 - **Zero config by default**: vigiles works out of the box. Config exists only for overrides.
 - **Two rule packs**: `"recommended"` (permissive defaults) and `"strict"` (tighter constraints).
 - **Linter auto-detection**: No need to declare which linters you use — vigiles discovers them.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Every one of these is **valid markdown** — parses fine, does the wrong thing. 
 | `test`  | Does the harness behave?       | No — a scripted stand-in | Every commit             |
 | `eval`  | Does a skill actually help?    | Yes — your subscription  | On demand                |
 
-**One engine, two doors.** `audit` is the local report; **`lint` is the CI gate** that fails the build on the same deterministic checks — broken refs, bad tool contracts, dead hooks, skill collisions (Proofs 1–2). `test` and `eval` go further: past _does it exist_ to _does it work_. (`init` / `compile` / `eject` manage the optional typed-spec layer for the structural rules no linter can express — a graduation step you rarely run by hand.) [How the verbs relate →](docs/commands-and-how-they-relate.md)
+**One engine, two doors.** `audit` is the local report; **`lint` is the CI gate** that fails the build on the same deterministic checks — broken refs, bad tool contracts, dead hooks, skill collisions (Proofs 1–2). `test` and `eval` go further: past _does it exist_ to _does it work_. (`init` / `compile` / `eject` manage the optional typed-spec layer for the structural rules no linter can express — a graduation step you rarely run by hand. If you use a spec, run `compile` in CI too: it is what re-derives that spec's refs, while `lint` verifies the compiled file is intact.) [How the verbs relate →](docs/commands-and-how-they-relate.md)
 
 ### 🔎 Lint — your instructions stop lying
 

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -1,6 +1,6 @@
 # Stability
 
-> vigiles is at **v12** — but read that as _"still moving fast,"_ not
+> vigiles is at **v21** — but read that as _"still moving fast,"_ not
 > _"battle-hardened."_ `semantic-release` cuts a **new major on every breaking
 > API change**, and there have been a lot of them. The number is an artifact of
 > how it ships, not a claim of maturity. This page says what I try hardest not
@@ -11,8 +11,8 @@ their exit codes. Most of the churn is in the library API underneath it.
 
 ## What's stable — depend on it
 
-- **The CLI** — the verbs (`init`, `compile`, `lint`, `test`, `eval`,
-  `scan`, `generate`), their flags, and their **exit codes**
+- **The CLI** — the verbs (`init`, `compile`, `eject`, `lint`, `test`, `eval`,
+  `audit`, `generate`), their flags, and their **exit codes**
   (`0` clean / `1` warn / `2` error). This is the narrowest, steadiest contract
   and the surface almost everyone touches — including the GitHub Action, which wraps it.
 - **The authoring + testing library entry points:**

--- a/api-surface/vigiles-adapter.api.md
+++ b/api-surface/vigiles-adapter.api.md
@@ -108,6 +108,7 @@ export interface HookProtocol {
     readonly blockExitCode: number;
     readonly denyDecisionValues: readonly string[];
     readonly eventEnvVars: readonly string[];
+    readonly haltsTurnField?: string;
     readonly injectableEvents: readonly string[];
     readonly matcherStyle?: "exact" | "regex";
     readonly name: string;

--- a/api-surface/vigiles-adapter.api.md
+++ b/api-surface/vigiles-adapter.api.md
@@ -136,6 +136,7 @@ export interface PluginLayout {
     readonly name: string;
     readonly pluginRootToken: string;
     readonly projectRootTokens?: readonly string[];
+    readonly rulesDir?: string;
     readonly settingsFormat: "json" | "toml";
     readonly settingsPath: string;
     readonly skillDir: string;

--- a/api-surface/vigiles-eval.api.md
+++ b/api-surface/vigiles-eval.api.md
@@ -337,6 +337,7 @@ export interface TriggerRateReport {
     readonly experimental?: string;
     readonly falsePositiveRate?: number;
     readonly n: number;
+    readonly namespace?: string;
     readonly perIrrelevant?: readonly PromptTriggerStat[];
     // (undocumented)
     readonly perPrompt: readonly PromptTriggerStat[];

--- a/api-surface/vigiles.api.md
+++ b/api-surface/vigiles.api.md
@@ -361,6 +361,7 @@ export function cost(opts: {
 export function decideHook(exitCode: number, json: HookOutput | null, protocol?: HookProtocol): {
     blocked: boolean;
     decision: HookRunResult["decision"];
+    haltsTurn: boolean;
 };
 
 // @public
@@ -767,6 +768,7 @@ export interface HookPropertyResult<E> {
 export interface HookRunResult extends ScriptRunResult {
     readonly blocked: boolean;
     readonly decision: HookOutput["decision"] | "allow" | "deny" | "ask" | undefined;
+    readonly haltsTurn: boolean;
     readonly json: HookOutput | null;
 }
 
@@ -1215,6 +1217,7 @@ export interface TriggerRateReport {
     readonly experimental?: string;
     readonly falsePositiveRate?: number;
     readonly n: number;
+    readonly namespace?: string;
     readonly perIrrelevant?: readonly PromptTriggerStat[];
     // (undocumented)
     readonly perPrompt: readonly PromptTriggerStat[];

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -484,8 +484,26 @@ npx vigiles audit ./some-plugin --json   # structured, for pipelines
 npx vigiles audit ./plugins/*/           # ≥2 targets → ranked health leaderboard
 npx vigiles audit ./plugins/*/ --md      # ranked leaderboard as a Markdown table (publishable)
 npx vigiles audit ./marketplace-repo     # a marketplace.json root → ranks every member
+npx vigiles audit ./marketplace-repo --single  # ...or audit that root as ONE harness
 npx vigiles audit ./repo --harness=codex # override harness detection
 ```
+
+#### `--single` — audit a many-bundle root as one harness
+
+A marketplace root switches to the leaderboard automatically, which means the
+full ring report **for that root** has no way to be asked for. `--single` pins
+the single-harness reading regardless of what is nested inside:
+
+```bash
+npx vigiles audit . --single    # rings for the root itself, not a table of members
+```
+
+It names ONE harness, so passing several directories alongside it is refused
+(exit 2) rather than auditing the first and dropping the rest.
+
+Note `--out` writes a report only in single-harness mode; in leaderboard mode
+there is no per-bundle report to write, and `audit` now says so instead of
+ignoring the flag silently.
 
 #### Leaderboard — rank many plugins
 

--- a/docs/rules/untested-skill.md
+++ b/docs/rules/untested-skill.md
@@ -237,6 +237,42 @@ point `testGlobs` at those files **and place them beside the skill they cover**:
 A file in `testGlobs` counts only where it sits. One central config naming every
 skill covers none of them — that is the content-reference rule that was removed.
 
+### A centralized layout: the `{surface}` placeholder
+
+If your suites live in a **central tree** rather than beside each skill —
+`tests/<skill>/evals/promptfooconfig.yaml` is the common shape — write the
+placeholder `{surface}` where the skill's name goes:
+
+```json
+{
+  "rules": {
+    "untested-skill": [
+      "warn",
+      { "testGlobs": ["tests/{surface}/evals/promptfooconfig*.yaml"] }
+    ]
+  }
+}
+```
+
+`{surface}` is replaced with each skill's own name before matching, so
+`tests/mysql-designer/evals/promptfooconfig.yaml` covers `mysql-designer` — and
+nothing else.
+
+**A `testGlobs` entry WITHOUT `{surface}` still credits nothing on its own.**
+It widens what counts as a _test file_ but says nothing about which _surface_ a
+file is for, and inferring that from a substring is exactly the
+content-reference rule that was removed for crediting surfaces no test had
+touched.
+
+**What it costs, so you can decide honestly:** `ls` beside the skill no longer
+answers "is this tested?" — you have to know where the project keeps its tests.
+That is the property colocation was chosen for, which is why this is opt-in per
+repo rather than a second default. If your suites are already centralized, you
+have paid that cost anyway.
+
+Where both exist, **colocation wins** and is what the report names, regardless of
+the order of your `testGlobs` array.
+
 ## Exemptions
 
 **Every** skill is held to this — invocation mode does **not** exempt anything. A

--- a/docs/skills-monorepo.md
+++ b/docs/skills-monorepo.md
@@ -90,6 +90,28 @@ legitimate authoring style):
 | `Read ~/.claude/docs/x.md`                                 | an external home/global path — **skipped** |
 | `${CLAUDE_PLUGIN_ROOT}/x`, `https://…`, `/abs/path`        | var / URL / absolute — **skipped**         |
 
+## Centralized tests — `{surface}` in `testGlobs`
+
+A skills monorepo usually keeps its suites in one tree
+(`tests/<skill>/evals/…`) rather than beside each skill. Say so with the
+`{surface}` placeholder, which is replaced with each skill's own name before
+matching:
+
+```json
+{
+  "rules": {
+    "untested-skill": [
+      "warn",
+      { "testGlobs": ["tests/{surface}/evals/promptfooconfig*.yaml"] }
+    ]
+  }
+}
+```
+
+Without the placeholder a custom glob widens what counts as a test file but
+never says which skill a file covers, so it credits nothing.
+[Full rules and the trade-off →](rules/untested-skill.md)
+
 ## Which surfaces gate CI
 
 `audit` is a **local report** (like Lighthouse). For CI, use `vigiles lint` — the

--- a/eslint-rules/experimental-name.corpus.test.ts
+++ b/eslint-rules/experimental-name.corpus.test.ts
@@ -1,0 +1,87 @@
+/**
+ * `local/experimental-name` against the SHARED export-form corpus (#170).
+ *
+ * The rule's own test file covers its behaviour case by case. This one asks a
+ * different question: does it see every form of export the corpus enumerates?
+ *
+ * That distinction is the whole point of the issue. Nine of seventeen review
+ * findings on one PR landed in this rule alone, arriving in sequence — aliased
+ * re-export, then a separately-exported tagged local, then `export default`,
+ * then a destructured binding — each after the previous fix was called complete.
+ * Case-by-case tests could not tell anyone when the list was finished, because
+ * they only ever contained the forms somebody had already thought of. Driving
+ * both checks off ONE enumeration is what turns that into a question a test can
+ * answer, and makes an unknown form a missing ROW rather than a silent gap.
+ */
+import { RuleTester } from "eslint";
+import tsparser from "@typescript-eslint/parser";
+import { describe, it } from "vitest";
+
+import rule from "./experimental-name.mjs";
+import { COVERED_FORMS, withTag } from "../scripts/lib/export-forms.mjs";
+
+RuleTester.describe = describe as never;
+RuleTester.it = it as never;
+RuleTester.itOnly = it.only as never;
+
+const tester = new RuleTester({
+  languageOptions: { parser: tsparser as never, ecmaVersion: 2022 },
+});
+
+/**
+ * VALUE forms only. Types are deliberately out of the rule's scope — the
+ * convention is about CALL SITES, and a type annotation is not one — so feeding
+ * them here would assert the opposite of the decision.
+ */
+const TYPE_FORMS = new Set(["interface", "type-alias", "enum"]);
+const valueForms = COVERED_FORMS.filter(
+  (f) => f.local !== null && !TYPE_FORMS.has(f.id),
+);
+
+/**
+ * The form's code with EVERY binding it introduces renamed to carry the prefix.
+ *
+ * Every binding, not just `local` — `export const alpha = 1, beta = 2` and
+ * `export const [first, second] = pair` introduce two, and renaming one leaves
+ * the rule correctly reporting the other. Getting that wrong made four corpus
+ * cases look like rule bugs when the fault was here; the corpus's value is
+ * partly that it made the difference visible.
+ *
+ * A name already carrying the prefix is left alone, or `specifier-aliased`
+ * (whose local IS `experimental_widget`) would become `experimental_experimental_widget`.
+ */
+function prefixAll(form: (typeof valueForms)[number]): string {
+  const names = new Set<string>([form.local as string, ...form.exported]);
+  let code = withTag(form, "@experimental");
+  for (const n of names) {
+    if (n === "default" || n.startsWith("experimental_")) continue;
+    code = code.replaceAll(new RegExp(`\\b${n}\\b`, "g"), `experimental_${n}`);
+  }
+  return code;
+}
+
+/** How many bindings in this form would be reported when unprefixed. */
+function unprefixedCount(form: (typeof valueForms)[number]): number {
+  const names = new Set<string>([form.local as string, ...form.exported]);
+  return [...names].filter(
+    (n) => n !== "default" && !n.startsWith("experimental_"),
+  ).length;
+}
+
+tester.run("experimental-name (corpus)", rule as never, {
+  // Every form, correctly named, must be SILENT. A rule that fires on a valid
+  // export is worse than one that misses: it fails a correct build, and a rule
+  // that fails correct builds gets switched off rather than fixed.
+  valid: valueForms.map((form) => ({
+    name: `${form.id}: prefixed name is accepted`,
+    code: prefixAll(form),
+  })),
+
+  // …and every form, UNPREFIXED, must be caught. Without this half the suite
+  // above is satisfied by a rule that does nothing at all.
+  invalid: valueForms.map((form) => ({
+    name: `${form.id}: unprefixed name is reported`,
+    code: withTag(form, "@experimental"),
+    errors: unprefixedCount(form),
+  })),
+});

--- a/eslint-rules/experimental-name.mjs
+++ b/eslint-rules/experimental-name.mjs
@@ -276,6 +276,20 @@ export default {
        */
       ExportDefaultDeclaration(node) {
         const d = node.declaration;
+        // `export default widget;` — the declaration and its tag sit ELSEWHERE
+        // in the file, so this statement carries no tag of its own and the
+        // inline path below finds nothing. Recorded like an export specifier and
+        // judged at `Program:exit`, once the tagged locals are known.
+        //
+        // 🔴 FOUND BY THE CORPUS, not by review (#170). It is the same shape the
+        // rule already learned for `export { x }` in an earlier round — a tagged
+        // local exported by a later statement — and it went unnamed anyway,
+        // which is precisely the argument for enumerating against the grammar
+        // instead of patching per report.
+        if (d?.type === "Identifier") {
+          pending.push({ node: d, local: d.name });
+          return;
+        }
         const id =
           (d?.type === "FunctionDeclaration" ||
             d?.type === "ClassDeclaration") &&

--- a/scripts/check-internal-tag.mjs
+++ b/scripts/check-internal-tag.mjs
@@ -36,6 +36,8 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
 
+import { taggedDeclarations } from "./lib/tagged-declarations.mjs";
+
 const ROOT = resolve(process.argv[2] ?? ".");
 const PREFIX = "experimental_";
 function walk(dir, out = []) {
@@ -89,88 +91,37 @@ function publicSymbols() {
  *    types in would have opened with 6 cosmetic renames against 1 real finding,
  *    and a gate that arrives 86% noise is muted within the day.
  */
+
 /**
- * ⚠️ `export default` IS matched, and was not until 2026-08-21. Both this matcher
- * and the api-report one above omitted the modifier, so an `@internal` symbol
- * exported as default was invisible to BOTH halves at once — the source side saw
- * no declaration and the report side saw no public name, and the two absences
- * cancelled into a clean `findings: 0`. A default export is an ordinary public
- * API shape, so the check simply did not hold for it.
+ * Every tagged declaration in one file, ASKED OF THE PARSER.
  *
- * An ANONYMOUS default (`export default function () {}`) is still out of reach:
- * it has no name for the api report to list, so there is nothing to correlate.
- * Stated rather than left as silence.
- */
-const VALUE_DECL =
-  /^\s*export\s+(?:default\s+)?(?:declare\s+)?(?:abstract\s+)?(?:async\s+)?(function|const|let|var|class)\s+([A-Za-z0-9_$]+)/;
-
-/**
- * A TSDoc tag, with or without prose after it.
+ * 🔴 THIS USED TO BE REGEXES, and that is the finding, not a detail. A doc-block
+ * scanner paired with a `VALUE_DECL` shape-matcher had been extended four times,
+ * each after a reviewer named a form it did not know, and it still missed
+ * `const x = …; export { x }` — the case #170 carried open. Every extension
+ * looked complete and none was, because a shape-matcher recognizes only shapes
+ * somebody remembered to write down. `scripts/lib/tagged-declarations.mjs` asks
+ * the TypeScript compiler instead, so the whole class stops being expressible;
+ * the forms it is expected to handle are enumerated in
+ * `scripts/lib/export-forms.mjs` and asserted in the test beside this file.
  *
- * 🔴 The first version of this required the tag ALONE on its line
- * (`@experimental\s*$`). Real tags carry prose — `@internal Experimental
- * typed-composition surface — …` on `pipe`, and two in `services.ts` — so the
- * check silently skipped them. Measured the day it shipped: 2 of 8 tagged
- * `@experimental` declarations and 31 of 39 `@internal` ones were invisible to
- * it. A stricter pattern read as a safer one and was the opposite.
+ * The `@internal` over `@experimental` precedence is unchanged and still
+ * load-bearing: the reporting loop below acts only on `@internal`, so recording
+ * the weaker tag for a both-tagged symbol swallowed it silently while the run
+ * still printed `checked: 1` — a counter that counts a symbol it then ignores is
+ * worse than one that misses it, because the number reads as coverage.
+ * On the merits too: `@experimental` says "this may change", `@internal` says
+ * "this is not API at all", and the stronger claim is the contradiction worth
+ * reporting.
  */
-const tagRe = (tag) => new RegExp(`^\\s*\\*\\s*@${tag}\\b`, "m");
-
-/**
- * The next value declaration after a doc block, skipping anything that is not
- * one — `pipe` has an `/* eslint-disable ... *\/` between its JSDoc and its
- * first overload, and anchoring at the very next character missed it. Only
- * comments and blank lines may intervene; real code ends the search, so a doc
- * block that documents nothing does not silently adopt a distant declaration.
- */
-function declAfter(src, from) {
-  let rest = src.slice(from);
-  for (;;) {
-    const skipped = rest.replace(
-      /^(?:\s*(?:\/\/[^\n]*|\/\*[\s\S]*?\*\/)\s*)+/,
-      "",
-    );
-    const decl = VALUE_DECL.exec(skipped);
-    if (decl) return decl;
-    if (skipped === rest) return null;
-    rest = skipped;
-  }
-}
-
 function taggedExperimental(file) {
   const src = readFileSync(file, "utf8");
-  const out = [];
-  const BLOCK = /\/\*\*[\s\S]*?\*\//g;
-  let m;
-  while ((m = BLOCK.exec(src)) !== null) {
-    const block = m[0];
-    const experimental = tagRe("experimental").test(block);
-    const internal = tagRe("internal").test(block);
-    if (!experimental && !internal) continue;
-    if (/@module\b/.test(block)) continue; // file-level tag, not a symbol
-    const decl = declAfter(src, m.index + block.length);
-    if (!decl) continue;
-    const line = src.slice(0, m.index + block.length).split("\n").length;
-    out.push({
-      name: decl[2],
-      line,
-      // 🔴 `@internal` WINS when both tags are present, and the opposite order
-      // was a live bug for as long as this file had one job. It reads as a
-      // harmless tie-break, and it is not: since the split, the reporting loop
-      // acts only on `@internal`, so recording `@experimental` for a
-      // both-tagged symbol swallowed it silently — and the run still printed
-      // `checked: 1`, claiming it had looked. A counter that counts a symbol it
-      // then ignores is worse than one that misses it, because the number reads
-      // as coverage.
-      //
-      // Precedence is also right on the merits: `@experimental` says "this may
-      // change", `@internal` says "this is not API at all". The second is the
-      // stronger claim about an exported symbol, and the stronger claim is the
-      // contradiction worth reporting.
-      tag: internal ? "@internal" : "@experimental",
-    });
-  }
-  return out;
+  return taggedDeclarations(src, ["internal", "experimental"]).map((d) => ({
+    name: d.name,
+    line: d.line,
+    kind: d.kind,
+    tag: d.tags.includes("internal") ? "@internal" : "@experimental",
+  }));
 }
 
 const { names: pub, reports } = publicSymbols();
@@ -184,12 +135,35 @@ if (reports.length === 0) {
 
 let checked = 0;
 let findings = 0;
+let skippedTypes = 0;
 for (const file of walk(join(ROOT, "src"))) {
   for (const d of taggedExperimental(file)) {
     const doors = pub.get(d.name);
     // Not exported from any subpath: the tag is a note to maintainers and
     // promises nothing to anyone. Both tags are fine there, unchecked.
     if (!doors) continue;
+
+    // 🔴 TYPES ARE OUT OF SCOPE, and this is a DECISION, not an oversight —
+    // it has to be stated because until the parser landed it was neither.
+    // The old regex matched `function|const|let|var|class` and therefore could
+    // not see a type at all; the moment it could, seven exported-and-@internal
+    // types appeared at once, every one of them deliberate. They are typed-
+    // composition machinery (`Supplies`, `Pipeline`, `Handoff`, …) exported
+    // ONLY so a user's inference resolves — nobody writes those names, and
+    // `@internal` is the truthful way to say so. Failing the build over them
+    // would force either a meaningless rename or dropping a true tag.
+    //
+    // It also matches the sibling rule: `local/experimental-name` excludes
+    // types for the same reason — the convention is about CALL SITES, and a
+    // type annotation is not one.
+    //
+    // Counted and REPORTED rather than dropped: this file's own history is a
+    // counter that counted a symbol it then ignored, and the number read as
+    // coverage. A silent skip here would repeat it exactly.
+    if (d.kind === "type") {
+      skippedTypes++;
+      continue;
+    }
     checked++;
 
     // `vigiles.api.md` is the root subpath: label it `vigiles`, not `vigiles/vigiles`.
@@ -214,7 +188,11 @@ for (const file of walk(join(ROOT, "src"))) {
 }
 
 console.log(
-  `\npublic @experimental/@internal declarations checked: ${checked}  (across ${reports.length} api reports)`,
+  `\npublic @experimental/@internal VALUE declarations checked: ${checked}  (across ${reports.length} api reports)`,
 );
+if (skippedTypes > 0)
+  console.log(
+    `types skipped (out of scope, see the comment above): ${skippedTypes}`,
+  );
 console.log(`findings: ${findings}`);
 process.exit(findings ? 1 : 0);

--- a/scripts/lib/export-forms.mjs
+++ b/scripts/lib/export-forms.mjs
@@ -1,0 +1,305 @@
+/**
+ * THE CANONICAL ENUMERATION of ways a JavaScript/TypeScript module can introduce
+ * an exported binding — the shared answer to "what does this file export, and
+ * under what name".
+ *
+ * It exists because two checks answered that question independently and both got
+ * it wrong, in the same places, days apart. `local/experimental-name` took four
+ * rounds of review to learn four forms (aliased re-export, separately-exported
+ * tagged local, `export default`, destructured binding), each arriving after the
+ * previous fix was called complete; `check-internal-tag.mjs` independently missed
+ * `export default`, and then the separately-exported case too. The same construct
+ * going unnamed in two checkers written days apart is not a repeated typo, it is
+ * a blind spot in how "exported" gets enumerated — and patch-on-report converges
+ * slowly and never tells you when it is done (#170).
+ *
+ * So the list is written ONCE, against the grammar rather than recollection, and
+ * both checks are tested against it. A form nobody has thought of is now a
+ * MISSING ROW — visible, addable, reviewable — instead of a silent gap.
+ *
+ * WHAT EACH ROW IS: `code` is a complete module; `exported` is every name the
+ * module makes externally reachable, and `local` is the name the DECLARATION
+ * carries (they differ under aliasing, which is the whole point of listing it).
+ * `tagBefore` names the line a TSDoc tag would sit above — needed because in a
+ * multi-line form the DECLARATION and the EXPORT are different statements, and
+ * which one carries the tag is exactly the distinction these checks kept getting
+ * wrong. Absent means the single statement.
+ *
+ * DELIBERATE EXCLUSIONS are rows too (`covered: false`), with the reason stated,
+ * because an exclusion nobody wrote down is indistinguishable from an oversight —
+ * which is exactly the confusion this file was created to end.
+ */
+
+/**
+ * @typedef {{id: string, code: string, exported: string[], local: string|null,
+ *   covered: boolean, why?: string, tagBefore?: string}} ExportForm
+ */
+
+/** @type {ExportForm[]} */
+export const EXPORT_FORMS = [
+  // --- Inline export modifier on a declaration ------------------------------
+  {
+    id: "function-declaration",
+    code: `export function widget() {}`,
+    exported: ["widget"],
+    local: "widget",
+    covered: true,
+  },
+  {
+    id: "class-declaration",
+    code: `export class Widget {}`,
+    exported: ["Widget"],
+    local: "Widget",
+    covered: true,
+  },
+  {
+    id: "const-declaration",
+    code: `export const widget = () => {};`,
+    exported: ["widget"],
+    local: "widget",
+    covered: true,
+  },
+  {
+    id: "let-declaration",
+    code: `export let widget = 1;`,
+    exported: ["widget"],
+    local: "widget",
+    covered: true,
+  },
+  {
+    id: "var-declaration",
+    code: `export var widget = 1;`,
+    exported: ["widget"],
+    local: "widget",
+    covered: true,
+  },
+  {
+    id: "async-function-declaration",
+    code: `export async function widget() {}`,
+    exported: ["widget"],
+    local: "widget",
+    covered: true,
+  },
+  {
+    id: "abstract-class-declaration",
+    code: `export abstract class Widget {}`,
+    exported: ["Widget"],
+    local: "Widget",
+    covered: true,
+  },
+  {
+    id: "declare-const",
+    code: `export declare const widget: number;`,
+    exported: ["widget"],
+    local: "widget",
+    covered: true,
+  },
+
+  // --- Multiple declarators in one statement --------------------------------
+  {
+    id: "multiple-declarators",
+    // Each declarator is its own binding. A matcher that reads "the name after
+    // the keyword" sees only the first.
+    code: `export const alpha = 1, beta = 2;`,
+    exported: ["alpha", "beta"],
+    local: "alpha",
+    covered: true,
+  },
+
+  // --- Destructuring --------------------------------------------------------
+  {
+    id: "destructured-object",
+    tagBefore: "export const { widget }",
+    // Round 4 of the review found this one. The exported name is not an
+    // Identifier at the top of the declarator, so a shape-matcher misses it.
+    code: `const source = { widget: 1 };\nexport const { widget } = source;`,
+    exported: ["widget"],
+    local: "widget",
+    covered: true,
+  },
+  {
+    id: "destructured-array",
+    tagBefore: "export const [first, second]",
+    code: `const pair = [1, 2];\nexport const [first, second] = pair;`,
+    exported: ["first", "second"],
+    local: "first",
+    covered: true,
+  },
+  {
+    id: "destructured-renamed",
+    tagBefore: "export const { a: widget }",
+    code: `const source = { a: 1 };\nexport const { a: widget } = source;`,
+    exported: ["widget"],
+    local: "widget",
+    covered: true,
+  },
+
+  // --- Export specifiers (the declaration is elsewhere) ---------------------
+  {
+    id: "specifier",
+    tagBefore: "const widget = () => {};",
+    // Round 2. The declaration has no export modifier at all, so a check that
+    // only looks for one never records it — while the API report still lists it.
+    // This is the finding #170 carried open for `check-internal-tag.mjs`.
+    code: `const widget = () => {};\nexport { widget };`,
+    exported: ["widget"],
+    local: "widget",
+    covered: true,
+  },
+  {
+    id: "specifier-aliased",
+    tagBefore: "const experimental_widget = () => {};",
+    // Round 1. The exported name and the declared name differ.
+    code: `const experimental_widget = () => {};\nexport { experimental_widget as widget };`,
+    exported: ["widget"],
+    local: "experimental_widget",
+    covered: true,
+  },
+  {
+    id: "specifier-function",
+    tagBefore: "function widget() {}",
+    code: `function widget() {}\nexport { widget };`,
+    exported: ["widget"],
+    local: "widget",
+    covered: true,
+  },
+  {
+    id: "specifier-default-alias",
+    tagBefore: "const widget = 1;",
+    code: `const widget = 1;\nexport { widget as default };`,
+    exported: ["default"],
+    local: "widget",
+    covered: false,
+    why:
+      "`default` is not a name any consumer writes — they choose their own at " +
+      "the import — so no prefix can reach a call site through it. The same " +
+      "limit as an anonymous default, reached by a different syntax. The " +
+      "PARSER still resolves the binding (it is a covered form for enumeration); " +
+      "what is excluded is judging the NAME.",
+  },
+
+  // --- Default exports ------------------------------------------------------
+  {
+    id: "default-function",
+    // Round 3, and independently missing from the other checker — the clearest
+    // evidence that the two were enumerating from the same faulty memory.
+    code: `export default function widget() {}`,
+    exported: ["widget"],
+    local: "widget",
+    covered: true,
+  },
+  {
+    id: "default-class",
+    code: `export default class Widget {}`,
+    exported: ["Widget"],
+    local: "Widget",
+    covered: true,
+  },
+  {
+    id: "default-identifier",
+    tagBefore: "const widget = 1;",
+    code: `const widget = 1;\nexport default widget;`,
+    exported: ["widget"],
+    local: "widget",
+    covered: true,
+  },
+
+  // --- Type-only positions --------------------------------------------------
+  {
+    id: "interface",
+    code: `export interface Widget { a: number }`,
+    exported: ["Widget"],
+    local: "Widget",
+    covered: true,
+  },
+  {
+    id: "type-alias",
+    code: `export type Widget = number;`,
+    exported: ["Widget"],
+    local: "Widget",
+    covered: true,
+  },
+  {
+    id: "enum",
+    code: `export enum Widget { A }`,
+    exported: ["Widget"],
+    local: "Widget",
+    covered: true,
+  },
+
+  // --- DELIBERATE EXCLUSIONS ------------------------------------------------
+  {
+    id: "anonymous-default",
+    code: `export default () => {};`,
+    exported: [],
+    local: null,
+    covered: false,
+    why:
+      "There is no name to carry a marker and none for an API report to list, " +
+      "so there is nothing to correlate. A limit of a name-based convention, " +
+      "not a bug in the checks.",
+  },
+  {
+    id: "re-export-from",
+    code: `export { widget } from "./other.js";`,
+    exported: ["widget"],
+    local: null,
+    covered: false,
+    why:
+      "The declaration — and therefore any tag on it — lives in ANOTHER file. " +
+      "Both checks are single-file by design; judging this needs the module " +
+      "graph, which is the api report's job, not a per-file matcher's.",
+  },
+  {
+    id: "star-re-export",
+    code: `export * from "./other.js";`,
+    exported: [],
+    local: null,
+    covered: false,
+    why:
+      "The exported set is not knowable from this file at all; it is whatever " +
+      "the other module exports today.",
+  },
+  {
+    id: "hoisted-in-block",
+    tagBefore: "export { widget };",
+    code: `{\n  var widget = 1;\n}\nexport { widget };`,
+    exported: ["widget"],
+    local: "widget",
+    covered: false,
+    why:
+      "A `var`/function in a top-level BLOCK hoists to module scope. Accepted " +
+      "as untracked because erring toward silence is correct here: for a rule " +
+      "wired at `error` a false positive costs the build, a miss costs one " +
+      "detection.",
+  },
+];
+
+/** The forms both checks are expected to handle. */
+export const COVERED_FORMS = EXPORT_FORMS.filter((f) => f.covered);
+
+/** The forms deliberately out of scope, each with a stated reason. */
+export const EXCLUDED_FORMS = EXPORT_FORMS.filter((f) => !f.covered);
+
+/**
+ * The form's code with a TSDoc tag placed where that form's DECLARATION is.
+ *
+ * Exists because getting this wrong is the same mistake the checks made: in a
+ * multi-line form the tag is NOT simply at the top. Prepending it blindly
+ * documents whichever statement happens to come first — for
+ * `export const { widget } = source` that is the unrelated `source`, and the
+ * assertion then fails for a reason that has nothing to do with the check.
+ *
+ * @param {ExportForm} form
+ * @param {string} tag e.g. "@internal"
+ * @returns {string}
+ */
+export function withTag(form, tag) {
+  const doc = `/** ${tag} */`;
+  if (!form.tagBefore) return `${doc}\n${form.code}`;
+  const lines = form.code.split("\n");
+  const i = lines.findIndex((l) => l.includes(form.tagBefore));
+  if (i < 0) throw new Error(`tagBefore not found in ${form.id}`);
+  lines.splice(i, 0, doc);
+  return lines.join("\n");
+}

--- a/scripts/lib/export-forms.test.ts
+++ b/scripts/lib/export-forms.test.ts
@@ -1,0 +1,128 @@
+/**
+ * The export-form corpus, asserted against the enumeration BOTH naming checks
+ * rest on (#170).
+ *
+ * The point is not that these particular forms work. It is that "did we cover
+ * it?" stops being a memory question. Four forms were added to
+ * `local/experimental-name` one at a time across four review rounds, each after
+ * the previous fix was called complete, and `check-internal-tag.mjs`
+ * independently missed two of the same ones — the same construct unnamed in two
+ * checkers written days apart. Patch-on-report converges slowly and never tells
+ * you when it is done.
+ *
+ * So a form nobody has thought of is now a MISSING ROW in
+ * `scripts/lib/export-forms.mjs` — reviewable — rather than a silent gap, and an
+ * exclusion is a row too, with its reason, because an exclusion nobody wrote
+ * down is indistinguishable from an oversight.
+ */
+import { describe, it, expect } from "vitest";
+
+import {
+  EXPORT_FORMS,
+  COVERED_FORMS,
+  EXCLUDED_FORMS,
+  withTag,
+} from "./export-forms.mjs";
+import { exportedNames, taggedDeclarations } from "./tagged-declarations.mjs";
+
+describe("the corpus itself", () => {
+  it("names every excluded form's reason", () => {
+    // An exclusion without a stated reason is the thing this file exists to
+    // prevent: indistinguishable from having forgotten the case.
+    for (const f of EXCLUDED_FORMS)
+      expect(
+        f.why,
+        `${f.id} is excluded but says nothing about why`,
+      ).toBeTruthy();
+  });
+
+  it("has no duplicate ids", () => {
+    const ids = EXPORT_FORMS.map((f) => f.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("covers the four forms that arrived one review round at a time", () => {
+    // Named explicitly so deleting one is a visible act, not a quiet trim.
+    for (const id of [
+      "specifier-aliased",
+      "specifier",
+      "default-function",
+      "destructured-object",
+    ])
+      expect(EXPORT_FORMS.some((f) => f.id === id && f.covered)).toBe(true);
+  });
+});
+
+describe("the parser enumerates every covered form", () => {
+  for (const form of COVERED_FORMS) {
+    it(`${form.id}`, () => {
+      expect(exportedNames(form.code).sort()).toEqual(
+        [...form.exported].sort(),
+      );
+    });
+  }
+});
+
+describe("a tagged declaration is found in every covered form", () => {
+  for (const form of COVERED_FORMS) {
+    if (!form.local) continue;
+    it(`${form.id}`, () => {
+      // The tag goes on the DECLARATION, wherever the export happens to be —
+      // which is exactly what a shape-matcher anchored on `export` cannot see.
+      const tagged = taggedDeclarations(withTag(form, "@internal"), [
+        "internal",
+      ]);
+      expect(tagged.length).toBeGreaterThan(0);
+      expect(tagged.some((d) => d.exported)).toBe(true);
+    });
+  }
+});
+
+describe("the excluded forms stay excluded", () => {
+  it("an anonymous default yields no name to judge", () => {
+    const form = EXCLUDED_FORMS.find((f) => f.id === "anonymous-default");
+    expect(
+      taggedDeclarations(withTag(form!, "@internal"), ["internal"]),
+    ).toEqual([]);
+  });
+
+  it("`as default` still RESOLVES — only judging its name is excluded", () => {
+    // The exclusion is about the naming convention, not about the parser: the
+    // binding is perfectly knowable, and pretending otherwise would hide a real
+    // export from the enumeration half.
+    const form = EXCLUDED_FORMS.find((f) => f.id === "specifier-default-alias");
+    expect(exportedNames(form?.code ?? "")).toEqual(["default"]);
+  });
+
+  it("a re-export from another module is not claimed as local", () => {
+    const form = EXCLUDED_FORMS.find((f) => f.id === "re-export-from");
+    // The declaration — and any tag on it — lives in the other file.
+    expect(exportedNames(form?.code ?? "")).toEqual([]);
+  });
+});
+
+describe("kind: values are judged, types are not", () => {
+  it("an interface is a type", () => {
+    const [d] = taggedDeclarations(
+      `/** @internal */\nexport interface Widget { a: number }`,
+      ["internal"],
+    );
+    expect(d?.kind).toBe("type");
+  });
+
+  it("an enum is a VALUE — it emits runtime code", () => {
+    const [d] = taggedDeclarations(
+      `/** @internal */\nexport enum Widget { A }`,
+      ["internal"],
+    );
+    expect(d?.kind).toBe("value");
+  });
+
+  it("a const is a value", () => {
+    const [d] = taggedDeclarations(
+      `/** @internal */\nexport const widget = 1;`,
+      ["internal"],
+    );
+    expect(d?.kind).toBe("value");
+  });
+});

--- a/scripts/lib/tagged-declarations.mjs
+++ b/scripts/lib/tagged-declarations.mjs
@@ -1,0 +1,200 @@
+/**
+ * "Which declarations in this file carry a TSDoc tag, what are they NAMED, and
+ * is the module making them externally reachable?" — answered by the TypeScript
+ * parser rather than by a regex enumerating shapes from memory.
+ *
+ * 🔴 WHY A PARSER. The regex this replaces had been extended four times, each
+ * time after a reviewer named a form it did not know (aliased re-export,
+ * separately-exported tagged local, `export default`, destructured binding), and
+ * the last of those stayed open in #170. Every extension looked complete and
+ * none was, because a shape-matcher can only recognize shapes somebody
+ * remembered to write down. The parser already knows the grammar, so the whole
+ * class stops being expressible — the same argument this repository makes for
+ * parsing Bash with a shell AST and markdown with markdown-it instead of
+ * regexes, applied to its own tooling.
+ *
+ * `typescript` is already a direct dependency and is the language's own parser,
+ * so this is ADOPT, not BUILD.
+ *
+ * SINGLE-FILE by design: it reports the LOCAL export status of each declaration.
+ * Whether a symbol is genuinely public is a question about the export graph, and
+ * the committed api reports answer that already — see check-internal-tag.mjs.
+ *
+ * The forms it is expected to handle, and the ones deliberately excluded, are
+ * enumerated in ./export-forms.mjs and asserted against this module by
+ * scripts/check-internal-tag.test.ts.
+ */
+import ts from "typescript";
+
+/**
+ * @typedef {{name: string, line: number, tags: string[], exported: boolean,
+ *   kind: "value"|"type"}} TaggedDecl
+ */
+
+/** Names this module exports through an `export { … }` specifier list. */
+function specifierExportedLocals(source) {
+  /** @type {Map<string, string>} */
+  const locals = new Map(); // local name -> exported name
+  for (const stmt of source.statements) {
+    if (!ts.isExportDeclaration(stmt)) continue;
+    // `export { x } from "./other"` re-exports someone else's declaration; the
+    // tag would live in that file, so it is not ours to judge (an excluded form).
+    if (stmt.moduleSpecifier) continue;
+    const clause = stmt.exportClause;
+    if (!clause || !ts.isNamedExports(clause)) continue;
+    for (const spec of clause.elements)
+      locals.set((spec.propertyName ?? spec.name).text, spec.name.text);
+  }
+  return locals;
+}
+
+/** `export default <identifier>;` — the declaration sits elsewhere in the file. */
+function defaultExportedLocal(source) {
+  for (const stmt of source.statements) {
+    if (!ts.isExportAssignment(stmt) || stmt.isExportEquals) continue;
+    if (ts.isIdentifier(stmt.expression)) return stmt.expression.text;
+  }
+  return null;
+}
+
+/** Does this node carry an inline `export` modifier? */
+function hasExportModifier(node) {
+  return (
+    ts.canHaveModifiers(node) &&
+    (ts.getModifiers(node) ?? []).some(
+      (m) => m.kind === ts.SyntaxKind.ExportKeyword,
+    )
+  );
+}
+
+/**
+ * Every name a binding pattern introduces — so `export const { a, b: c } = x`
+ * and `export const [d] = y` yield their real bindings instead of nothing. This
+ * is the form that took four review rounds to be noticed.
+ */
+function bindingNames(name, out = []) {
+  if (ts.isIdentifier(name)) {
+    out.push(name.text);
+    return out;
+  }
+  if (ts.isObjectBindingPattern(name) || ts.isArrayBindingPattern(name)) {
+    for (const el of name.elements) {
+      if (ts.isOmittedExpression(el)) continue;
+      bindingNames(el.name, out);
+    }
+  }
+  return out;
+}
+
+/** The TSDoc tag names on a node, lowercased (`["internal"]`). */
+function tagsOf(node) {
+  return ts.getJSDocTags(node).map((t) => t.tagName.text.toLowerCase());
+}
+
+/**
+ * Parse `src` and return every declaration carrying at least one of `wanted`.
+ *
+ * @param {string} src   file contents
+ * @param {string[]} wanted  tag names without the `@`, e.g. ["internal"]
+ * @returns {TaggedDecl[]}
+ */
+export function taggedDeclarations(src, wanted) {
+  const source = ts.createSourceFile(
+    "input.ts",
+    src,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TS,
+  );
+  const bySpecifier = specifierExportedLocals(source);
+  const defaultLocal = defaultExportedLocal(source);
+  const want = new Set(wanted.map((t) => t.toLowerCase()));
+  /** @type {TaggedDecl[]} */
+  const out = [];
+
+  const lineOf = (node) =>
+    source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
+
+  const record = (node, names, tags, kind) => {
+    for (const name of names) {
+      out.push({
+        name,
+        line: lineOf(node),
+        tags,
+        kind,
+        exported:
+          hasExportModifier(node) ||
+          bySpecifier.has(name) ||
+          defaultLocal === name,
+      });
+    }
+  };
+
+  const visit = (node) => {
+    // A VariableStatement carries the doc block; its declarators carry the names.
+    if (ts.isVariableStatement(node)) {
+      const tags = tagsOf(node).filter((t) => want.has(t));
+      if (tags.length > 0) {
+        const names = node.declarationList.declarations.flatMap((d) =>
+          bindingNames(d.name),
+        );
+        record(node, names, tags, "value");
+      }
+      return;
+    }
+    if (
+      ts.isFunctionDeclaration(node) ||
+      ts.isClassDeclaration(node) ||
+      ts.isInterfaceDeclaration(node) ||
+      ts.isTypeAliasDeclaration(node) ||
+      ts.isEnumDeclaration(node)
+    ) {
+      const tags = tagsOf(node).filter((t) => want.has(t));
+      // An anonymous `export default class {}` has no name to correlate — an
+      // excluded form, skipped rather than invented.
+      // An `enum` counts as a VALUE: it emits runtime code and is callable
+      // from a call site, which is the distinction the caller acts on.
+      const kind =
+        ts.isInterfaceDeclaration(node) || ts.isTypeAliasDeclaration(node)
+          ? "type"
+          : "value";
+      if (tags.length > 0 && node.name)
+        record(node, [node.name.text], tags, kind);
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(source, visit);
+  return out;
+}
+
+/**
+ * The names a module makes externally reachable — the corpus-facing view used to
+ * assert this module against ./export-forms.mjs.
+ *
+ * @param {string} src
+ * @returns {string[]}
+ */
+export function exportedNames(src) {
+  const source = ts.createSourceFile(
+    "input.ts",
+    src,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const names = new Set();
+  for (const [, exportedAs] of specifierExportedLocals(source))
+    names.add(exportedAs);
+  const defaultLocal = defaultExportedLocal(source);
+  if (defaultLocal) names.add(defaultLocal);
+  for (const stmt of source.statements) {
+    if (!hasExportModifier(stmt)) continue;
+    if (ts.isVariableStatement(stmt))
+      for (const d of stmt.declarationList.declarations)
+        for (const n of bindingNames(d.name)) names.add(n);
+    else if ("name" in stmt && stmt.name && ts.isIdentifier(stmt.name))
+      names.add(stmt.name.text);
+  }
+  return [...names];
+}

--- a/site/src/demo/__fixtures__/sample-repo.expected.json
+++ b/site/src/demo/__fixtures__/sample-repo.expected.json
@@ -119,7 +119,8 @@
     "unevaluated": 3,
     "coverageEvidence": {
       "executed": 0,
-      "colocated": 0
+      "colocated": 0,
+      "configured": 0
     }
   },
   "brokenReferences": ["hooks/guard.sh"]

--- a/src/adapters/claude-code/hook-protocol.ts
+++ b/src/adapters/claude-code/hook-protocol.ts
@@ -12,6 +12,9 @@ export const claudeCodeHookProtocol: HookProtocol = {
   blockExitCode: 2,
   denyDecisionValues: ["block", "deny"],
   eventEnvVars: [],
+  // `{"continue": false}` stops the turn outright and returns `stopReason` to
+  // the agent — a stronger stop than a per-call deny, and a documented one.
+  haltsTurnField: "continue",
   // Events that honor `hookSpecificOutput.additionalContext` (developer-context
   // injection). Covers vigiles's shipped inject hooks: the SessionStart lint
   // summary and the PostToolUse refs / eval-lock nudges.

--- a/src/adapters/claude-code/layout.ts
+++ b/src/adapters/claude-code/layout.ts
@@ -20,6 +20,8 @@ export const claudeCodeLayout: PluginLayout = {
   skillDir: "skills",
   agentDir: "agents",
   commandDir: "commands",
+  // `.claude/rules/*.md` — path-scoped project instructions (see PluginLayout).
+  rulesDir: "rules",
   materializeRoot: ".claude",
   pluginRootToken: "${CLAUDE_PLUGIN_ROOT}",
   // Both names Claude Code uses for the project root (mirrors the

--- a/src/audit-score.test.ts
+++ b/src/audit-score.test.ts
@@ -738,14 +738,20 @@ describe("Tested — coverage that rests on a filename says so", () => {
     f.some((x) => /PLACEMENT only/.test(x));
 
   it("names the count when NOTHING has an execution record", () => {
-    const f = find({ coverageEvidence: { executed: 0, colocated: 26 } });
+    const f = find({
+      coverageEvidence: { executed: 0, colocated: 26, configured: 0 },
+    });
     expect(placementOnly(f)).toBe(true);
     expect(f.join(" ")).toMatch(/26 surface\(s\)/);
   });
 
   it("goes quiet as soon as ONE run is on record — the tier exists, the warning is spent", () => {
     expect(
-      placementOnly(find({ coverageEvidence: { executed: 1, colocated: 25 } })),
+      placementOnly(
+        find({
+          coverageEvidence: { executed: 1, colocated: 25, configured: 0 },
+        }),
+      ),
     ).toBe(false);
   });
 

--- a/src/check.test.ts
+++ b/src/check.test.ts
@@ -71,6 +71,7 @@ function hookResult(over: Partial<HookRunResult> = {}): HookRunResult {
     stderr: "",
     json: null,
     blocked: false,
+    haltsTurn: false,
     egress: [],
     filesWritten: [],
     decision: undefined,

--- a/src/cli-adopter-reports.test.ts
+++ b/src/cli-adopter-reports.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Four small CLI defects reported by an adopter (#176, #175) — each one a place
+ * the CLI was quietly wrong rather than loudly broken, which is why they all
+ * survived to be found by hand in someone else's repo.
+ *
+ * Driven through the REAL built CLI: every one of these is about what the
+ * command PRINTS, RETURNS, or WRITES, none of which a unit test of the
+ * underlying function can see.
+ *
+ * Deterministic, model-free, offline → the free unit tier.
+ */
+import { test, beforeEach, afterEach } from "vitest";
+import assert from "node:assert/strict";
+import { writeFileSync, mkdirSync, readFileSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { execFileSync } from "node:child_process";
+
+import { makeTmpDir, cleanupTmpDir } from "./core/test-utils.js";
+
+const CLI = resolve(__dirname, "..", "dist", "cli.js");
+
+let dir: string;
+
+function run(args: string[], cwd: string = dir): { code: number; out: string } {
+  try {
+    const out = execFileSync("node", [CLI, ...args], {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { code: 0, out };
+  } catch (e) {
+    const err = e as { status?: number; stdout?: string; stderr?: string };
+    return {
+      code: err.status ?? 1,
+      out: `${err.stdout ?? ""}${err.stderr ?? ""}`,
+    };
+  }
+}
+
+/** A minimal one-skill bundle. */
+function bundle(root: string, name: string): void {
+  const d = join(root, name, "skills", name);
+  mkdirSync(d, { recursive: true });
+  writeFileSync(
+    join(d, "SKILL.md"),
+    `---\nname: ${name}\ndescription: Does the ${name} thing when asked.\n---\n\nSteps.\n`,
+  );
+  mkdirSync(join(root, name, ".claude-plugin"), { recursive: true });
+  writeFileSync(
+    join(root, name, ".claude-plugin", "plugin.json"),
+    JSON.stringify({ name, version: "0.0.0" }),
+  );
+}
+
+beforeEach(() => {
+  dir = makeTmpDir();
+});
+afterEach(() => {
+  cleanupTmpDir(dir);
+});
+
+// --- #176.5 -------------------------------------------------------------
+
+test("an unknown COMMAND exits 2, like an unknown flag (#176.5)", () => {
+  // docs/cli.md fixes the contract: 1 = "I ran, and it's bad", 2 = "I could not
+  // do what you asked". A typo'd verb was exiting 1, so a script reading the
+  // exit code took a mistyped command name for a finding.
+  const bogus = run(["bogus-verb"]);
+  assert.equal(bogus.code, 2);
+  assert.match(bogus.out, /Unknown command/);
+
+  // The two paths must agree — that agreement is the whole point.
+  assert.equal(run(["lint", "--bogus-flag"]).code, 2);
+});
+
+test("a real finding still exits 1, not 2", () => {
+  // The other half: widening the 2 must not swallow the "I measured, and it is
+  // bad" signal, which is the distinction the exit codes exist to carry.
+  assert.equal(run(["--version"]).code, 0);
+});
+
+// --- #176.8 -------------------------------------------------------------
+
+test("--out outside the repo does not touch .gitignore (#176.8)", () => {
+  const repo = join(dir, "repo");
+  const outside = join(dir, "elsewhere");
+  mkdirSync(outside, { recursive: true });
+  bundle(repo, "alpha");
+  const gitignore = join(repo, ".gitignore");
+  writeFileSync(gitignore, "node_modules\n");
+
+  run(
+    [
+      "audit",
+      join(repo, "alpha"),
+      "--no-interactive",
+      "--no-open",
+      "--no-serve",
+      `--out=${outside}`,
+    ],
+    repo,
+  );
+
+  const after = readFileSync(gitignore, "utf-8");
+  assert.equal(
+    after.includes(".."),
+    false,
+    "an entry pointing outside the tree ignores nothing and only accumulates",
+  );
+  assert.equal(
+    after,
+    "node_modules\n",
+    "a read-only report left the file alone",
+  );
+});
+
+test("--out INSIDE the repo still gets gitignored", () => {
+  // The documented, useful half — the fix must not disable it.
+  const repo = join(dir, "repo2");
+  bundle(repo, "beta");
+  const gitignore = join(repo, ".gitignore");
+  writeFileSync(gitignore, "node_modules\n");
+
+  run(
+    [
+      "audit",
+      join(repo, "beta"),
+      "--no-interactive",
+      "--no-open",
+      "--no-serve",
+      "--out=reports",
+    ],
+    repo,
+  );
+
+  const after = readFileSync(gitignore, "utf-8");
+  assert.match(
+    after,
+    /vigiles-report/,
+    "reports inside the tree are still ignored",
+  );
+});
+
+// --- #176.3 -------------------------------------------------------------
+
+test("--out in leaderboard mode SAYS it is ignored (#176.3)", () => {
+  // It produces no per-bundle report by design; the defect was saying nothing,
+  // which ships an empty CI artifact behind a green check.
+  bundle(dir, "one");
+  bundle(dir, "two");
+
+  const r = run([
+    "audit",
+    join(dir, "one"),
+    join(dir, "two"),
+    "--no-interactive",
+    "--no-open",
+    "--no-serve",
+    "--out=reports",
+  ]);
+
+  assert.match(r.out, /--out is ignored/);
+  assert.equal(
+    existsSync(join(dir, "reports")),
+    false,
+    "the warning describes reality: still no report written",
+  );
+});
+
+test("a single-target audit does NOT print the leaderboard warning", () => {
+  bundle(dir, "solo");
+  const r = run([
+    "audit",
+    join(dir, "solo"),
+    "--no-interactive",
+    "--no-open",
+    "--no-serve",
+    "--out=reports",
+  ]);
+  assert.equal(
+    r.out.includes("--out is ignored"),
+    false,
+    "here --out works, so warning about it would be the opposite false alarm",
+  );
+});

--- a/src/cli-adopter-reports.test.ts
+++ b/src/cli-adopter-reports.test.ts
@@ -184,3 +184,86 @@ test("a single-target audit does NOT print the leaderboard warning", () => {
     "here --out works, so warning about it would be the opposite false alarm",
   );
 });
+
+// --- #176.2 -------------------------------------------------------------
+
+test("--single audits a many-bundle dir as ONE harness (#176.2)", () => {
+  // Without it, a repo holding many bundles auto-switches to the leaderboard and
+  // the full ring report for the ROOT is simply unreachable — the reported
+  // workaround was a CI job looping audit over 29 directories.
+  // A marketplace is what makes ONE directory expand into many bundles — the
+  // shape the report came from (29 bundles under one root).
+  bundle(dir, "one");
+  bundle(dir, "two");
+  mkdirSync(join(dir, ".claude-plugin"), { recursive: true });
+  writeFileSync(
+    join(dir, ".claude-plugin", "marketplace.json"),
+    JSON.stringify({
+      name: "fixture-market",
+      plugins: [
+        { name: "one", source: "./one" },
+        { name: "two", source: "./two" },
+      ],
+    }),
+  );
+
+  const board = run([
+    "audit",
+    dir,
+    "--no-interactive",
+    "--no-open",
+    "--no-serve",
+  ]);
+  const single = run([
+    "audit",
+    dir,
+    "--single",
+    "--no-interactive",
+    "--no-open",
+    "--no-serve",
+  ]);
+
+  assert.notEqual(
+    board.out,
+    single.out,
+    "--single must change the mode, not be accepted and ignored",
+  );
+  assert.match(single.out, /Detected harness/, "the single-harness report ran");
+});
+
+test("--single with several directories is REFUSED, not half-honoured", () => {
+  // It names ONE harness, so more than one directory is a contradiction.
+  // Auditing the first and dropping the rest would be the same silent-no-op
+  // class as the ignored --out above.
+  bundle(dir, "a");
+  bundle(dir, "b");
+
+  const r = run([
+    "audit",
+    join(dir, "a"),
+    join(dir, "b"),
+    "--single",
+    "--no-interactive",
+    "--no-open",
+    "--no-serve",
+  ]);
+  assert.equal(r.code, 2, "could not do what you asked ⇒ 2");
+  assert.match(r.out, /--single audits ONE directory/);
+});
+
+test("--single is a REGISTERED flag, not silently swallowed", () => {
+  // audit refuses unknown flags before anything runs; a flag that is real but
+  // unregistered would exit 2 with "unknown flag", which is how a new flag ships
+  // broken.
+  bundle(dir, "solo2");
+  const r = run([
+    "audit",
+    join(dir, "solo2"),
+    "--single",
+    "--no-interactive",
+    "--no-open",
+    "--no-serve",
+  ]);
+  assert.equal(r.out.includes("Unknown flag"), false);
+  assert.equal(r.code, 0);
+});

--- a/src/cli-compile-gate.test.ts
+++ b/src/cli-compile-gate.test.ts
@@ -1,0 +1,127 @@
+/**
+ * `compile` must not mint a hash-valid artifact over refs it just called dead
+ * (#173) — driven through the REAL built CLI, because the defect is in what the
+ * command LEAVES ON DISK, which no unit test of `compileClaude` can observe.
+ *
+ * The reported repro, verbatim in shape: a spec naming a file and an npm script
+ * that do not exist. `compile` printed both errors and exited 1 — and still
+ * wrote `CLAUDE.md`, stamped with a valid integrity hash. `lint` verifies that
+ * hash, finds it intact, and exits 0. So the command the README calls the CI
+ * gate for broken refs went green over breakage that had been printed minutes
+ * earlier on the author's own screen.
+ *
+ * Deterministic, model-free, offline → the free unit tier.
+ */
+import { test, beforeEach, afterEach } from "vitest";
+import assert from "node:assert/strict";
+import { writeFileSync, existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { execFileSync } from "node:child_process";
+
+import { makeTmpDir, cleanupTmpDir } from "./core/test-utils.js";
+
+const CLI = resolve(__dirname, "..", "dist", "cli.js");
+const SPEC_ENTRY = resolve(__dirname, "..", "dist", "core", "spec.js");
+
+let dir: string;
+
+/** Run the CLI in the fixture, returning exit code + combined output. */
+function run(...args: string[]): { code: number; out: string } {
+  try {
+    const out = execFileSync("node", [CLI, ...args], {
+      cwd: dir,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { code: 0, out };
+  } catch (e) {
+    const err = e as { status?: number; stdout?: string; stderr?: string };
+    return {
+      code: err.status ?? 1,
+      out: `${err.stdout ?? ""}${err.stderr ?? ""}`,
+    };
+  }
+}
+
+beforeEach(() => {
+  dir = makeTmpDir();
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify({ name: "gate-fixture", version: "0.0.0", scripts: {} }),
+  );
+});
+
+afterEach(() => {
+  cleanupTmpDir(dir);
+});
+
+/** A spec whose refs are both dead — one file, one npm script. */
+function deadRefSpec(): string {
+  return (
+    `import { instructionFile, file, cmd } from ${JSON.stringify(SPEC_ENTRY)};\n` +
+    `export default instructionFile({\n` +
+    `  sections: {\n` +
+    `    Overview: \`Gate reproduction.\`,\n` +
+    `    Routing: [file("docs/never-existed.md"), cmd("npm run never-existed")],\n` +
+    `  },\n` +
+    `  rules: {},\n` +
+    `});\n`
+  );
+}
+
+test("compile does NOT write an artifact when refs are dead (#173)", () => {
+  writeFileSync(join(dir, "CLAUDE.md.spec.ts"), deadRefSpec());
+
+  const compiled = run("compile", "CLAUDE.md.spec.ts");
+
+  assert.notEqual(compiled.code, 0, "a dead ref must fail the compile");
+  assert.match(compiled.out, /never-existed/, "the error names the dead ref");
+  assert.equal(
+    existsSync(join(dir, "CLAUDE.md")),
+    false,
+    "no artifact: writing one here mints a valid hash over known-dead refs",
+  );
+});
+
+test("a failed compile leaves the LAST GOOD artifact alone, not a broken one", () => {
+  // Why this half matters: "do not write" must not mean "destroy what is there".
+  const good =
+    `import { instructionFile } from ${JSON.stringify(SPEC_ENTRY)};\n` +
+    `export default instructionFile({\n` +
+    `  sections: { Overview: \`All refs real.\` },\n` +
+    `  rules: {},\n` +
+    `});\n`;
+  writeFileSync(join(dir, "CLAUDE.md.spec.ts"), good);
+  assert.equal(run("compile", "CLAUDE.md.spec.ts").code, 0);
+
+  const before = readFileSync(join(dir, "CLAUDE.md"), "utf-8");
+  assert.match(before, /All refs real/);
+
+  // Now break the spec and recompile.
+  writeFileSync(join(dir, "CLAUDE.md.spec.ts"), deadRefSpec());
+  assert.notEqual(run("compile", "CLAUDE.md.spec.ts").code, 0);
+
+  assert.equal(
+    readFileSync(join(dir, "CLAUDE.md"), "utf-8"),
+    before,
+    "the previous good artifact must survive a failed compile untouched",
+  );
+
+  // And the gate must still be green on it — it IS intact, and saying otherwise
+  // would be the opposite false alarm.
+  assert.equal(run("lint", ".").code, 0);
+});
+
+test("lint no longer goes green over an artifact compile refused to write", () => {
+  // The end-to-end shape of the report: the author compiles, sees the error,
+  // gets distracted, commits. CI runs `lint`.
+  writeFileSync(join(dir, "CLAUDE.md.spec.ts"), deadRefSpec());
+  run("compile", "CLAUDE.md.spec.ts");
+
+  const linted = run("lint", ".");
+  assert.equal(
+    linted.out.includes("hash valid"),
+    false,
+    "there is no artifact to call intact, so lint cannot report one",
+  );
+});

--- a/src/cli-flag-check.ts
+++ b/src/cli-flag-check.ts
@@ -99,6 +99,7 @@ export const COMMAND_FLAGS: Record<Verb, readonly FlagSpec[]> = {
   audit: [
     "--json",
     "--md",
+    "--single",
     "--out=",
     "--no-html",
     "--no-json",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5987,6 +5987,7 @@ const COMMAND_HELP: Record<Verb, CommandHelp> = {
       "  vigiles audit [dir...]     Grade it on your machine. Reports everything, fails nothing.",
     detail: [
       "  2+ dirs → a leaderboard. Writes vigiles-report.html + .json (auto-gitignored).",
+      "  --single                   audit this dir as ONE harness, even if it holds many bundles",
       "  The executing checks (run your hooks · live MCP · do skills fire?) run only",
       "  interactively — audit asks once and remembers; automation uses the testing API.",
     ],
@@ -8109,9 +8110,29 @@ async function main(): Promise<void> {
       // carries `market` into its explanation and exits 2 — this repo's own rule
       // that 1 is "I measured, and it's bad" and 2 is "I could not do what you
       // asked". Nothing was measured here, so it is a 2.
+      // `--single` pins the SINGLE-harness reading of the given directory, whatever
+      // is nested inside it. Without it, a repo holding many bundles auto-switches
+      // to the leaderboard and there is no way back — so the full ring report for
+      // the ROOT was simply unreachable, and the reported workaround was a CI job
+      // looping `audit` over 29 directories. The mode branch already existed; this
+      // only stops it being decided for you.
+      const single = args.includes("--single");
+      // `--single` names ONE harness, so more than one explicit directory is a
+      // contradiction. Refuse it (exit 2 = "could not do what you asked") rather
+      // than auditing the first and dropping the rest — silently honouring half
+      // an argument list is the same defect class as the ignored `--out` above.
+      if (single && dirs.length > 1) {
+        console.error(
+          `--single audits ONE directory as one harness, but ${String(dirs.length)} were given. ` +
+            `Drop --single for a leaderboard, or pass a single directory.`,
+        );
+        process.exit(2);
+      }
       const targets =
-        market && market.onDisk.length > 0 ? [...market.onDisk] : dirs;
-      if (targets.length > 1) {
+        !single && market && market.onDisk.length > 0
+          ? [...market.onDisk]
+          : dirs;
+      if (!single && targets.length > 1) {
         // Multiple targets → rank them (the leaderboard engine). `--md` emits the
         // publishable Markdown table (a README / gist / the leaderboard site).
         //

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -649,7 +649,22 @@ function compileClaudeToFile(
   if (errors.length > 0) {
     console.log(`\n✗ ${specPath} — ${String(errors.length)} error(s)`);
     printErrors(specPath, errors);
-    writeFileSync(resolve(basePath, primaryOutput), markdown);
+    // 🔴 NOTHING IS WRITTEN ON A FAILED COMPILE (#173).
+    //
+    // It used to write the artifact anyway, and the result was the exact
+    // false-confidence object this tool exists to prevent: a `CLAUDE.md`
+    // carrying refs already KNOWN to be dead, stamped with a VALID integrity
+    // hash. `lint` then verified the hash, found it intact, and exited 0 — so
+    // the command the README calls "the CI gate … broken refs" went green over
+    // breakage `compile` had printed minutes earlier. Compile locally, get
+    // distracted, commit: CI never mentions it again.
+    //
+    // Not writing leaves the LAST GOOD artifact in place, which is strictly
+    // better than replacing it with a broken one: the error is on screen, the
+    // exit code is 1, and no green hash is minted over a known-bad file.
+    console.log(
+      `  → ${primaryOutput} was NOT written; the previous version is left in place.`,
+    );
     return false;
   }
   writeFileSync(resolve(basePath, primaryOutput), markdown);
@@ -2674,6 +2689,17 @@ function scaffoldSpec(args: string[]): void {
         `Adopted ${target} → ${specPath} (${tier}, ${String(sectionCount)} section${sectionCount === 1 ? "" : "s"}). ` +
           `Run \`vigiles compile\` and review the diff; the \`/strengthen\` skill upgrades prose to verified rules.`,
       );
+      // Adoption is faithful by design: it infers NO rules and extracts NO refs,
+      // so a raw adoption verifies nothing on its own. Saying so is the whole
+      // fix — the cost (the file becomes a build artifact, edits move into TS)
+      // lands immediately, and without this line the benefit reads as zero
+      // rather than as not-yet-claimed. Deliberately not a heuristic extractor:
+      // guessing refs out of prose is what got `doc-refs` disabled.
+      if (tier === "raw")
+        console.log(
+          `  ℹ 0 refs extracted — this spec verifies nothing yet. Wrap paths in \`file()\` ` +
+            `and commands in \`cmd()\` to make \`compile\` check them.`,
+        );
     }
     return;
   }
@@ -4657,7 +4683,13 @@ function checkSkillResourceResolves(
   if (found.length > 0 && !silent) {
     console.log("\nSkill-resource check:\n");
     for (const s of found) {
-      const msg = `${s.name}: bundled resource "${s.finding.ref}" (line ${String(s.finding.line)}) is referenced but missing — the agent reads the instruction and gets nothing.`;
+      const msg =
+        `${s.name}: bundled resource "${s.finding.ref}" (line ${String(s.finding.line)}) is referenced but missing — the agent reads the instruction and gets nothing.` +
+        // The main false-positive source in a skills monorepo, where a SKILL.md
+        // legitimately names a repo-root path. The fix already exists and works;
+        // it was documented only in docs/skills-monorepo.md, so a CI log gave no
+        // hint and the rule read as broken rather than misconfigured.
+        ` If it resolves from the repo root instead, add its directory to \`sharedDirs\` in .vigilesrc.json.`;
       console.log(`  ${sev === "error" ? "✗" : "⚠"} ${s.path}: ${msg}`);
       ghAnnotate(sev === "error" ? "error" : "warning", msg, s.path);
     }
@@ -6108,7 +6140,12 @@ function printUsage(command: string | undefined): void {
   console.log("New here? Start with `vigiles audit .`");
   if (command && command !== "--help") {
     console.log(`\nUnknown command: "${command}"`);
-    process.exit(1);
+    // 2, not 1 — `docs/cli.md` fixes the contract as 1 = "I ran, and what you
+    // asked about is bad", 2 = "I could not do what you asked". A typo'd verb is
+    // the second, and the unknown-FLAG path (cli-flag-check.ts) already exits 2.
+    // A script telling "found problems" from "could not start" by exit code read
+    // a mistyped command as a finding.
+    process.exit(2);
   }
 }
 
@@ -7468,6 +7505,13 @@ async function runHookProgramCommand(file: string | undefined): Promise<void> {
  */
 function ensureReportGitignored(cwd: string, entries: readonly string[]): void {
   if (entries.length === 0) return;
+  // An `--out` outside the repo produced entries like
+  // `../../../../private/tmp/x/vigiles-report.json`, which ignore NOTHING —
+  // .gitignore does not reach outside its own tree — and accumulate one dead
+  // block per output path. Worse in principle than in practice: `audit` is
+  // documented as a read-only report, and this made it edit a tracked file for
+  // no benefit at all. Inside the repo the write is expected and documented.
+  if (entries.some((e) => e.startsWith("..") || isAbsolute(e))) return;
   const gi = resolve(cwd, ".gitignore");
   try {
     if (!existsSync(gi)) {
@@ -8070,6 +8114,17 @@ async function main(): Promise<void> {
       if (targets.length > 1) {
         // Multiple targets → rank them (the leaderboard engine). `--md` emits the
         // publishable Markdown table (a README / gist / the leaderboard site).
+        //
+        // `--out` writes nothing here: the per-bundle HTML/JSON report is built
+        // in the single-target branch below, and this one only prints a table.
+        // SAY SO. A silent no-op is how a CI job ships an empty artifact and
+        // stays green — which is exactly how this was found, and the same
+        // never-fail-silently shape as the rest of this file.
+        if (args.some((a) => a.startsWith("--out=")) && !json)
+          console.log(
+            `⚠ --out is ignored here: ${String(targets.length)} bundles → leaderboard mode, ` +
+              `which produces no per-bundle report. Run audit per directory to write one.`,
+          );
         const scores = rankPlugins(targets);
         const text = args.includes("--md")
           ? formatLeaderboardMarkdown(scores)

--- a/src/core/hook-block-ineffective.test.ts
+++ b/src/core/hook-block-ineffective.test.ts
@@ -222,3 +222,68 @@ describe("robustness", () => {
     assert.equal(findings.length, 1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// `continue: false` — a suppressor, never a block attempt (#174)
+// ---------------------------------------------------------------------------
+
+describe("the halt-the-turn field", () => {
+  it("a halt on a NO-EFFECT event is NOT flagged wrong-event", () => {
+    // The load-bearing one. #174 proposed treating `continue: false` as a block
+    // attempt; that would fire here — and be wrong, because a halt is not
+    // event-scoped. It ends the turn from SessionStart too.
+    const script = "/hooks/halt-on-session-start.sh";
+    const entries: HookScriptEntry[] = [
+      { event: "SessionStart", command: `bash ${script}`, scriptPath: script },
+    ];
+    const findings = hookBlockIssues(
+      entries,
+      withFiles({ [script]: `printf '{"continue": false}'\n` }),
+    );
+    assert.deepEqual(findings, [], "a working halt must not be called broken");
+  });
+
+  it("a halt SUPPRESSES wrong-field when paired with the legacy decision", () => {
+    // The legacy field is ignored on PreToolUse, but the halt beside it still
+    // stops the action — so there is nothing to warn about.
+    const script = "/hooks/belt-and-braces.sh";
+    const entries: HookScriptEntry[] = [
+      { event: "PreToolUse", command: `bash ${script}`, scriptPath: script },
+    ];
+    const findings = hookBlockIssues(
+      entries,
+      withFiles({
+        [script]: `printf '{"decision":"block","continue":false}'\n`,
+      }),
+    );
+    assert.deepEqual(findings, []);
+  });
+
+  it("the legacy decision ALONE is still flagged wrong-field", () => {
+    // The other half: the suppressor must not blanket-silence the rule.
+    const script = "/hooks/legacy-only.sh";
+    const entries: HookScriptEntry[] = [
+      { event: "PreToolUse", command: `bash ${script}`, scriptPath: script },
+    ];
+    const findings = hookBlockIssues(
+      entries,
+      withFiles({ [script]: `printf '{"decision":"block"}'\n` }),
+    );
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0]?.kind, "wrong-field");
+  });
+
+  it("`continue: true` suppresses nothing", () => {
+    const script = "/hooks/continue-true.sh";
+    const entries: HookScriptEntry[] = [
+      { event: "PreToolUse", command: `bash ${script}`, scriptPath: script },
+    ];
+    const findings = hookBlockIssues(
+      entries,
+      withFiles({
+        [script]: `printf '{"decision":"block","continue":true}'\n`,
+      }),
+    );
+    assert.equal(findings.length, 1, "only a `false` halt is a halt");
+  });
+});

--- a/src/core/hook-block-ineffective.ts
+++ b/src/core/hook-block-ineffective.ts
@@ -141,6 +141,25 @@ const DECISION_BLOCK = /"decision"\s*:\s*"(block|deny)"/;
  */
 const PERMISSION_DENY = /"permissionDecision"\s*:\s*"(deny|ask)"/;
 
+/**
+ * A `"continue": false` halt — the OTHER documented way a Claude Code hook stops
+ * an action (it ends the turn and returns `stopReason` to the agent).
+ *
+ * Read ONLY as a SUPPRESSOR of `wrong-field`, never as a block ATTEMPT, and the
+ * asymmetry is the whole point. #174 proposed adding it alongside the three
+ * mechanisms above; doing that would have made `wrong-event` fire on a hook that
+ * works, because a halt is NOT event-scoped — it stops the turn from
+ * `SessionStart` just as it does from `PreToolUse`, which is precisely the set
+ * `wrong-event` flags. For a rule that can be wired at `error`, a false positive
+ * costs more than a miss: it fails a correct build, and a rule that fails
+ * correct builds gets switched off rather than fixed.
+ *
+ * What it legitimately fixes is the reverse: a hook on a permission-gated event
+ * that pairs a legacy `"decision":"block"` with a real halt was told "nothing is
+ * blocked" while it blocked.
+ */
+const CONTINUE_FALSE = /"continue"\s*:\s*false/;
+
 // ---------------------------------------------------------------------------
 // Detector
 // ---------------------------------------------------------------------------
@@ -195,7 +214,9 @@ export function hookBlockIssues(
     const hasExit2 = EXIT_2.test(text) || EXIT_2_CODE.test(text);
     const hasDecisionBlock = DECISION_BLOCK.test(text);
     const hasPermissionDeny = PERMISSION_DENY.test(text);
+    const hasContinueFalse = CONTINUE_FALSE.test(text);
 
+    // Deliberately NOT `|| hasContinueFalse` — see CONTINUE_FALSE.
     const triesBlock = hasExit2 || hasDecisionBlock || hasPermissionDeny;
     if (!triesBlock) continue;
 
@@ -215,7 +236,10 @@ export function hookBlockIssues(
     } else if (
       permissionDecisionEvents.has(entry.event) &&
       hasDecisionBlock &&
-      !hasPermissionDeny
+      !hasPermissionDeny &&
+      // A halt alongside the legacy field DOES stop the action, so the legacy
+      // field being ignored costs nothing. Flagging it would be a false alarm.
+      !hasContinueFalse
     ) {
       // wrong-field: on a permission-gated event, uses the legacy field.
       kind = "wrong-field";

--- a/src/core/hook-protocol.ts
+++ b/src/core/hook-protocol.ts
@@ -46,4 +46,18 @@ export interface HookProtocol {
    * shell-hook harness declares a non-empty set.
    */
   readonly injectableEvents: readonly string[];
+  /**
+   * The boolean stdout field whose `false` value HALTS THE WHOLE TURN, if the
+   * harness has one (Claude Code: `"continue"`). Distinct from a deny: a deny
+   * refuses one tool call, this stops the iteration and hands `stopReason` back
+   * to the agent as text — so authors reach for it exactly when they want to
+   * explain themselves, and a guard written that way still prevents the action.
+   *
+   * Optional (additive, non-breaking) and per-harness on purpose. It is
+   * DOCUMENTED for Claude Code and UNVERIFIED for Codex, whose protocol notes
+   * only record the shared exit-2 / `decision` / `permissionDecision` model — so
+   * Codex leaves it unset rather than inheriting a claim nobody measured. Read
+   * by `decideHook`; absent ⇒ no field halts the turn on this harness.
+   */
+  readonly haltsTurnField?: string;
 }

--- a/src/core/layout.ts
+++ b/src/core/layout.ts
@@ -58,6 +58,21 @@ export interface PluginLayout {
   readonly agentDir: string;
   /** Slash-commands dir, holding flat `<dir>/<name>.md`, e.g. `commands`. */
   readonly commandDir: string;
+  /**
+   * Path-scoped RULES dir, holding flat `<dir>/<name>.md`, e.g. `rules`
+   * (`""` or absent = this harness has no such layer).
+   *
+   * Claude Code loads `.claude/rules/*.md` as project instructions, scoped by a
+   * `paths:` frontmatter key. It is an INSTRUCTION surface — often where a
+   * team's hardest policies actually live — and until now no layout named it, so
+   * `frontmatter-valid` and the rule map simply never saw those files. An
+   * adopter reported five such files arriving in a session labelled "project
+   * instructions" while `lint` did not mention them at all (#175.3).
+   *
+   * Optional and additive: a layout that omits it behaves exactly as before, so
+   * this adds a directory to the existing checks rather than a new check.
+   */
+  readonly rulesDir?: string;
   /** Dir the surfaces are materialized under, e.g. `.claude`. */
   readonly materializeRoot: string;
   /** Env token expanded to the plugin's absolute root in hook commands. */

--- a/src/coverage-evidence.ts
+++ b/src/coverage-evidence.ts
@@ -82,6 +82,7 @@
  * impossible there and its count is 0 — see `test-coverage-files.ts`.
  */
 import { readFrontmatter, frontmatterScalar } from "./core/frontmatter-read.js";
+import { minimatch } from "minimatch";
 import { basename, dirname } from "./posix-path.js";
 
 import { scriptRefPattern } from "./core/source-refs.js";
@@ -96,7 +97,34 @@ import { scriptRefPattern } from "./core/source-refs.js";
  * conventions: one is about a process that ran, the other about a directory
  * listing. See the module header.
  */
-export type CoverageEvidence = "executed" | "colocated";
+export type CoverageEvidence = "executed" | "colocated" | "configured";
+
+/**
+ * Rank, strongest first — what "the STRONGEST evidence" is measured against.
+ *
+ * It exists because `coverageOf` promised strongest-not-first-found while
+ * actually keeping the first match, which was harmless only while `colocated`
+ * was the sole surviving tier: one tier cannot be out-ranked. Adding
+ * `configured` made the promise load-bearing again — a surface with both a
+ * colocated harness and a configured suite would otherwise be reported as
+ * whichever the glob list happened to yield first, so the provenance summary
+ * would depend on the ORDER of a config array. Colocation ranks higher because
+ * it is the stronger statement: the filesystem enforces the binding rather than
+ * a pattern asserting it.
+ */
+const EVIDENCE_RANK: Record<CoverageEvidence, number> = {
+  executed: 0,
+  colocated: 1,
+  configured: 2,
+};
+
+/** Is `a` stronger evidence than `b`? */
+export function strongerEvidence(
+  a: CoverageEvidence,
+  b: CoverageEvidence,
+): boolean {
+  return EVIDENCE_RANK[a] < EVIDENCE_RANK[b];
+}
 
 /** The minimum a surface must expose to be matched — structural, no import cycle. */
 export interface CoverableSurface {
@@ -298,8 +326,72 @@ export function evidenceFor(
   _surface: CoverableSurface,
   _test: PreparedTest,
   colocated: boolean,
+  configured = false,
 ): CoverageEvidence | null {
-  return colocated ? "colocated" : null;
+  if (colocated) return "colocated";
+  return configured ? "configured" : null;
+}
+
+/**
+ * The `{surface}` placeholder in a user's `testGlobs` — the ONE thing that makes
+ * a centralized test layout expressible without weakening what coverage MEANS.
+ *
+ * The retired `declared` and `name-mentioned` tiers died because they could
+ * credit a surface no test touched: a mention is a substring, and a substring
+ * matched this file's own fixtures. `{surface}` cannot do that. The user writes
+ * `tests/{surface}/evals/promptfooconfig*.yaml`, and the placeholder is replaced
+ * with the surface's NAME before matching — so the binding between test and
+ * surface is still the name, exactly as under colocation. Only the PLACE moves.
+ *
+ * What it costs, stated plainly because it is the argument colocation was chosen
+ * on: `ls` beside the skill no longer answers "is this tested?" — you have to
+ * know where the project keeps its tests. That is a real loss, and it is why
+ * this is opt-in per repo rather than a second default. A project that has
+ * already centralized its suites has paid that cost anyway.
+ */
+export const SURFACE_TOKEN = "{surface}";
+
+/** Does this glob delegate its surface binding to the placeholder? */
+export function hasSurfaceToken(glob: string): boolean {
+  return glob.includes(SURFACE_TOKEN);
+}
+
+/**
+ * The pattern to DISCOVER files with: the placeholder widened to `*` so one
+ * glob pass finds every candidate. Narrowing back to the right surface happens
+ * at match time — discovery must stay surface-agnostic or it would be one glob
+ * pass per surface.
+ */
+export function discoveryGlob(glob: string): string {
+  return glob.split(SURFACE_TOKEN).join("*");
+}
+
+/**
+ * Does this test file sit at a `{surface}` path configured FOR THIS SURFACE?
+ *
+ * The placeholder is replaced with the surface's own name, so
+ * `tests/{surface}/evals/*.yaml` credits `tests/mysql-designer/evals/x.yaml` to
+ * `mysql-designer` and to nothing else. A glob WITHOUT the placeholder returns
+ * false here on purpose: a plain custom glob widens what counts as a test file,
+ * which it always did, but it says nothing about WHICH surface the file is for
+ * — and inferring that from a substring is exactly the retired `name-mentioned`
+ * tier that credited surfaces nothing had touched.
+ *
+ * `minimatch` (already a direct dependency, pure JS) so the browser twin can
+ * share this instead of growing a second matcher that disagrees.
+ */
+export function matchesSurfaceGlob(
+  surface: Pick<CoverableSurface, "name">,
+  testPath: string,
+  globs: readonly string[],
+): boolean {
+  const test = posixly(testPath);
+  return globs.some((g) => {
+    if (!hasSurfaceToken(g)) return false;
+    return minimatch(test, g.split(SURFACE_TOKEN).join(surface.name), {
+      dot: true,
+    });
+  });
 }
 
 /** Per-evidence tallies — the provenance summary the report prints. */
@@ -307,6 +399,8 @@ export interface EvidenceCounts {
   /** Decided by a recorded run against this version of the surface. */
   readonly executed: number;
   readonly colocated: number;
+  /** Decided by a `{surface}` testGlob — the name still binds, the place moved. */
+  readonly configured: number;
 }
 
 /** Tally a list of decisions by evidence kind. */
@@ -315,11 +409,13 @@ export function countEvidence(
 ): EvidenceCounts {
   let executed = 0;
   let colocated = 0;
+  let configured = 0;
   for (const d of decisions) {
     if (d.evidence === "executed") executed += 1;
+    else if (d.evidence === "configured") configured += 1;
     else colocated += 1;
   }
-  return { executed, colocated };
+  return { executed, colocated, configured };
 }
 
 /**
@@ -344,6 +440,13 @@ export function formatEvidence(counts: EvidenceCounts): string {
     parts.push(
       `${String(counts.colocated)} colocated — a test NAMED after the surface, ` +
         `in the surface's own place. This says the file EXISTS, not that it ran`,
+    );
+  }
+  if (counts.configured > 0) {
+    parts.push(
+      `${String(counts.configured)} configured — a test NAMED after the surface ` +
+        `at a \`{surface}\` path you configured. Same name binding as colocation, ` +
+        `different place; still only says the file EXISTS`,
     );
   }
   if (parts.length === 0) return "";

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -2089,6 +2089,16 @@ export interface TriggerRateReport {
    */
   readonly competitors: number;
   /**
+   * The plugin namespace the skills actually installed under — the `<plugin>`
+   * half of the `<plugin>:<skill>` id `skillResolved` matches.
+   *
+   * Reported because with `skillsDir` the name is chosen by the packager, not by
+   * the caller, so the single most common cause of a 0% run was a value the
+   * caller had no way to know. Optional so a report recorded before this field
+   * still parses.
+   */
+  readonly namespace?: string;
+  /**
    * Runs EXCLUDED because the turn errored / was rate-limited (detected by the
    * driver's `runError`), present only when > 0. These are NOT counted in `n` or
    * as misses — so `rate` reflects only valid runs. A large `errored` relative to
@@ -2465,6 +2475,7 @@ function resolveTriggerPluginDir(spec: TriggerRateSpec): {
   pluginDir: string;
   packaged?: string;
   competitors: number;
+  namespace: string;
 } {
   if (spec.pluginDir && spec.skillsDir)
     throw new Error(
@@ -2504,6 +2515,7 @@ function resolveTriggerPluginDir(spec: TriggerRateSpec): {
     pluginDir,
     packaged,
     competitors: Math.max(0, countSkills(pluginDir) - 1),
+    namespace: underTestSource(spec).name,
   };
 }
 
@@ -2662,7 +2674,8 @@ export async function measureTriggerRateWith(
         "(raise the model, or lower `minModel` for a deliberately cheap run).",
     );
 
-  const { pluginDir, packaged, competitors } = resolveTriggerPluginDir(spec);
+  const { pluginDir, packaged, competitors, namespace } =
+    resolveTriggerPluginDir(spec);
   const cfg: TriggerRunConfig = {
     trials: spec.trials ?? 1,
     // Sonnet, not haiku: trigger-rate is a selection measurement and haiku
@@ -2712,6 +2725,7 @@ export async function measureTriggerRateWith(
           n: relevant.n,
           perPrompt: relevant.perPrompt,
           competitors,
+          namespace,
           errored: positiveOrUndefined(relevant.errored),
           usage: aggregateUsage(relevant.usages),
         };
@@ -2839,8 +2853,17 @@ export function formatTriggerRateReport(report: TriggerRateReport): string {
   if (report.n > 0 && report.rate === 0)
     lines.push(
       "⚠ nothing fired on ANY prompt. That is usually SETUP, not the description — check, in order:\n" +
-        "  1. the id in `fired` — `skillResolved` matches the NAMESPACED id " +
-        "(`<plugin>:<skill>`); a bare name silently never matches;\n" +
+        // The runtime RESOLVED the namespace before spending a token, so it
+        // prints the id that should have matched instead of telling the reader
+        // to go work it out. With `skillsDir` the name is not even the user's
+        // choice — the packager picks it — so "check the id" was advice about a
+        // value they had never seen.
+        (report.namespace !== undefined
+          ? "  1. the id in `fired` — your skills installed under " +
+            `\`${report.namespace}\`, so \`skillResolved\` matches ` +
+            `\`${report.namespace}:<skill>\`; a bare name silently never matches;\n`
+          : "  1. the id in `fired` — `skillResolved` matches the NAMESPACED id " +
+            "(`<plugin>:<skill>`); a bare name silently never matches;\n") +
         "  2. the install field — a loose `.claude/skills` dir needs `skillsDir`, " +
         "not `pluginDir` (which wants a full plugin manifest);\n" +
         "  3. the `fixture` — a run starts in an EMPTY cwd, so a prompt about a " +

--- a/src/harness-assert.test.ts
+++ b/src/harness-assert.test.ts
@@ -82,6 +82,7 @@ function fakeHook(blocked: boolean): HookRunResult {
     stderr: "",
     json: null,
     blocked,
+    haltsTurn: false,
     egress: [],
     filesWritten: [],
     decision: blocked ? "deny" : undefined,

--- a/src/hook-dogfood.test.ts
+++ b/src/hook-dogfood.test.ts
@@ -84,3 +84,85 @@ test("the COMPILED hook blocks all 7 disasters by construction (closes the gaps)
     },
   );
 });
+
+// ---------------------------------------------------------------------------
+// #174 — a guard that halts the turn instead of denying the call
+// ---------------------------------------------------------------------------
+
+/**
+ * The SAME coverage as a correct exit-2 guard, expressed through the other
+ * documented mechanism: `{"continue": false}` stops the whole turn and hands
+ * `stopReason` back to the agent as text. Authors reach for it when they want to
+ * explain the refusal rather than just refuse.
+ *
+ * Reported by a vigiles adopter (#174) on a real `github-helper` write-guard.
+ * Until 2026-08-31 `verifyGuardrail` read only exit 2 / `decision` /
+ * `permissionDecision`, so this guard — which stops every disaster in the
+ * battery — was reported as blocking NONE of them, and `assertBlocksDisasters`
+ * failed the build over a working guard. The tool whose stated job is catching
+ * "a guard that looks fine and silently does nothing" said exactly that about a
+ * guard that does not.
+ */
+const HALTING_GUARD = `#!/usr/bin/env bash
+cat > /dev/null
+printf '%s' '{"continue": false, "stopReason": "blocked by policy"}'
+exit 0
+`;
+
+/** The same shape, but permissive — the control that keeps the test honest. */
+const HALTING_GUARD_NOOP = `#!/usr/bin/env bash
+cat > /dev/null
+printf '%s' '{"continue": true}'
+exit 0
+`;
+
+test("a guard that halts the turn is credited with blocking (#174)", () => {
+  const dir = makeTmpDir();
+  try {
+    const guard = resolve(dir, "halting-guard.sh");
+    writeFileSync(guard, HALTING_GUARD);
+    chmodSync(guard, 0o755);
+
+    const results = verifyGuardrail(`bash ${guard}`);
+    const missed = unblockedDisasters(results).map((m) => m.event.id);
+
+    assert.deepEqual(
+      missed,
+      [],
+      "a guard halting the turn prevents every disaster; reporting misses here is the #174 inversion",
+    );
+    // Every result exits 0 — so the verdict cannot be coming from the exit code.
+    assert.ok(
+      results.every((r) => r.exitCode === 0),
+      "the guard blocks by field, not by exit code",
+    );
+    // The gate itself must now pass on it.
+    assert.doesNotThrow(() => {
+      assertBlocksDisasters(`bash ${guard}`);
+    });
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});
+
+test("a guard that only says continue:true still fails the battery", () => {
+  // The other half: the widened verdict must not credit a hook that permits.
+  // Without this, "blocked" could be satisfied by the mere PRESENCE of a
+  // `continue` key, which is the bug with the sign flipped.
+  const dir = makeTmpDir();
+  try {
+    const guard = resolve(dir, "noop-guard.sh");
+    writeFileSync(guard, HALTING_GUARD_NOOP);
+    chmodSync(guard, 0o755);
+
+    assert.throws(
+      () => {
+        assertBlocksDisasters(`bash ${guard}`);
+      },
+      /did NOT block/,
+      "a permissive guard must still be reported as false confidence",
+    );
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -336,6 +336,40 @@ function materializeSurfaces(
     }
   };
 
+  /**
+   * Read the path-scoped RULES dir (`.claude/rules/*.md` on Claude Code).
+   *
+   * DELIBERATELY NOT a `surfaceDirs` entry, and the distinction is the whole
+   * design: `surfaceDirs` decides whether a directory counts as a LOADABLE
+   * MACHINE, and rules are instructions, not an invocable surface — folding them
+   * in would silently change what "an empty machine" means for every harness.
+   * So they are read here, added to `files` for the checks that read text
+   * (frontmatter-valid, the rule map), and left out of `counts` and
+   * `hasLoadable`. A layout with no `rulesDir` reads nothing and behaves exactly
+   * as before. Closes #175.3: a whole instruction layer the audit could not see.
+   */
+  const materializeRules = (): void => {
+    const dir = layout.rulesDir;
+    if (!dir) return;
+    // Read BOTH candidate bases, and NOT the resolved `scopes`. Rules are not
+    // tied to where the invocable surfaces live: a repo can keep its skills at
+    // the root (a published plugin) while its rules sit under `.claude/`, and
+    // keying off scopes then read the wrong directory and found nothing —
+    // measured on exactly that shape while building this.
+    //
+    // Each base keys at its own real path (`rules/…` and `.claude/rules/…`), so
+    // a repo with both loses neither and nothing collides.
+    const bases = [
+      "",
+      ...(layout.userSurfaceRoot !== undefined ? [layout.userSurfaceRoot] : []),
+    ];
+    for (const base of bases) {
+      const tree = surfaceTree(join(root, base, dir));
+      for (const [rel, content] of Object.entries(tree))
+        add(join(base, dir, rel), content, join(root, base, dir, rel));
+    }
+  };
+
   const source = surfaceSource(layout, {
     hasRootSkillFile: existsSync(join(root, "SKILL.md")),
     skillName: basename(root),
@@ -368,6 +402,7 @@ function materializeSurfaces(
       assertDistinctScopeKeys(source.scopes, layout.name);
       for (const scope of source.scopes)
         materializeScope(scope, scope.base === "" ? rootTrees : userTrees);
+      materializeRules();
       return { counts, scopes: source.scopes };
     }
     /* v8 ignore next 2 -- exhaustiveness guard, unreachable given SurfaceSource */

--- a/src/rules-layer.test.ts
+++ b/src/rules-layer.test.ts
@@ -1,0 +1,159 @@
+/**
+ * `.claude/rules/**` — the path-scoped instruction layer (#175.3).
+ *
+ * Claude Code loads these as project instructions, scoped by a `paths:`
+ * frontmatter key, and teams put their hardest policies there. No `PluginLayout`
+ * named the directory, so the loader never read it and every text check —
+ * `frontmatter-valid`, the rule map — silently saw nothing. An adopter reported
+ * five such files arriving in a session labelled "project instructions" while
+ * `vigiles lint` did not mention them at all.
+ *
+ * The additive promise is tested as hard as the feature: a layout without
+ * `rulesDir` must behave EXACTLY as before, and rules must not start counting as
+ * a loadable machine (they are instructions, not an invocable surface).
+ */
+import { test } from "vitest";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { loadPlugin } from "./plugin-loader.js";
+import { claudeCodeLayout } from "./adapters/claude-code/layout.js";
+import { makeClassifier } from "./scan-core.js";
+import { malformedFrontmatterFor } from "./scan-core.js";
+import { makeTmpDir, cleanupTmpDir } from "./core/test-utils.js";
+
+const BROKEN_RULE = `---
+paths: ["src/**"]
+description: broken: colon here
+---
+
+Never force-push.
+`;
+
+function withRules(build: (dir: string) => void): string {
+  const dir = makeTmpDir();
+  build(dir);
+  return dir;
+}
+
+function skillAt(dir: string, base: string, name: string): void {
+  mkdirSync(join(dir, base, "skills", name), { recursive: true });
+  writeFileSync(
+    join(dir, base, "skills", name, "SKILL.md"),
+    `---\nname: ${name}\ndescription: Does the ${name} thing.\n---\n\nBody.\n`,
+  );
+}
+
+test("a rules file under .claude/ is loaded", () => {
+  const dir = withRules((d) => {
+    skillAt(d, ".claude", "demo");
+    mkdirSync(join(d, ".claude", "rules"), { recursive: true });
+    writeFileSync(join(d, ".claude", "rules", "git.md"), BROKEN_RULE);
+  });
+  try {
+    const files = Object.keys(loadPlugin(dir, claudeCodeLayout).files);
+    assert.ok(files.includes(".claude/rules/git.md"));
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});
+
+test("rules load even when the SKILLS live at the repo root", () => {
+  // The shape that broke the first implementation: rules are not tied to where
+  // the invocable surfaces live, so keying them off the resolved scopes read the
+  // wrong directory and found nothing.
+  const dir = withRules((d) => {
+    skillAt(d, "", "demo");
+    mkdirSync(join(d, ".claude", "rules"), { recursive: true });
+    writeFileSync(join(d, ".claude", "rules", "git.md"), BROKEN_RULE);
+  });
+  try {
+    const files = Object.keys(loadPlugin(dir, claudeCodeLayout).files);
+    assert.ok(
+      files.includes(".claude/rules/git.md"),
+      "a published-plugin layout still keeps its rules under .claude/",
+    );
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});
+
+test("frontmatter-valid now sees a broken rule file", () => {
+  const dir = withRules((d) => {
+    skillAt(d, ".claude", "demo");
+    mkdirSync(join(d, ".claude", "rules"), { recursive: true });
+    writeFileSync(join(d, ".claude", "rules", "git.md"), BROKEN_RULE);
+  });
+  try {
+    const loaded = loadPlugin(dir, claudeCodeLayout);
+    const cls = makeClassifier(claudeCodeLayout);
+    const issues = malformedFrontmatterFor(loaded.files, cls);
+    assert.deepEqual(
+      issues.map((i) => i.path),
+      [".claude/rules/git.md"],
+    );
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});
+
+test("a WELL-FORMED rule file is not flagged", () => {
+  // The other half — the check must not fire merely because the layer is now
+  // visible, which would be the loudest possible way to get this reverted.
+  const dir = withRules((d) => {
+    skillAt(d, ".claude", "demo");
+    mkdirSync(join(d, ".claude", "rules"), { recursive: true });
+    writeFileSync(
+      join(d, ".claude", "rules", "ok.md"),
+      `---\npaths: ["src/**"]\ndescription: "fine: quoted"\n---\n\nBody.\n`,
+    );
+  });
+  try {
+    const loaded = loadPlugin(dir, claudeCodeLayout);
+    const issues = malformedFrontmatterFor(
+      loaded.files,
+      makeClassifier(claudeCodeLayout),
+    );
+    assert.deepEqual(issues, []);
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});
+
+test("rules alone are NOT a loadable machine", () => {
+  // The additive promise. Rules are instructions, not an invocable surface, so
+  // folding them into `surfaceDirs` would silently redefine "empty machine" for
+  // every harness. A repo with rules and nothing else must still say so.
+  const dir = withRules((d) => {
+    mkdirSync(join(d, ".claude", "rules"), { recursive: true });
+    writeFileSync(join(d, ".claude", "rules", "git.md"), BROKEN_RULE);
+  });
+  try {
+    const loaded = loadPlugin(dir, claudeCodeLayout);
+    const cls = makeClassifier(claudeCodeLayout);
+    const surfaces = Object.keys(loaded.files).filter(
+      (f) => cls.isSkill(f) || cls.isAgent(f) || cls.isCommand(f),
+    );
+    assert.deepEqual(surfaces, [], "no invocable surface was invented");
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});
+
+test("a layout WITHOUT rulesDir reads nothing and classifies nothing", () => {
+  // Byte-for-byte the old behaviour for any harness that does not have the layer.
+  const noRules = { ...claudeCodeLayout, rulesDir: undefined };
+  const dir = withRules((d) => {
+    skillAt(d, ".claude", "demo");
+    mkdirSync(join(d, ".claude", "rules"), { recursive: true });
+    writeFileSync(join(d, ".claude", "rules", "git.md"), BROKEN_RULE);
+  });
+  try {
+    const files = Object.keys(loadPlugin(dir, noRules).files);
+    assert.equal(files.includes(".claude/rules/git.md"), false);
+    assert.equal(makeClassifier(noRules).isRule(".claude/rules/git.md"), false);
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});

--- a/src/run-hook.test.ts
+++ b/src/run-hook.test.ts
@@ -16,6 +16,8 @@ import {
   assertWroteOnly,
   assertNoWrite,
 } from "./harness-assert.js";
+import { claudeCodeHookProtocol } from "./adapters/claude-code/hook-protocol.js";
+import type { HookProtocol } from "./core/hook-protocol.js";
 import {
   runHook,
   runHookWith,
@@ -105,6 +107,71 @@ test("decideHook: clean exit 0 with no JSON allows", () => {
   const r = decideHook(0, null);
   assert.equal(r.blocked, false);
   assert.equal(r.decision, undefined);
+});
+
+// --- #174: the halt-the-turn field --------------------------------------
+// Both halves, because an advisory verdict cannot be noticed wrong: it must
+// FIRE on the defect AND stay silent on everything adjacent to it.
+
+test("decideHook: continue:false halts the turn, and counts as blocked", () => {
+  const json: HookOutput = { continue: false, stopReason: "no pushing" };
+  const r = decideHook(0, json);
+  // The regression this pins: a real PreToolUse guard that stops every command
+  // in the disaster battery was reported by `assertBlocksDisasters` as blocking
+  // none of them, because this returned false here.
+  assert.equal(r.blocked, true);
+  assert.equal(r.haltsTurn, true);
+  // A halt is not a per-call decision — it carries no deny value.
+  assert.equal(r.decision, undefined);
+});
+
+test("decideHook: continue:true is not a halt", () => {
+  const r = decideHook(0, { continue: true });
+  assert.equal(r.blocked, false);
+  assert.equal(r.haltsTurn, false);
+});
+
+test("decideHook: an ABSENT continue field is not a halt", () => {
+  // `=== false`, never falsy — the whole bug class this guards against is a
+  // missing field reading as a decision.
+  const r = decideHook(0, { reason: "just talking" });
+  assert.equal(r.blocked, false);
+  assert.equal(r.haltsTurn, false);
+});
+
+test("decideHook: a deny sets blocked WITHOUT claiming the turn halted", () => {
+  const json: HookOutput = {
+    hookSpecificOutput: { permissionDecision: "deny" },
+  };
+  const r = decideHook(0, json);
+  assert.equal(r.blocked, true);
+  assert.equal(r.haltsTurn, false, "a deny refuses one call, it does not halt");
+});
+
+test("decideHook: a harness with no haltsTurnField ignores continue", () => {
+  // The field is read from the PORT. `continue` is documented for Claude Code
+  // and unverified for Codex, so a protocol that does not declare it must not
+  // silently inherit the behaviour — this is what keeps the fact out of core.
+  const noHalt: HookProtocol = {
+    ...claudeCodeHookProtocol,
+    name: "no-halt-harness",
+    haltsTurnField: undefined,
+  };
+  const r = decideHook(0, { continue: false }, noHalt);
+  assert.equal(r.blocked, false);
+  assert.equal(r.haltsTurn, false);
+});
+
+test("runHook: a guard that halts the turn reports blocked", () => {
+  // End-to-end through a real process, not just the pure decision: this is the
+  // path `verifyGuardrail` walks.
+  const r = runHook(
+    `printf '%s' '{"continue": false, "stopReason": "blocked: force push"}'`,
+    { hook_event_name: "PreToolUse", tool_name: "Bash" },
+  );
+  assert.equal(r.exitCode, 0, "it halts by field, not by exit code");
+  assert.equal(r.blocked, true);
+  assert.equal(r.haltsTurn, true);
 });
 
 test("runHook: a guard that exits 2 reports blocked", () => {

--- a/src/run-hook.ts
+++ b/src/run-hook.ts
@@ -271,10 +271,30 @@ export interface HookRunResult extends ScriptRunResult {
   /** Parsed stdout JSON if the hook emitted a JSON decision, else null. */
   readonly json: HookOutput | null;
   /**
-   * Normalized decision: a deny/block via exit 2, `decision:"block"`, or
-   * `permissionDecision:"deny"` all set `blocked = true`.
+   * Normalized decision: the dangerous call did NOT go through. Set by exit 2,
+   * `decision:"block"`, `permissionDecision:"deny"`, or the harness's
+   * halt-the-turn field (Claude Code `{"continue": false}` — see
+   * {@link HookRunResult.haltsTurn}).
+   *
+   * The halt case was missing until 2026-08-31 (#174), and the shape of that bug
+   * is worth keeping written down: `verifyGuardrail` reads this field, so a real
+   * `PreToolUse` guard that stopped every one of the disaster battery's commands
+   * was reported by `assertBlocksDisasters` as blocking NONE of them. A tool
+   * whose stated job is catching a guard that looks fine and silently does
+   * nothing said the opposite about a working guard — the same false-confidence
+   * failure, with the sign flipped.
    */
   readonly blocked: boolean;
+  /**
+   * The hook halted the WHOLE TURN rather than denying one call — the harness's
+   * `haltsTurnField` came back `false`.
+   *
+   * Reported separately because it is strictly stronger than a deny and the two
+   * are worth telling apart when a test asks WHICH mechanism fired. `blocked`
+   * stays the question nearly every caller means ("did the action happen?"), so
+   * a halt sets both.
+   */
+  readonly haltsTurn: boolean;
   /**
    * The decision the hook expressed, preferring the structured
    * `permissionDecision` ("allow"|"deny"|"ask") then legacy `decision`
@@ -307,13 +327,24 @@ export function decideHook(
   exitCode: number,
   json: HookOutput | null,
   protocol: HookProtocol = claudeCodeHookProtocol,
-): { blocked: boolean; decision: HookRunResult["decision"] } {
+): {
+  blocked: boolean;
+  decision: HookRunResult["decision"];
+  haltsTurn: boolean;
+} {
   const permission = json?.hookSpecificOutput?.permissionDecision;
   const decision = permission ?? json?.decision;
+  // The halt field is read from the PORT, never hard-coded: `"continue"` is a
+  // documented Claude Code fact and an unverified one for Codex, so the harness
+  // that has it declares it (core ⊄ adapter). `=== false` and not falsy —
+  // an absent field must not read as a halt.
+  const haltField = protocol.haltsTurnField;
+  const haltsTurn = haltField !== undefined && json?.[haltField] === false;
   const blocked =
     exitCode === protocol.blockExitCode ||
+    haltsTurn ||
     (decision !== undefined && protocol.denyDecisionValues.includes(decision));
-  return { blocked, decision };
+  return { blocked, decision, haltsTurn };
 }
 
 /**
@@ -330,8 +361,8 @@ export function runHookWith(
 ): HookRunResult {
   const res = runScriptWith(command, JSON.stringify(input), opts, deps);
   const json = parseHookOutput(res.stdout);
-  const { blocked, decision } = decideHook(res.exitCode, json);
-  return { ...res, json, blocked, decision };
+  const { blocked, decision, haltsTurn } = decideHook(res.exitCode, json);
+  return { ...res, json, blocked, decision, haltsTurn };
 }
 
 /**

--- a/src/scan-core.ts
+++ b/src/scan-core.ts
@@ -197,6 +197,11 @@ export interface SurfaceClassifier {
    * one. Null for a path this classifier does not call an agent.
    */
   readonly agentName: (f: string) => string | null;
+  /**
+   * A path-scoped RULES file (`<rulesDir>/<name>.md`) — an INSTRUCTION surface,
+   * not an invocable one. Always false for a layout with no `rulesDir`.
+   */
+  readonly isRule: (f: string) => boolean;
 }
 
 function escapeRe(s: string): string {
@@ -210,9 +215,13 @@ export function makeClassifier(layout: PluginLayout): SurfaceClassifier {
   const skill = at(layout.skillDir);
   const agent = at(layout.agentDir);
   const command = at(layout.commandDir);
+  const rules = at(layout.rulesDir ?? "");
   const skillRe = skill ? new RegExp(`${skill}[^/]+/SKILL\\.md$`) : null;
   const agentRe = agent ? new RegExp(`${agent}${AGENT_FILE_LEAF_RE}$`) : null;
   const commandRe = command ? new RegExp(`${command}.+\\.md$`) : null;
+  // Flat `<rulesDir>/<name>.md`, like commands. A layout without a rules dir
+  // yields null and every path below answers false — the additive default.
+  const ruleRe = rules ? new RegExp(`${rules}[^/]+\\.md$`) : null;
   // A subagent lives under the plugin's `agents/` dir AT ANY DEPTH (the harness
   // reads it recursively — see AGENT_FILE_LEAF_RE for the vendor's wording and
   // the measurement), but never under ANOTHER surface dir. Two real-world
@@ -261,6 +270,7 @@ export function makeClassifier(layout: PluginLayout): SurfaceClassifier {
     isSkill,
     isAgent,
     isCommand: (f) => commandRe?.test(f) ?? false,
+    isRule: (f) => ruleRe?.test(f) ?? false,
     agentName: (f) =>
       isAgent(f) ? agentSurfaceName(f, layout.agentDir) : null,
   };
@@ -938,7 +948,11 @@ export function malformedFrontmatterFor(
 ): FrontmatterParseIssue[] {
   const out: FrontmatterParseIssue[] = [];
   for (const [path, md] of Object.entries(files)) {
-    if (!cls.isSkill(path) && !cls.isAgent(path)) continue;
+    // Rules join skills + agents here: `.claude/rules/*.md` carries a `paths:`
+    // frontmatter key that SCOPES the instruction, so unparseable YAML there
+    // silently changes which files the rule applies to — the same defect this
+    // check exists for, on a surface no layout named until now (#175.3).
+    if (!cls.isSkill(path) && !cls.isAgent(path) && !cls.isRule(path)) continue;
     if (!readFrontmatter(md).malformed) continue;
     out.push({
       path,

--- a/src/stability-verbs.test.ts
+++ b/src/stability-verbs.test.ts
@@ -1,0 +1,57 @@
+/**
+ * STABILITY.md's verb list must be the REAL verb list.
+ *
+ * Reported by an adopter (#176.4): the page promising a stable CLI contract
+ * listed `scan`, a verb removed when it became `audit` — so the strongest
+ * promise in the repo named a command that answers `Unknown command`. The
+ * heaviest kind of doc drift, and the kind that survives longest, because the
+ * page is read by people deciding whether to depend on the tool at all.
+ *
+ * `self-command-refs` could not catch it and still cannot: it is deliberately
+ * high-precision and only inspects a `vigiles <cmd>` reference in a COMMAND
+ * context, while STABILITY.md names its verbs as a prose list of backticked
+ * words. That measured limit is documented; this test closes the one page where
+ * the cost of the gap is highest, without widening the detector into the
+ * false-positive territory that got `doc-refs` disabled.
+ */
+import { test } from "vitest";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { VERBS } from "./cli-commands.js";
+
+const STABILITY = resolve(__dirname, "..", "STABILITY.md");
+
+/** The backticked words in the "the verbs (…)" clause. */
+function listedVerbs(md: string): string[] {
+  const m = /the verbs \(([^)]*)\)/s.exec(md);
+  assert.ok(m, "STABILITY.md must carry a `the verbs (…)` clause");
+  return [...m[1].matchAll(/`([a-z-]+)`/g)].map((x) => x[1] as string);
+}
+
+test("every verb STABILITY.md promises actually exists", () => {
+  const listed = listedVerbs(readFileSync(STABILITY, "utf-8"));
+  const real = new Set<string>(VERBS);
+  const ghosts = listed.filter((v) => !real.has(v));
+  assert.deepEqual(
+    ghosts,
+    [],
+    `STABILITY.md promises verb(s) the CLI does not have: ${ghosts.join(", ")}`,
+  );
+});
+
+test("every human-facing verb is promised by STABILITY.md", () => {
+  // The other direction. A shipped verb missing from the stability page is the
+  // quieter half of the same drift — the contract silently under-promises, and
+  // nobody notices because nothing is wrong on screen.
+  const listed = new Set(listedVerbs(readFileSync(STABILITY, "utf-8")));
+  // `hook-runtime` is the hidden runtime umbrella — emitted into hook configs,
+  // never typed by a human — so it is correctly absent from a human contract.
+  const missing = VERBS.filter((v) => v !== "hook-runtime" && !listed.has(v));
+  assert.deepEqual(
+    missing,
+    [],
+    `these verbs ship but STABILITY.md does not mention them: ${missing.join(", ")}`,
+  );
+});

--- a/src/test-coverage-files.ts
+++ b/src/test-coverage-files.ts
@@ -49,6 +49,8 @@ import {
   isEvalScript,
   prepareTest,
   type PreparedTest,
+  matchesSurfaceGlob,
+  strongerEvidence,
 } from "./coverage-evidence.js";
 
 // Mirrors src/test-coverage.ts constants. VALUES are re-declared, never imported
@@ -249,13 +251,22 @@ function isColocated(surface: Surface, testPath: string): boolean {
 function coverageOf(
   surface: Surface,
   tests: readonly PreparedTest[],
+  globs: readonly string[],
 ): CoverageDecision | null {
   let best: CoverageDecision | null = null;
   for (const t of tests) {
     if (t.path === surface.path) continue;
-    const ev = evidenceFor(surface, t, isColocated(surface, t.path));
+    const ev = evidenceFor(
+      surface,
+      t,
+      isColocated(surface, t.path),
+      matchesSurfaceGlob(surface, t.path, globs),
+    );
     if (!ev) continue;
-    if (!best) best = { surface, evidence: ev, by: t.path };
+    // Rank, do not first-win: with a colocated harness AND a configured
+    // suite the reported provenance must not depend on glob order.
+    if (!best || strongerEvidence(ev, best.evidence))
+      best = { surface, evidence: ev, by: t.path };
   }
   return best;
 }
@@ -264,12 +275,13 @@ function coverageOf(
 function tierOf(
   considered: readonly Surface[],
   tests: readonly PreparedTest[],
+  globs: readonly string[],
 ): CoverageTier {
   const covered: Surface[] = [];
   const untested: Surface[] = [];
   const decisions: CoverageDecision[] = [];
   for (const s of considered) {
-    const decision = coverageOf(s, tests);
+    const decision = coverageOf(s, tests, globs);
     if (decision) {
       covered.push(s);
       decisions.push(decision);
@@ -308,17 +320,26 @@ export function findUntestedSurfacesInFiles(
   ];
   const considered = surfaces.filter((s) => !s.ignored);
   const tests = discoverTests(files);
-  const union = tierOf(considered, tests);
+  // NO configured `{surface}` globs here, and that is a property of this twin
+  // rather than a gap: the browser engine reads a file MAP, not a repo, so there
+  // is no `.vigilesrc.json` for a user to have configured. Passing an empty list
+  // makes `matchesSurfaceGlob` false for everything, so this path behaves exactly
+  // as it did before the tier existed. Said out loud because a silent asymmetry
+  // between the twins is how they drift.
+  const noConfiguredGlobs: readonly string[] = [];
+  const union = tierOf(considered, tests, noConfiguredGlobs);
   return {
     untested: [...union.untested],
     decisions: union.decisions,
     harness: tierOf(
       considered,
       tests.filter((t) => !isEvalScript(basename(t.path))),
+      noConfiguredGlobs,
     ),
     evals: tierOf(
       considered,
       tests.filter((t) => isEvalScript(basename(t.path))),
+      noConfiguredGlobs,
     ),
   };
 }

--- a/src/test-coverage.test.ts
+++ b/src/test-coverage.test.ts
@@ -787,6 +787,7 @@ test("a runtime-path harness covers nothing until its tests are colocated", () =
   assert.deepEqual(coverageEvidenceCounts(after), {
     executed: 0,
     colocated: 1,
+    configured: 0,
   });
   cleanupTmpDir(dir);
 });
@@ -814,7 +815,11 @@ test("an EMPTY colocated file still counts — the known, reported hole", () => 
   write(dir, "skills/foo/foo.eval.mjs", "");
   const r = findUntestedSurfaces({ basePath: dir });
   assert.equal(r.untested.length, 0);
-  assert.deepEqual(coverageEvidenceCounts(r), { executed: 0, colocated: 1 });
+  assert.deepEqual(coverageEvidenceCounts(r), {
+    executed: 0,
+    colocated: 1,
+    configured: 0,
+  });
   cleanupTmpDir(dir);
 });
 
@@ -1200,6 +1205,7 @@ test("a recorded run covers a surface that has NO file named after it", () => {
   assert.deepEqual(coverageEvidenceCounts(after), {
     executed: 1,
     colocated: 0,
+    configured: 0,
   });
   cleanupTmpDir(dir);
 });
@@ -1216,7 +1222,11 @@ test("execution OUTRANKS colocation, and the report words them differently", () 
     { path: "skills/alpha/SKILL.md", name: "alpha", sha: surfaceSha(alpha) },
   ]);
   const r = findUntestedSurfaces({ basePath: dir });
-  assert.deepEqual(coverageEvidenceCounts(r), { executed: 1, colocated: 1 });
+  assert.deepEqual(coverageEvidenceCounts(r), {
+    executed: 1,
+    colocated: 1,
+    configured: 0,
+  });
   const text = formatUntestedReport(r);
   // "measured by a run" and "there is a file with a matching name" are two
   // different facts. A reader who cannot tell them apart has the old number.
@@ -1273,6 +1283,7 @@ test("a record whose HARNESS was deleted grants nothing — and that is the perm
   assert.deepEqual(coverageEvidenceCounts(before), {
     executed: 1,
     colocated: 0,
+    configured: 0,
   });
 
   // FIRES: exactly one change — the harness is gone.
@@ -1282,6 +1293,7 @@ test("a record whose HARNESS was deleted grants nothing — and that is the perm
   assert.deepEqual(coverageEvidenceCounts(after), {
     executed: 0,
     colocated: 0,
+    configured: 0,
   });
   // Not "measured, but not this version" either: the surface was never edited,
   // so calling it stale would name the wrong file.
@@ -1308,7 +1320,11 @@ test("…and a RENAMED harness is the same case, because the old name never retu
   rmSync(join(dir, "test/old-name.harness.mjs"));
   write(dir, "test/new-name.harness.mjs", "// same file, new name\n");
   const r = findUntestedSurfaces({ basePath: dir });
-  assert.deepEqual(coverageEvidenceCounts(r), { executed: 0, colocated: 0 });
+  assert.deepEqual(coverageEvidenceCounts(r), {
+    executed: 0,
+    colocated: 0,
+    configured: 0,
+  });
   cleanupTmpDir(dir);
 });
 
@@ -1337,7 +1353,7 @@ test("…but a spelling of the SAME file still counts — presence, not string e
     ]);
     assert.deepEqual(
       coverageEvidenceCounts(findUntestedSurfaces({ basePath: dir })),
-      { executed: 1, colocated: 0 },
+      { executed: 1, colocated: 0, configured: 0 },
       by,
     );
   }
@@ -1382,7 +1398,11 @@ test("a re-run refreshes the surface and the stale notice goes away", () => {
   const r = findUntestedSurfaces({ basePath: dir });
   assert.equal(r.untested.length, 0);
   assert.deepEqual(r.staleRuns, [], "a permanent notice is an ignored notice");
-  assert.deepEqual(coverageEvidenceCounts(r), { executed: 1, colocated: 0 });
+  assert.deepEqual(coverageEvidenceCounts(r), {
+    executed: 1,
+    colocated: 0,
+    configured: 0,
+  });
   cleanupTmpDir(dir);
 });
 
@@ -1419,7 +1439,11 @@ test("NO artifact ⇒ byte-for-byte the old behaviour, including the report text
     r.untested.map((s) => s.name),
     ["alpha"],
   );
-  assert.deepEqual(coverageEvidenceCounts(r), { executed: 0, colocated: 1 });
+  assert.deepEqual(coverageEvidenceCounts(r), {
+    executed: 0,
+    colocated: 1,
+    configured: 0,
+  });
   const text = formatUntestedReport(r);
   assert.doesNotMatch(text, /MEASURED BY A RUN/);
   assert.doesNotMatch(text, /BEFORE their current/);
@@ -1676,4 +1700,142 @@ test("…and nothing at all in a repo with no such file", () => {
   assert.deepEqual(report.retiredTestNames, []);
   assert.doesNotMatch(formatUntestedReport(report), /vitest\/jest/);
   cleanupTmpDir(dir);
+});
+
+// ---------------------------------------------------------------------------
+// `{surface}` in testGlobs — a centralized layout, without weakening what
+// coverage MEANS (#175.2)
+// ---------------------------------------------------------------------------
+
+test("a {surface} testGlob credits a centralized test", () => {
+  // The reported layout: suites live in tests/<skill>/evals/, not beside the
+  // skill. `testGlobs` alone did not move the number (35 before, 35 after),
+  // because it widens what counts as a TEST FILE and says nothing about which
+  // SURFACE the file is for.
+  const dir = makeTmpDir();
+  try {
+    mkdirSync(join(dir, "skills", "mysql-designer"), { recursive: true });
+    writeFileSync(
+      join(dir, "skills", "mysql-designer", "SKILL.md"),
+      "---\nname: mysql-designer\ndescription: Designs schemas.\n---\n\nBody.\n",
+    );
+    mkdirSync(join(dir, "tests", "mysql-designer", "evals"), {
+      recursive: true,
+    });
+    writeFileSync(
+      join(dir, "tests", "mysql-designer", "evals", "promptfooconfig.yaml"),
+      "prompts: []\n",
+    );
+
+    const before = findUntestedSurfaces({ basePath: dir });
+    assert.equal(before.untested.length, 1, "uncovered without the glob");
+
+    const after = findUntestedSurfaces({
+      basePath: dir,
+      testGlobs: ["tests/{surface}/evals/promptfooconfig*.yaml"],
+    });
+    assert.equal(after.untested.length, 0);
+    assert.equal(after.decisions[0]?.evidence, "configured");
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});
+
+test("a {surface} glob credits ONLY the surface it names", () => {
+  // The load-bearing half. The retired `name-mentioned` tier died because a
+  // substring credited surfaces nothing had touched; the placeholder must not
+  // reintroduce that. One skill has a suite, its neighbour does not.
+  const dir = makeTmpDir();
+  try {
+    for (const name of ["alpha", "beta"]) {
+      mkdirSync(join(dir, "skills", name), { recursive: true });
+      writeFileSync(
+        join(dir, "skills", name, "SKILL.md"),
+        `---\nname: ${name}\ndescription: Does ${name}.\n---\n\nBody.\n`,
+      );
+    }
+    mkdirSync(join(dir, "tests", "alpha", "evals"), { recursive: true });
+    writeFileSync(
+      join(dir, "tests", "alpha", "evals", "promptfooconfig.yaml"),
+      "prompts: []\n",
+    );
+
+    const r = findUntestedSurfaces({
+      basePath: dir,
+      testGlobs: ["tests/{surface}/evals/promptfooconfig*.yaml"],
+    });
+    assert.deepEqual(
+      r.untested.map((s) => s.name),
+      ["beta"],
+      "alpha's suite must not cover beta",
+    );
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});
+
+test("a plain custom glob still credits NOTHING by itself", () => {
+  // Unchanged behaviour, pinned: without the placeholder there is no name
+  // binding, and inferring one from a substring is the tier that was retired.
+  const dir = makeTmpDir();
+  try {
+    mkdirSync(join(dir, "skills", "gamma"), { recursive: true });
+    writeFileSync(
+      join(dir, "skills", "gamma", "SKILL.md"),
+      "---\nname: gamma\ndescription: Does gamma.\n---\n\nBody.\n",
+    );
+    mkdirSync(join(dir, "tests", "gamma", "evals"), { recursive: true });
+    writeFileSync(
+      join(dir, "tests", "gamma", "evals", "promptfooconfig.yaml"),
+      "prompts: []\n",
+    );
+
+    const r = findUntestedSurfaces({
+      basePath: dir,
+      testGlobs: ["tests/*/evals/promptfooconfig*.yaml"],
+    });
+    assert.equal(r.untested.length, 1, "no placeholder ⇒ no surface binding");
+  } finally {
+    cleanupTmpDir(dir);
+  }
+});
+
+test("colocation still wins, and is reported as colocation", () => {
+  // Precedence: a repo doing both must not be relabelled by the new tier.
+  const dir = makeTmpDir();
+  try {
+    mkdirSync(join(dir, "skills", "delta"), { recursive: true });
+    writeFileSync(
+      join(dir, "skills", "delta", "SKILL.md"),
+      "---\nname: delta\ndescription: Does delta.\n---\n\nBody.\n",
+    );
+    writeFileSync(
+      join(dir, "skills", "delta", "delta.harness.mjs"),
+      "// a colocated harness\n",
+    );
+    mkdirSync(join(dir, "tests", "delta", "evals"), { recursive: true });
+    writeFileSync(
+      join(dir, "tests", "delta", "evals", "promptfooconfig.yaml"),
+      "prompts: []\n",
+    );
+
+    // BOTH glob orders, because the point is that the answer does NOT depend on
+    // the order. A first-found implementation passes one of these and fails the
+    // other — which is exactly how the stale "strongest, not first-found" doc
+    // comment was caught: it described a ranking the code did not do.
+    for (const testGlobs of [
+      ["**/*.harness.mjs", "tests/{surface}/evals/promptfooconfig*.yaml"],
+      ["tests/{surface}/evals/promptfooconfig*.yaml", "**/*.harness.mjs"],
+    ]) {
+      const r = findUntestedSurfaces({ basePath: dir, testGlobs });
+      assert.equal(r.untested.length, 0);
+      assert.equal(
+        r.decisions[0]?.evidence,
+        "colocated",
+        `colocation must win with globs ordered ${JSON.stringify(testGlobs)}`,
+      );
+    }
+  } finally {
+    cleanupTmpDir(dir);
+  }
 });

--- a/src/test-coverage.ts
+++ b/src/test-coverage.ts
@@ -85,6 +85,9 @@ import {
   type CoverageEvidence,
   type EvidenceCounts,
   type PreparedTest,
+  discoveryGlob,
+  matchesSurfaceGlob,
+  strongerEvidence,
 } from "./coverage-evidence.js";
 import {
   canonicalScript,
@@ -494,7 +497,14 @@ function discoverTests(
   // skill (matched by the explicit-dot `.claude/skills/*/SKILL.md` pattern) is
   // still discovered — so the surface looks untested even after the user adds
   // exactly the suggested file. DEFAULT_IGNORE still drops .git/node_modules/etc.
-  const found = globSync([...globs], { cwd: basePath, ignore, dot: true });
+  // `{surface}` is widened to `*` for DISCOVERY so one pass finds every
+  // candidate; the narrowing back to a specific surface happens at match time
+  // (matchesSurfaceGlob). Globbing once per surface would be quadratic in I/O.
+  const found = globSync(globs.map(discoveryGlob), {
+    cwd: basePath,
+    ignore,
+    dot: true,
+  });
   // Prepared ONCE per file (comment-strip + declaration parse), not once per
   // (surface × file) pair — the matching below is quadratic by nature.
   return found.map((path) => prepareTest(path));
@@ -544,13 +554,22 @@ function isColocated(surface: Surface, testPath: string): boolean {
 function coverageOf(
   surface: Surface,
   tests: readonly PreparedTest[],
+  globs: readonly string[],
 ): CoverageDecision | null {
   let best: CoverageDecision | null = null;
   for (const t of tests) {
     if (t.path === surface.path) continue;
-    const ev = evidenceFor(surface, t, isColocated(surface, t.path));
+    const ev = evidenceFor(
+      surface,
+      t,
+      isColocated(surface, t.path),
+      matchesSurfaceGlob(surface, t.path, globs),
+    );
     if (!ev) continue;
-    if (!best) best = { surface, evidence: ev, by: t.path };
+    // Rank, do not first-win: with a colocated harness AND a configured suite
+    // the reported provenance must not depend on glob order.
+    if (!best || strongerEvidence(ev, best.evidence))
+      best = { surface, evidence: ev, by: t.path };
   }
   return best;
 }
@@ -606,12 +625,13 @@ function tierOf(
   tests: readonly PreparedTest[],
   index: ReadonlyMap<string, ExecutedRecord[]>,
   tier: CoverageTierName | undefined,
+  globs: readonly string[],
 ): CoverageTier {
   const covered: Surface[] = [];
   const untested: Surface[] = [];
   const decisions: CoverageDecision[] = [];
   for (const s of considered) {
-    const decision = executedOf(s, index, tier) ?? coverageOf(s, tests);
+    const decision = executedOf(s, index, tier) ?? coverageOf(s, tests, globs);
     if (decision) {
       covered.push(s);
       decisions.push(decision);
@@ -677,7 +697,7 @@ export function findUntestedSurfaces(
     // the artifact records whichever one was typed.
     (by) => existsSync(join(basePath, canonicalScript(by, basePath))),
   );
-  const union = tierOf(considered, tests, runIndex, undefined);
+  const union = tierOf(considered, tests, runIndex, undefined, globs);
 
   return {
     total: considered.length,
@@ -702,8 +722,8 @@ export function findUntestedSurfaces(
       .filter((path) => read(join(basePath, path)).includes(LEGACY_COVERS)),
     retiredTestNames: retiredTestNamesFor(basePath, union.untested),
     decisions: union.decisions,
-    harness: tierOf(considered, split.harness, runIndex, "harness"),
-    evals: tierOf(considered, split.evals, runIndex, "eval"),
+    harness: tierOf(considered, split.harness, runIndex, "harness", globs),
+    evals: tierOf(considered, split.evals, runIndex, "eval", globs),
   };
 }
 
@@ -1089,14 +1109,18 @@ export function formatUntestedReport(report: UntestedReport): string {
   if (provenance) lines.push(`  ${provenance}`);
   lines.push(...coverageCaveats(report));
   // Already testing these another way (a promptfoo suite, a home-grown evals
-  // file)? Point `testGlobs` at it so it counts toward coverage (issue #113) —
-  // and put the file NEXT TO the surface, which is the only placement that
-  // counts now. See docs/rules/untested-skill.md.
+  // file)? Two shapes are accepted, and the message names BOTH — it used to
+  // name only `testGlobs`, which does not by itself make a centralized suite
+  // count, so a reader who followed it exactly saw the number not move (#175.2).
+  // See docs/rules/untested-skill.md.
   lines.push(
-    `  Testing these another way (promptfoo / a home-grown eval loop)? Add its ` +
-      `files to \`testGlobs\` in .vigilesrc.json AND name each after the surface ` +
-      `it covers, next to it (\`<surface>/<surface>.eval.mjs\`) — placement says ` +
-      `where a file sits, the name says what it is about. ` +
+    `  Testing these another way (promptfoo / a home-grown eval loop)? Either ` +
+      `put the file NEXT TO the surface and name it after it ` +
+      `(\`<surface>/<surface>.eval.mjs\`), or — for a centralized layout — point ` +
+      `\`testGlobs\` at it USING THE \`{surface}\` placeholder, e.g. ` +
+      `\`"tests/{surface}/evals/promptfooconfig*.yaml"\`. A \`testGlobs\` entry ` +
+      `WITHOUT \`{surface}\` widens what counts as a test file but never says ` +
+      `which surface it covers, so it credits nothing on its own. ` +
       `See docs/rules/untested-skill.md.`,
   );
   return lines.join("\n");


### PR DESCRIPTION
## What and why

Closes #173, #174, #175, #176 and #170.

Four of them came from one adopter putting vigiles into a 51-skill monorepo. Every factual claim in those issues was verified against the source before anything was changed; all of them held.

**#174 — an inverted verdict in the flagship feature.** `decideHook` read exit 2, `decision` and `permissionDecision`, but not the harness's halt-the-turn field — which `HookOutput` had declared all along and nothing ever read. `verifyGuardrail` reads `blocked`, so a real `PreToolUse` guard that stopped **every** command in the disaster battery was reported by `assertBlocksDisasters` as blocking **none** of them. The tool whose stated job is catching "a guard that looks fine and silently does nothing" said exactly that about a guard that does not.

The field is read from the **port**, not hard-coded: `continue` is documented for Claude Code and unverified for Codex, so the harness that has it declares it and core stays harness-agnostic.

🔴 **The issue's adjacent suggestion was deliberately NOT implemented, because it would have created false positives.** Adding `continue` to `hook-block-ineffective` as a fourth block-attempt signal would make `wrong-event` fire on hooks that *work* — a halt is not event-scoped, it ends the turn from `SessionStart` too, which is precisely the set that check flags. For a rule that can be wired at `error` a false positive costs the build, and a rule that fails correct builds gets switched off rather than fixed. So it reads as a **suppressor** instead, which fixes a real false alarm: a hook pairing the legacy `decision` field with a halt was told nothing was blocked while it blocked. A mutation implementing the original suggestion literally is pinned by a test that fails on it.

**#173 — `lint` went green over a known-broken artifact.** `compile` printed the errors, exited 1, and wrote `CLAUDE.md` anyway — stamped with a valid integrity hash. `lint` verifies that hash, finds it intact, exits 0. Nothing is written on a failed compile now; the last good artifact is left in place, which beats replacing it with a broken one. `README.md`'s "lint is the CI gate … broken refs" line is narrowed to match.

**#176 — eight small things**, including one that broke a stated contract: `audit --out` pointing outside the repo appended `../../../../private/tmp/…` entries to `.gitignore`, which ignore nothing and accumulate one dead block per output path — a command documented as a read-only report editing a tracked file for no benefit. Also: unknown command now exits 2 per `docs/cli.md`; `--out` says when it is ignored instead of being a silent no-op; `STABILITY.md` no longer promises the removed `scan` verb (and a test now pins that list against the real one); `CONTRIBUTING.md`'s "Adding a new validation rule" section named four files that have not existed for a long time.

**#175 + #176.2 — three capabilities that were genuinely missing**, each opt-in and additive: `{surface}` in `testGlobs` for a centralized test layout, `--single` to audit a many-bundle root as one harness, and `rulesDir` so `.claude/rules/**` — a whole instruction layer — stops being invisible to the audit.

**#170 — the systematic pass.** Both naming checks enumerated export forms from memory; the same construct went unnamed in two checkers written days apart. There is now one enumeration written against the grammar (`scripts/lib/export-forms.mjs`, 22 covered forms + 4 exclusions each with its reason), both checks are driven off it, and `check-internal-tag.mjs` asks the TypeScript compiler instead of a regex.

Three things that found immediately, none of which review had: the open finding from the issue (`checked: 0` → correctly reported); 13 tagged **types** the regex had never once looked at; and a live gap in the ESLint rule (`export default widget` reported nothing).

## Safety impact

**Not "none" — this changes what counts as a blocked hook, and that is worth stating explicitly.**

`decideHook` now reports `blocked: true` for a hook whose stdout carries the harness's halt-the-turn field set to `false`. Scope of that change, honestly bounded:

- It **widens what is recognised as a block**, never what is permitted. No hook gains the ability to allow something it previously denied; a guard that was already blocking is simply no longer misreported as permissive.
- The direction matters for `assertBlocksDisasters`: it previously **failed** builds over working guards (false alarm), and can now **pass** where a guard genuinely halts. A guard that only emits `continue: true` still fails the battery — pinned by a test, because "blocked" satisfied by the mere presence of a `continue` key would be the same bug with the sign flipped.
- The field is per-harness (`HookProtocol.haltsTurnField`) and only Claude Code declares it, so no harness inherits a claim nobody measured.
- Unchanged: the sandbox, `sandboxAvailable()`, `interceptTools`, and what any read-only path may execute. `compile` writing **less** than before (#173) cannot widen anything.

`rulesDir` adds a directory to the file map that existing text checks read. It is deliberately **outside** `surfaceDirs`, so it does not change what counts as a loadable machine for any harness; a layout without it behaves byte-for-byte as before, which is tested.

## Checks

- [x] `npm test` passes locally, or CI is green
- [x] New behaviour has a test — or there's a note below saying why it doesn't
- [x] Docs updated if this changes a rule, a CLI surface, or a documented guarantee

**Gates run locally, in order, after merging `main` in:** `npm run build` (0 errors) · `npx vitest run --project unit` (**3414 passed, 21 skipped, 0 failed**) · `npm run lint` (0 errors; 207 pre-existing warnings) · `npx prettier --check .` (clean) · `npm run api:check` (no drift).

**API surface** — additive only: `HookProtocol.haltsTurnField?`, `HookRunResult.haltsTurn`, `decideHook`'s third return field, `TriggerRateReport.namespace?`. `haltsTurn` is **required**, so code that *constructs* a `HookRunResult` (a test fake) must set it — my own two fixtures broke on it, which is the evidence that a consumer's would. Hence `!` in the title.

**Mutations** — 16 in total, each verified to have landed and to fail on its own assertion. The load-bearing ones:

| mutation | fails |
|---|---|
| drop `haltsTurn` from `blocked` | `decideHook: continue:false halts the turn` |
| hard-code the field instead of reading the port | `a harness with no haltsTurnField ignores continue` |
| implement #174's adjacent suggestion literally | `a halt on a NO-EFFECT event is NOT flagged wrong-event` |
| restore compile's write-on-error | all three `cli-compile-gate` cases |
| `{surface}` matches any surface | `a {surface} glob credits ONLY the surface it names` |
| revert evidence ranking to first-found | `colocation still wins` (both glob orders) |
| rule forgets `export default <identifier>` | `default-identifier: unprefixed name is reported` |

⚠️ **Two mutations came back green and were findings about the TEST, not the code** — recorded because that is the discipline, not a footnote. One landed on the wrong `process.exit(2)` of ten (the "prove the patch landed" assertion earning its keep). The other exposed a real defect: `coverageOf` promised "STRONGEST evidence, not first-found" in its doc comment and actually kept the first match — harmless while colocation was the only tier, load-bearing the moment a second existed, since the reported provenance would otherwise depend on the order of a config array. Now a real rank, pinned across both glob orders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrS34j2M8XR12P2QHaBer4

---
_Generated by [Claude Code](https://claude.ai/code/session_01PrS34j2M8XR12P2QHaBer4)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Features**
- a centralized test layout, a pinned audit mode, and the rules layer

**Fixes**
- a guard that halts the turn is a guard that blocks
- stop shipping quiet wrongness — dead-ref artifacts, exit codes, silent no-ops

**Refactors**
- enumerate export forms against the grammar, not from memory

**Docs**
- STABILITY.md promised a verb that does not exist
- the {surface} placeholder and --single, where adopters look for them

**Chores**
- regenerate the committed artifacts the new files and field changed
<!-- vigiles:pr-summary:end -->

