### PR TITLE
fix(lint)!: make the lint report complete, tierable and machine-readable

### DIFF
--- a/.vigiles/generated.d.ts
+++ b/.vigiles/generated.d.ts
@@ -101,7 +101,7 @@ declare module "vigiles/generated" {
     | "internal:check"
     | "docs:api";
 
-  /** 400 project files. */
+  /** 403 project files. */
   export type ProjectFile = 
     | "src/CLAUDE.md"
     | "src/CLAUDE.md.spec.ts"
@@ -388,6 +388,8 @@ declare module "vigiles/generated" {
     | "src/guardrail-check.ts"
     | "src/harness-assert.test.ts"
     | "src/harness-assert.ts"
+    | "src/harness-resolve-hooks.mts"
+    | "src/harness-resolve.test.ts"
     | "src/harness-test.test.ts"
     | "src/harness-test.ts"
     | "src/hook-dogfood.test.ts"
@@ -405,6 +407,7 @@ declare module "vigiles/generated" {
     | "src/judge.ts"
     | "src/leaderboard.test.ts"
     | "src/leaderboard.ts"
+    | "src/lint-contract.test.ts"
     | "src/linting.ts"
     | "src/load-hook.test.ts"
     | "src/load-hook.ts"
@@ -860,6 +863,8 @@ declare module "vigiles/spec" {
       | "src/guardrail-check.ts"
       | "src/harness-assert.test.ts"
       | "src/harness-assert.ts"
+      | "src/harness-resolve-hooks.mts"
+      | "src/harness-resolve.test.ts"
       | "src/harness-test.test.ts"
       | "src/harness-test.ts"
       | "src/hook-dogfood.test.ts"
@@ -877,6 +882,7 @@ declare module "vigiles/spec" {
       | "src/judge.ts"
       | "src/leaderboard.test.ts"
       | "src/leaderboard.ts"
+      | "src/lint-contract.test.ts"
       | "src/linting.ts"
       | "src/load-hook.test.ts"
       | "src/load-hook.ts"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -488,6 +488,44 @@ npx vigiles audit ./marketplace-repo --single  # ...or audit that root as ONE ha
 npx vigiles audit ./repo --harness=codex # override harness detection
 ```
 
+### `lint` in a monorepo, and getting both artefacts from one run
+
+**Nested bundles.** `lint` scores the root bundle. If the repo holds more
+(`plugins/*/skills/`), it now NAMES them rather than leaving them out silently:
+
+```
+⚠ 2 nested bundle(s) discovered but NOT scored: plugins/alpha, plugins/beta
+```
+
+Score them all in one pass — one exit code over the whole repo, which is what a
+CI gate needs — with `--bundles=all`, or `"bundles": "all"` in `.vigilesrc.json`.
+Root-only stays the default because descending unconditionally would also score
+vendored third-party plugins as if they were yours.
+
+**Both artefacts, one scan.** `--json` replaces stdout; `--json-out=<file>`
+writes the JSON to disk and leaves stdout human-readable, so a CI job that wants
+the log for a human AND the JSON for a PR comment scans once:
+
+```bash
+npx vigiles lint . --json-out=reports/lint.json
+```
+
+**One number to quote.** Every run ends with a total that matches `--json`:
+
+```
+88 finding(s): 0 error, 88 warning — exit 0
+```
+
+Counting `⚠` lines gives a different number — some checks print one line per
+finding, others one line carrying a count — so the total is computed from the
+report, not from the output.
+
+**Running the harness tier without installing into the project.** A harness
+imports `vigiles` by name, and in a repo that already has a `package.json` a root
+install pulls the entire dependency tree. `vigiles test` now resolves that import
+from the CLI's own installation, so `npx vigiles@<version> test` works with
+nothing installed in the project. A locally installed vigiles still wins.
+
 #### `--single` — audit a many-bundle root as one harness
 
 A marketplace root switches to the leaderboard automatically, which means the

--- a/docs/rules/duplicate-rules.md
+++ b/docs/rules/duplicate-rules.md
@@ -1,0 +1,54 @@
+# `duplicate-rules`
+
+Near-duplicate rules **within one spec** — two rules that say the same thing in
+different words. Detected by NCD (gzip-based) similarity, so it is deterministic
+and needs no model.
+
+```json
+{ "rules": { "duplicate-rules": "warn" } }
+```
+
+|              |                                      |
+| ------------ | ------------------------------------ |
+| **Default**  | `warn`                               |
+| **Surface**  | instruction-file specs (`*.spec.ts`) |
+| **Bucket**   | heuristic-behavioral                 |
+| **Detector** | `findDuplicateRules`                 |
+
+## What it checks
+
+Every pair of rules inside a spec is compared by normalized compression
+distance. A pair below the similarity threshold is reported as spec bloat:
+duplicated guidance is guidance the reader has to reconcile, and the model has to
+weigh twice.
+
+## Severity
+
+- `"warn"` (default) — reported, exit code untouched.
+- `"error"` — a duplicate pair fails the build.
+- `false` / `"off"` — the check does not run.
+
+## Why it defaults to `warn`
+
+It is a **proxy**, not a fact: NCD says two strings compress well together, which
+is evidence that they overlap and not proof that they are redundant. Two rules
+can legitimately share vocabulary and mean different things.
+
+This repo's calibration rule is that a heuristic never defaults to `error`,
+because a rule that fails a correct build gets switched off rather than fixed.
+
+## History
+
+Until 2026-09 this check had **no rule id at all** — the finding fed the exit
+code directly, so `vigiles lint` could exit 1 over it with no name a config could
+even mention, and no way to tier it (#181). Registering it surfaced a second
+problem: it was behaving as `error` while being a heuristic, which is exactly the
+combination the calibration rule exists to prevent. Set it back to `"error"`
+explicitly if the old blocking behaviour is what you want.
+
+## See also
+
+- [`orphan-docs`](orphan-docs.md) — the other check that used to be untierable
+  for the same reason.
+- The validation-rule matrix in
+  [verifying instruction files](../verifying-instruction-files.md).

--- a/docs/rules/spec-refs.md
+++ b/docs/rules/spec-refs.md
@@ -1,0 +1,55 @@
+# `spec-refs`
+
+A compiled instruction file whose `.spec.ts` references a file, script or symbol
+that no longer exists.
+
+```json
+{ "rules": { "spec-refs": "error" } }
+```
+
+|              |                                        |
+| ------------ | -------------------------------------- |
+| **Default**  | `error`                                |
+| **Surface**  | instruction files compiled from a spec |
+| **Bucket**   | external-decidable                     |
+| **Detector** | `compileClaude`                        |
+
+## What it checks
+
+For every `<file>.spec.ts` whose compiled `<file>` exists, the spec's references
+are re-derived and validated exactly as `compile` validates them: `file()` paths
+against the filesystem, `cmd()` against `package.json` scripts, `enforce()`
+against the real linter catalogs.
+
+## Why the integrity hash is not enough
+
+They answer different questions, and reading them as one is what hid this:
+
+| check       | answers                                       |
+| ----------- | --------------------------------------------- |
+| `integrity` | is this file still what the spec compiled to? |
+| `spec-refs` | do the things it NAMES still exist?           |
+
+An artifact committed while its references were live stays hash-valid forever.
+Delete the referenced file afterwards and `compile` errors while `lint` reports
+`✓ hash valid — All compiled files intact` and exits 0 — over a file that names a
+path the agent will not find.
+
+## Severity
+
+- `"error"` (default) — matches `compile`. A dead reference is decidable from the
+  filesystem, not a proxy, so it sits in the hard tier.
+- `"warn"` — reported, exit code untouched.
+- `false` / `"off"` — skipped.
+
+## Cost
+
+Only specs whose compiled output already exists are loaded, so a repo with no
+specs does no extra work. A spec that fails to LOAD is not reported here — that
+is `compile`'s finding, and reporting it twice would blame the wrong command.
+
+## See also
+
+- [`integrity`](integrity.md) — the hash half.
+- The validation-rule matrix in
+  [verifying instruction files](../verifying-instruction-files.md).

--- a/examples/CLAUDE.md
+++ b/examples/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- vigiles:sha256:17fb913f226f6087 compiled from examples/CLAUDE.md.spec.ts -->
+<!-- vigiles:sha256:fba6647caccddb24 compiled from examples/CLAUDE.md.spec.ts -->
 
 # CLAUDE.md
 
@@ -14,14 +14,14 @@ The linter cross-referencing engine is the core moat: `enforce("@typescript-esli
 
 Three rule kinds in specs: `enforce()` (delegated to an external linter — vigiles verifies the rule exists and is enabled), `guard()` (a path→command guard, e.g. recompile when a spec changes), and `guidance()` (prose only).
 
-Core modules: `src/spec.ts` (types + builders), `src/compile.ts` (compiler), `src/linters.ts` (11-catalog cross-referencing engine), `src/generate-types.ts` (type generator).
+Core modules: `src/core/spec.ts` (types + builders), `src/core/compile.ts` (compiler), `src/core/linters.ts` (11-catalog cross-referencing engine), `src/core/generate-types.ts` (type generator).
 
 ## Key Files
 
-- `src/spec.ts` — Type system and builder functions
-- `src/compile.ts` — Compiler: spec → markdown with SHA-256 hash
-- `src/linters.ts` — Cross-referencing engine (11 catalogs incl. Cedar + JVM/Go)
-- `src/generate-types.ts` — Type generator: project state → .d.ts
+- `src/core/spec.ts` — Type system and builder functions
+- `src/core/compile.ts` — Compiler: spec → markdown with SHA-256 hash
+- `src/core/linters.ts` — Cross-referencing engine (11 catalogs incl. Cedar + JVM/Go)
+- `src/core/generate-types.ts` — Type generator: project state → .d.ts
 - `src/cli.ts` — CLI: init, compile, lint, test, eval, generate-types
 
 ## Commands

--- a/examples/CLAUDE.md.spec.ts
+++ b/examples/CLAUDE.md.spec.ts
@@ -16,15 +16,15 @@ The linter cross-referencing engine is the core moat: \`enforce("@typescript-esl
 
     architecture: `Three rule kinds in specs: \`enforce()\` (delegated to an external linter — vigiles verifies the rule exists and is enabled), \`guard()\` (a path→command guard, e.g. recompile when a spec changes), and \`guidance()\` (prose only).
 
-Core modules: \`src/spec.ts\` (types + builders), \`src/compile.ts\` (compiler), \`src/linters.ts\` (11-catalog cross-referencing engine), \`src/generate-types.ts\` (type generator).`,
+Core modules: \`src/core/spec.ts\` (types + builders), \`src/core/compile.ts\` (compiler), \`src/core/linters.ts\` (11-catalog cross-referencing engine), \`src/core/generate-types.ts\` (type generator).`,
   },
 
   keyFiles: {
-    "src/spec.ts": "Type system and builder functions",
-    "src/compile.ts": "Compiler: spec → markdown with SHA-256 hash",
-    "src/linters.ts":
+    "src/core/spec.ts": "Type system and builder functions",
+    "src/core/compile.ts": "Compiler: spec → markdown with SHA-256 hash",
+    "src/core/linters.ts":
       "Cross-referencing engine (11 catalogs incl. Cedar + JVM/Go)",
-    "src/generate-types.ts": "Type generator: project state → .d.ts",
+    "src/core/generate-types.ts": "Type generator: project state → .d.ts",
     "src/cli.ts": "CLI: init, compile, lint, test, eval, generate-types",
   },
 

--- a/src/adapters/claude-code/run-scripts.ts
+++ b/src/adapters/claude-code/run-scripts.ts
@@ -13,6 +13,7 @@
 import { spawn } from "node:child_process";
 import { availableParallelism } from "node:os";
 import { resolve, join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { globSync } from "glob";
@@ -324,10 +325,25 @@ export async function runScripts(
         return;
       }
       const countFile = join(countDir, `${String(i)}.count`);
-      const child = spawn("node", argv, {
+      // Resolve a harness's bare `vigiles` import from the CLI's OWN install, so
+      // running the gate does not require installing the package into the
+      // project — which, in a repo that already has a package.json, drags in the
+      // entire dependency tree (measured at 840 packages against vigiles' 42,
+      // #184). Only rescues that specifier, and only after normal resolution
+      // fails, so a locally installed copy still wins.
+      const selfRoot = resolve(__dirname, "..", "..", "..");
+      const hook = pathToFileURL(
+        join(selfRoot, "dist", "harness-resolve-hooks.mjs"),
+      ).href;
+      const child = spawn("node", ["--import", hookImport(hook), ...argv], {
         cwd,
         stdio: ["ignore", "pipe", "pipe"],
-        env: { ...process.env, ...env, [CHECK_COUNT_ENV]: countFile },
+        env: {
+          ...process.env,
+          ...env,
+          VIGILES_SELF_ROOT: selfRoot,
+          [CHECK_COUNT_ENV]: countFile,
+        },
       });
       const chunks: Buffer[] = [];
       child.stdout.on("data", (c: Buffer) => chunks.push(c));
@@ -476,4 +492,15 @@ export function formatScriptSummary(
     );
   }
   return lines.join("\n");
+}
+
+/**
+ * A `--import` argument that registers the resolver hook without a temp file:
+ * a data: URL calling `module.register`. Inline because writing a shim into the
+ * user's tree to run their tests would be a side effect the runner has no
+ * business having.
+ */
+function hookImport(hookHref: string): string {
+  const src = `import {register} from "node:module";register(${JSON.stringify(hookHref)});`;
+  return `data:text/javascript,${encodeURIComponent(src)}`;
 }

--- a/src/cli-compile-gate.test.ts
+++ b/src/cli-compile-gate.test.ts
@@ -107,9 +107,19 @@ test("a failed compile leaves the LAST GOOD artifact alone, not a broken one", (
     "the previous good artifact must survive a failed compile untouched",
   );
 
-  // And the gate must still be green on it — it IS intact, and saying otherwise
-  // would be the opposite false alarm.
-  assert.equal(run("lint", ".").code, 0);
+  // 🔴 THIS ASSERTION USED TO SAY `lint` MUST BE GREEN HERE, and that expectation
+  // was the hole itself. The surviving artifact IS intact — its hash matches what
+  // the spec compiled to — but the spec it came from now names a file that does
+  // not exist, so calling the repo clean is exactly the false confidence #173 was
+  // filed about. The hash is an integrity claim, not a reference claim.
+  //
+  // `spec-refs` closes that residue, so a dead reference is reported even though
+  // the artifact is untouched. What the surviving-artifact half of this test
+  // still pins is the FILE: refusing to write must not mean destroying what is
+  // there, which is asserted above by comparing the bytes.
+  const linted = run("lint", ".");
+  assert.equal(linted.code, 2, "the dead reference is caught, not the file");
+  assert.match(linted.out, /never-existed/);
 });
 
 test("lint no longer goes green over an artifact compile refused to write", () => {

--- a/src/cli-flag-check.ts
+++ b/src/cli-flag-check.ts
@@ -82,7 +82,7 @@ export const COMMAND_FLAGS: Record<Verb, readonly FlagSpec[]> = {
   ],
   compile: [],
   eject: ["--keep-spec"],
-  lint: ["--summary", "--json"],
+  lint: ["--bundles=", "--summary", "--json", "--json-out="],
   // handleRunScripts (free tier — no lock flags).
   test: ["--min=", "--all", "--yes", "--no-interactive", "--no-skip"],
   // handleRunScripts + resolveEvalLockEnv + the trials knob.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,7 +31,9 @@ import {
   relative,
   isAbsolute,
   sep as pathSep,
+  join,
 } from "node:path";
+import { minimatch } from "minimatch";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { globSync } from "glob";
 import { generateTypes } from "./core/generate-types.js";
@@ -1140,12 +1142,16 @@ interface LintReport {
   frontmatterErrors: number;
   frontmatterRules: number;
   duplicatePairs: number;
+  /** Severity of `duplicate-instructions` — carried so the exit code can tier it. */
+  duplicateSeverity: RuleSeverity;
   coverageEnabled: number;
   coverageDocumented: number;
   strengthenSuggestions: number;
   integrityErrors: number;
   coverageErrors: number;
   orphanCount: number;
+  /** Severity of `orphan-docs` — carried so the exit code can tier it (#181). */
+  orphanSeverity: RuleSeverity;
   untestedSurfaces: number;
   untestedErrors: number;
   toolContractIssues: number;
@@ -1192,6 +1198,12 @@ interface LintReport {
   symbolRefErrors: number;
   mcpRefErrors: number;
   files: string[];
+  /**
+   * Findings / errors / warnings for the whole run — the same numbers the
+   * human-readable summary line prints, so a consumer never has to reconstruct
+   * them by counting output lines (#183, and the generic-consumer half of #181).
+   */
+  totals?: { findings: number; errors: number; warnings: number };
 }
 
 /**
@@ -1272,6 +1284,64 @@ async function verifyMarkdownMcpRefs(
 }
 
 /** Exit codes: 0 clean, 1 warnings only, 2 hard errors. */
+/**
+ * The run's totals, derived from the report itself.
+ *
+ * 🔴 ONE SOURCE, because the two numbers disagreeing IS the bug (#183). The
+ * human-readable log had no total, and counting its `⚠` lines gave a different
+ * number from the JSON — 21 against 88 on a real repo — because some checks print
+ * one line per finding and others one line carrying a count. Both numbers were
+ * right and nothing said why they differed, so "vigiles reports 21 warnings" and
+ * "88 warnings" were equally defensible readings of one run.
+ *
+ * Counted GENERICALLY off the `*Issues` / `*Errors` / count keys rather than a
+ * hand-maintained list, so a rule added later is included by existing, not by
+ * somebody remembering. `orphanCount` and `duplicatePairs` are named explicitly
+ * only because they predate the `*Issues` convention (#181).
+ */
+export function lintTotals(report: LintReport): {
+  findings: number;
+  errors: number;
+  warnings: number;
+} {
+  let errors = 0;
+  let findings = 0;
+  for (const [key, value] of Object.entries(report)) {
+    if (typeof value !== "number" || value === 0) continue;
+    if (key === "files") continue;
+    // Informational counters: not findings, they describe the corpus.
+    if (
+      key === "inlineRules" ||
+      key === "frontmatterRules" ||
+      key === "coverageEnabled" ||
+      key === "coverageDocumented" ||
+      key === "strengthenSuggestions"
+    )
+      continue;
+    if (key.endsWith("Errors")) {
+      errors += value;
+      findings += value;
+      continue;
+    }
+    // `*Issues` counts EVERY finding of that rule; when the rule is at "error"
+    // the same findings are also in `*Errors`, so they must not be counted twice.
+    if (key.endsWith("Issues")) {
+      const paired = (report as unknown as Record<string, number>)[
+        `${key.slice(0, -"Issues".length)}Errors`
+      ];
+      findings += paired && paired > 0 ? 0 : value;
+      continue;
+    }
+    if (
+      key === "orphanCount" ||
+      key === "duplicatePairs" ||
+      key === "untestedSurfaces"
+    )
+      findings += value;
+  }
+  return { findings, errors, warnings: findings - errors };
+}
+
 function lintExitCode(report: LintReport): 0 | 1 | 2 {
   if (
     report.hashErrors > 0 ||
@@ -1310,7 +1380,12 @@ function lintExitCode(report: LintReport): 0 | 1 | 2 {
     report.docRefErrors > 0
   )
     return 2;
-  if (report.duplicatePairs > 0 || report.orphanCount > 0) return 1;
+  // Tierable now: a `warn` orphan/duplicate finding is reported and does NOT
+  // change the exit code. Both used to feed the exit directly, which is what
+  // made them the only untierable findings in the tool.
+  if (report.orphanCount > 0 && report.orphanSeverity === "error") return 1;
+  if (report.duplicatePairs > 0 && report.duplicateSeverity === "error")
+    return 1;
   // Guidance counts are informational, not failures
   return 0;
 }
@@ -1636,6 +1711,112 @@ function sharedDirsRootFor(scanTarget: string): string {
   return underCwd ? cwd : target;
 }
 
+/**
+ * Nested plugin bundles under a lint root — a directory that is itself a harness
+ * (its own `.claude-plugin/plugin.json`, or its own skills dir) and is NOT the
+ * root being linted.
+ *
+ * 🔴 WHY THIS EXISTS. Every per-surface check reads ONE root, so in a monorepo
+ * holding `skills/` plus `plugins/  * /skills/` the nested skills were never scored
+ * and nothing said so. Measured on a fixture: 4 skills over the description
+ * budget, `lint .` reported 2, exit 0 — a repo reads that as green-with-2 while
+ * the other 2 carry the same defect (#185). The failure is silent, which is the
+ * shape this repo treats as worse than a loud one.
+ *
+ * Deliberately shallow (one level under a container dir): deep recursion would
+ * sweep vendored corpora — this repo's own `test/dogfood/` holds real pinned
+ * third-party plugins — and scoring someone else's vendored plugin as if it were
+ * yours is the false-positive that gets a gate switched off.
+ */
+export function discoverNestedBundles(
+  root: string,
+  exclude: readonly string[] = [],
+): string[] {
+  const out: string[] = [];
+  const skip = new Set([
+    "node_modules",
+    ".git",
+    "dist",
+    "coverage",
+    ".vigiles",
+  ]);
+  const isBundle = (dir: string): boolean =>
+    existsSync(join(dir, ".claude-plugin", "plugin.json")) ||
+    existsSync(join(dir, "skills"));
+  const excluded = (rel: string): boolean =>
+    exclude.some(
+      (pattern) =>
+        rel === pattern ||
+        rel.startsWith(`${pattern}/`) ||
+        minimatch(rel, pattern) ||
+        minimatch(rel, `${pattern}/**`),
+    );
+
+  let entries: string[];
+  try {
+    entries = readdirSync(root, { withFileTypes: true })
+      .filter(
+        (e) => e.isDirectory() && !skip.has(e.name) && !e.name.startsWith("."),
+      )
+      .map((e) => e.name);
+  } catch {
+    return out;
+  }
+  for (const name of entries) {
+    const dir = join(root, name);
+    if (excluded(name)) continue;
+    // A container (`plugins/`) holds bundles; a bundle may also sit directly.
+    if (isBundle(dir)) {
+      out.push(dir);
+      continue;
+    }
+    let inner: string[];
+    try {
+      inner = readdirSync(dir, { withFileTypes: true })
+        .filter((e) => e.isDirectory() && !e.name.startsWith("."))
+        .map((e) => e.name);
+    } catch {
+      continue;
+    }
+    for (const child of inner) {
+      const sub = join(dir, child);
+      if (excluded(`${name}/${child}`)) continue;
+      if (isBundle(sub)) out.push(sub);
+    }
+  }
+  return out.sort();
+}
+
+/**
+ * Run one per-surface check over EVERY root and sum its counters.
+ *
+ * The checks all share `(config, silent, adapter, root)` and return a small
+ * record of numbers, so one wrapper covers all twenty rather than twenty edits —
+ * and a check added later is swept in by using it, not by remembering to.
+ */
+function overBundles<T extends Record<string, number>>(
+  fn: (
+    config: VigilesConfig | undefined,
+    silent: boolean,
+    adapter: HarnessAdapter,
+    root: string,
+  ) => T,
+  config: VigilesConfig | undefined,
+  silent: boolean,
+  adapter: HarnessAdapter,
+  roots: readonly string[],
+): T {
+  const [first, ...rest] = roots;
+  const total = { ...fn(config, silent, adapter, first) };
+  for (const root of rest) {
+    const next = fn(config, silent, adapter, root);
+    for (const key of Object.keys(next) as (keyof T)[])
+      (total as Record<keyof T, number>)[key] =
+        (total[key] ?? 0) + (next[key] ?? 0);
+  }
+  return total;
+}
+
 async function runLint(
   restArgs: string[],
   flags: string[],
@@ -1675,6 +1856,33 @@ async function runLint(
     configHarness: normalizeHarnessList(config?.harness),
   });
   const adapter = lintSelection.adapter;
+
+  // 🔴 WHICH ROOTS GET SCORED, and saying so either way (#185).
+  //
+  // Every per-surface check reads ONE root, so a monorepo with `skills/` plus
+  // `plugins/*/skills/` scored only the first and said nothing — measured at 2
+  // findings reported against 4 real ones, exit 0. A skipped surface that is not
+  // announced reads as a clean surface.
+  //
+  // Default stays ROOT-ONLY on purpose: descending by default would start
+  // scoring vendored third-party corpora (this repo's own `test/dogfood/` holds
+  // pinned real plugins), and scoring someone else's plugin as if it were yours
+  // is the false positive that gets a gate turned off. So the DEFAULT fixes the
+  // SILENCE, and `bundles: "all"` fixes the COVERAGE — one exit code over the
+  // whole repo, which is what a CI gate needs.
+  const nestedBundles = discoverNestedBundles(scanRoot, config?.exclude ?? []);
+  const scoreAll = flags.includes("--bundles=all") || config?.bundles === "all";
+  const lintRoots = scoreAll ? [scanRoot, ...nestedBundles] : [scanRoot];
+  if (!silent && nestedBundles.length > 0) {
+    const rel = nestedBundles.map((b) => relative(scanRoot, b) || b);
+    console.log(
+      scoreAll
+        ? `\nScoring ${String(lintRoots.length)} bundles: the root + ${rel.join(", ")}`
+        : `\n⚠ ${String(nestedBundles.length)} nested bundle(s) discovered but NOT scored: ${rel.join(", ")}\n` +
+            `  Their skills/agents/hooks are not in the counters below. Add \`"bundles": "all"\` to ` +
+            `.vigilesrc.json (or pass --bundles=all) to score them in this run.`,
+    );
+  }
 
   // Discover the compiled files whose integrity is verified. Include the active
   // harness's subagent dir (dogfood E2): a compiled `agents/<name>.md` carries a
@@ -1746,7 +1954,14 @@ async function runLint(
   // declares the block; its `include` defaults to docs/ (research/ etc. are
   // opted into explicitly). `enforce("vigiles/orphan-docs")` in a spec only
   // validates the rule NAME — the block is what drives the scan.
-  const orphansCfg = config?.orphans;
+  // 🔴 SEVERITY IS READ, not just the block's presence (#181). `orphan-docs` had
+  // a RULE_META entry and a documented severity, and nothing ever read it: both
+  // `"warn"` and `"off"` still exited 1, so a repo could only choose between an
+  // always-blocking check and deleting the `orphans` block. `warn` now reports
+  // without touching the exit code and `false`/`"off"` skips the scan, exactly
+  // like every other rule.
+  const orphanSeverity = ruleSeverity(config?.rules?.["orphan-docs"]) ?? "warn";
+  const orphansCfg = orphanSeverity ? config?.orphans : undefined;
   if (!silent) console.log("\nOrphan docs check:\n");
   let orphanReport: ReturnType<typeof findOrphanDocs> = {
     include: [],
@@ -1778,142 +1993,218 @@ async function runLint(
   // 7b. Untested-surface check — skills/agents/hooks shipping without a test or
   // eval. Warning by default (a nudge, exit 0); set rules.untested-{skill,agent,
   // hook} to "error" to gate CI. See src/test-coverage.ts and docs/rules/.
-  const untested = checkUntestedSurfaces(config, silent, adapter, scanRoot);
+  const untested = overBundles(
+    checkUntestedSurfaces,
+    config,
+    silent,
+    adapter,
+    lintRoots,
+  );
 
   // 7c. Subagent tool-contract check — cross-reference each subagent's `tools:`
   // rail against the harness catalog (the moat). n/a on a harness with no
   // subagents. Off by default unless a severity is configured; warning surfaces
   // a typo/never-available tool, error gates CI.
-  const toolContract = checkSubagentToolContracts(
+  const toolContract = overBundles(
+    checkSubagentToolContracts,
     config,
     silent,
     adapter,
-    scanRoot,
+    lintRoots,
   );
 
   // 7d. Hook-event check — a hook registered under an event the harness doesn't
   // define never fires. High-precision (close typos only). Off unless configured.
-  const hookEvents = checkHookEvents(config, silent, adapter, scanRoot);
-
-  // 7e. Subagent-frontmatter check — a subagent missing required frontmatter
-  // (name + description) won't register. n/a on a harness with no subagents.
-  const frontmatter = checkFrontmatterSchema(config, silent, adapter, scanRoot);
-
-  // 7f. MCP-config check — a declared MCP server with no command/url can't start.
-  const mcpConfig = checkMcpConfig(config, silent, adapter, scanRoot);
-
-  // 7g. Skill-frontmatter — RECOMMEND explicit name/description on skills (a
-  // reliable trigger surface). Best-practice nudge; skills load without it.
-  const skillFm = checkSkillFrontmatter(config, silent, adapter, scanRoot);
-
-  // 7h. MCP tool-resolution — an `mcp__server__tool` in a contract whose server
-  // the plugin doesn't declare can't resolve (the MCP half of the tool moat).
-  const mcpToolResolves = checkMcpToolResolves(
+  const hookEvents = overBundles(
+    checkHookEvents,
     config,
     silent,
     adapter,
-    scanRoot,
+    lintRoots,
+  );
+
+  // 7e. Subagent-frontmatter check — a subagent missing required frontmatter
+  // (name + description) won't register. n/a on a harness with no subagents.
+  const frontmatter = overBundles(
+    checkFrontmatterSchema,
+    config,
+    silent,
+    adapter,
+    lintRoots,
+  );
+
+  // 7f. MCP-config check — a declared MCP server with no command/url can't start.
+  const mcpConfig = overBundles(
+    checkMcpConfig,
+    config,
+    silent,
+    adapter,
+    lintRoots,
+  );
+
+  // 7g. Skill-frontmatter — RECOMMEND explicit name/description on skills (a
+  // reliable trigger surface). Best-practice nudge; skills load without it.
+  const skillFm = overBundles(
+    checkSkillFrontmatter,
+    config,
+    silent,
+    adapter,
+    lintRoots,
+  );
+
+  // 7h. MCP tool-resolution — an `mcp__server__tool` in a contract whose server
+  // the plugin doesn't declare can't resolve (the MCP half of the tool moat).
+  const mcpToolResolves = overBundles(
+    checkMcpToolResolves,
+    config,
+    silent,
+    adapter,
+    lintRoots,
   );
 
   // 7i. Hook-script existence — a hook command referencing a missing script file
   // never runs (matches Anthropic's own `claude plugin validate`).
-  const hookScripts = checkHookScriptExists(config, silent, adapter, scanRoot);
-
-  // 7j. Disallowed-tools — a `disallowedTools:` block-list typo blocks nothing
-  // (the deny-side mirror of subagent-tool-contract; close-typo only).
-  const disallowedTools = checkDisallowedTools(
+  const hookScripts = overBundles(
+    checkHookScriptExists,
     config,
     silent,
     adapter,
-    scanRoot,
+    lintRoots,
+  );
+
+  // 7j. Disallowed-tools — a `disallowedTools:` block-list typo blocks nothing
+  // (the deny-side mirror of subagent-tool-contract; close-typo only).
+  const disallowedTools = overBundles(
+    checkDisallowedTools,
+    config,
+    silent,
+    adapter,
+    lintRoots,
   );
 
   // 7k. Description-overlap — two model-invocable skills with near-identical
   // descriptions collide in the selector (deterministic NCD precision proxy).
-  const descriptionOverlap = checkDescriptionOverlap(
+  const descriptionOverlap = overBundles(
+    checkDescriptionOverlap,
     config,
     silent,
     adapter,
-    scanRoot,
+    lintRoots,
   );
 
   // 7k². Skill-description-budget — a model-invocable skill whose description is
   // so long the trigger signal is buried (heuristic proxy; degrades recall +
   // precision). Generous 500-char budget; warn-tier, never gates.
-  const descriptionBudget = checkDescriptionBudget(
+  const descriptionBudget = overBundles(
+    checkDescriptionBudget,
     config,
     silent,
     adapter,
-    scanRoot,
+    lintRoots,
   );
 
   // 7l. Frontmatter-valid — a `---` block that isn't valid YAML (warn; js-yaml is
   // stricter than some loaders, so verify before enforcing).
-  const frontmatterValid = checkFrontmatterValid(
+  const frontmatterValid = overBundles(
+    checkFrontmatterValid,
     config,
     silent,
     adapter,
-    scanRoot,
+    lintRoots,
   );
 
   // 7m. MCP hook-target — a `type: mcp_tool` hook action that's incomplete or
   // targets an undeclared server (the moat applied to the hook surface).
-  const mcpHookTargets = checkMcpHookTargets(config, silent, adapter, scanRoot);
-
-  // 7n. Prefer-compiled-hooks — ONE discovery nudge (not per-hook) toward
-  // compiled `vigiles/hook` artifacts when hand-written hooks ship. Recommendation.
-  const preferCompiledHooks = checkPreferCompiledHooks(
+  const mcpHookTargets = overBundles(
+    checkMcpHookTargets,
     config,
     silent,
     adapter,
-    scanRoot,
+    lintRoots,
+  );
+
+  // 7n. Prefer-compiled-hooks — ONE discovery nudge (not per-hook) toward
+  // compiled `vigiles/hook` artifacts when hand-written hooks ship. Recommendation.
+  const preferCompiledHooks = overBundles(
+    checkPreferCompiledHooks,
+    config,
+    silent,
+    adapter,
+    lintRoots,
   );
 
   // 7o. Lethal-trifecta — a unit (subagent / model-invocable skill) whose tools
   // hold all three legs (read-private + ingest-untrusted + exfiltrate) is a
   // prompt-injection exfil path (Rule of Two). Capability SET-intersection.
-  const lethalTrifecta = checkLethalTrifecta(config, silent, adapter, scanRoot);
-
-  // 7p. Skill-resource — a SKILL.md body referencing a bundled file that doesn't
-  // exist on disk under the skill dir (the agent gets nothing). FP-safe.
-  const skillResources = checkSkillResourceResolves(
+  const lethalTrifecta = overBundles(
+    checkLethalTrifecta,
     config,
     silent,
     adapter,
-    scanRoot,
+    lintRoots,
+  );
+
+  // 7p. Skill-resource — a SKILL.md body referencing a bundled file that doesn't
+  // exist on disk under the skill dir (the agent gets nothing). FP-safe.
+  const skillResources = overBundles(
+    checkSkillResourceResolves,
+    config,
+    silent,
+    adapter,
+    lintRoots,
   );
 
   // 7q. Skill-missing-fence — a SKILL.md opening with `name:`/`description:` but no
   // `---` fence loads as plain body (invisible — no name/description/trigger).
-  const skillFence = checkSkillMissingFence(config, silent, adapter, scanRoot);
-
-  // 7r. Plugin-dir-layout — functional surface dirs (skills/agents/commands) nested
-  // inside the `.claude-plugin/` manifest dir where the harness can't see them.
-  const pluginLayout = checkPluginDirLayout(config, silent, adapter, scanRoot);
-
-  // 7s. Delegation-trifecta — a lethal trifecta that emerges across a delegation
-  // edge (a subagent's own ∪ delegated-to capability) though no single unit trips it.
-  const delegationTrifecta = checkDelegationTrifecta(
+  const skillFence = overBundles(
+    checkSkillMissingFence,
     config,
     silent,
     adapter,
-    scanRoot,
+    lintRoots,
+  );
+
+  // 7r. Plugin-dir-layout — functional surface dirs (skills/agents/commands) nested
+  // inside the `.claude-plugin/` manifest dir where the harness can't see them.
+  const pluginLayout = overBundles(
+    checkPluginDirLayout,
+    config,
+    silent,
+    adapter,
+    lintRoots,
+  );
+
+  // 7s. Delegation-trifecta — a lethal trifecta that emerges across a delegation
+  // edge (a subagent's own ∪ delegated-to capability) though no single unit trips it.
+  const delegationTrifecta = overBundles(
+    checkDelegationTrifecta,
+    config,
+    silent,
+    adapter,
+    lintRoots,
   );
 
   // 7t. Hook-block-ineffective — a hook that looks like it blocks but silently
   // doesn't (block decision on a non-blocking event, or the legacy `decision`
   // field on a permission-gated event). The #1 verified hook pain (#19009).
-  const hookBlock = checkHookBlockIneffective(
+  const hookBlock = overBundles(
+    checkHookBlockIneffective,
     config,
     silent,
     adapter,
-    scanRoot,
+    lintRoots,
   );
 
   // 7u. Hook-matcher — a hook `matcher` that doesn't fire as written (tool-name
   // typo, an uncompilable or unreachable MCP pattern, one too narrow for real
   // server naming, or an undeclared MCP server).
-  const hookMatcher = checkHookMatcher(config, silent, adapter, scanRoot);
+  const hookMatcher = overBundles(
+    checkHookMatcher,
+    config,
+    silent,
+    adapter,
+    lintRoots,
+  );
 
   // 8. Validate vigiles builder calls inside markdown code blocks — the
   // `doc-refs` rule, DEFAULT OFF. Illustrative blocks opt out via
@@ -2001,12 +2292,15 @@ async function runLint(
     frontmatterErrors,
     frontmatterRules,
     duplicatePairs: dups.pairCount,
+    duplicateSeverity:
+      ruleSeverity(config?.rules?.["duplicate-rules"]) ?? "warn",
     coverageEnabled: coverage.enabled,
     coverageDocumented: coverage.documented,
     strengthenSuggestions: guidanceCount,
     integrityErrors,
     coverageErrors,
     orphanCount: orphanReport.orphans.length,
+    orphanSeverity: orphanSeverity,
     untestedSurfaces: untested.untested,
     untestedErrors: untested.errors,
     toolContractIssues: toolContract.issues,
@@ -2058,13 +2352,43 @@ async function runLint(
     files,
   };
 
-  if (summary) {
-    printLintSummary(report);
-  } else if (json) {
-    console.log(JSON.stringify(report, null, 2));
+  // The totals both surfaces quote, computed ONCE (#183). Attaching them to the
+  // report is what makes the log line and `--json` incapable of disagreeing —
+  // the previous gap was not a wrong number, it was two right numbers with
+  // nothing explaining the difference.
+  const totals = lintTotals(report);
+  const reported: LintReport = { ...report, totals };
+
+  // `--json-out=<file>` writes the JSON to disk while stdout keeps the
+  // human-readable run — one scan, both artefacts (#182). A CI job needed both
+  // (the log is what a human opens; the JSON is what the PR comment is built
+  // from) and had to scan the repo TWICE to get them, which is the same work
+  // done twice and grows with the corpus.
+  const jsonOutFlag = flags.find((f) => f.startsWith("--json-out="));
+  if (jsonOutFlag) {
+    const dest = resolve(jsonOutFlag.slice("--json-out=".length));
+    mkdirSync(dirname(dest), { recursive: true });
+    writeFileSync(dest, `${JSON.stringify(reported, null, 2)}\n`);
+    if (!silent) console.log(`\n✓ JSON report written to ${dest}`);
   }
 
-  return report;
+  if (summary) {
+    printLintSummary(reported);
+  } else if (json) {
+    console.log(JSON.stringify(reported, null, 2));
+  } else {
+    // The one number a reader can quote. Counting `⚠` lines gives a DIFFERENT
+    // number, because some checks print one line per finding and others one line
+    // carrying a count — so the log now states the finding total outright rather
+    // than leaving the reader to infer it from line shapes.
+    const code = lintExitCode(reported);
+    console.log(
+      `\n${String(totals.findings)} finding(s): ${String(totals.errors)} error, ` +
+        `${String(totals.warnings)} warning — exit ${String(code)}`,
+    );
+  }
+
+  return reported;
 }
 
 /** Single-line lint summary for SessionStart hooks — minimal token cost. */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1141,6 +1141,8 @@ interface LintReport {
   inlineRules: number;
   frontmatterErrors: number;
   frontmatterRules: number;
+  specRefIssues: number;
+  specRefErrors: number;
   duplicatePairs: number;
   /** Severity of `duplicate-instructions` — carried so the exit code can tier it. */
   duplicateSeverity: RuleSeverity;
@@ -1377,7 +1379,8 @@ function lintExitCode(report: LintReport): 0 | 1 | 2 {
     // it to "error", so it belongs in the hard tier with every other explicit
     // error — it used to sit at exit 1 because it fired unasked and could not be
     // turned off.
-    report.docRefErrors > 0
+    report.docRefErrors > 0 ||
+    report.specRefErrors > 0
   )
     return 2;
   // Tierable now: a `warn` orphan/duplicate finding is reported and does NOT
@@ -1817,6 +1820,71 @@ function overBundles<T extends Record<string, number>>(
   return total;
 }
 
+/**
+ * Re-derive a compiled artifact's references from its SPEC, and report the dead
+ * ones — the half of #173 that deleting the write-on-error did not close.
+ *
+ * 🔴 THE HOLE. `lint` verifies the integrity HASH, which answers "is this file
+ * still what the spec compiled to" and says nothing about whether the things it
+ * NAMES still exist. So a `CLAUDE.md` committed while its refs were live stays
+ * green forever after the referenced file is deleted: `compile` errors, `lint`
+ * prints "hash valid — All compiled files intact" and exits 0. Reproduced:
+ *
+ *     $ vigiles compile CLAUDE.md.spec.ts
+ *     ✗ [stale-file] File not found: "docs/guide.md"
+ *     $ vigiles lint .
+ *     ✓ CLAUDE.md — hash valid       # exit 0
+ *
+ * The reporter named this residue himself when filing #173 and I deferred it;
+ * it is the gap between what `README.md` promises of `lint` ("the CI gate …
+ * broken refs") and what it checked. A hash is an integrity claim, not a
+ * reference claim, and the two were being read as one.
+ *
+ * Cost is bounded: only specs whose compiled target actually EXISTS are loaded,
+ * so a repo with no specs does no extra work at all.
+ */
+async function checkSpecRefs(
+  config: VigilesConfig | undefined,
+  silent: boolean,
+  dialect: HarnessDialect,
+): Promise<{ issues: number; errors: number }> {
+  const sev = ruleSeverity(config?.rules?.["spec-refs"]) ?? "error";
+  if (!sev) return { issues: 0, errors: 0 };
+  const found: string[] = [];
+  for (const specPath of findSpecs()) {
+    const target = specPath.replace(/\.spec\.ts$/, "");
+    if (!existsSync(target)) continue; // never compiled — `compile` reports it
+    const spec = await loadSpec(specPath);
+    if (!spec || spec._specType !== "claude") continue;
+    try {
+      const { errors } = compileClaude(spec, {
+        basePath: process.cwd(),
+        specFile: specPath,
+        dialect,
+        maxRules: config?.maxRules,
+        maxTokens: config?.maxTokens,
+        maxSectionLines: config?.maxSectionLines,
+        catalogOnly: config?.catalogOnly,
+        linters: config?.linters,
+      });
+      for (const e of errors)
+        found.push(`${target}: ${e.message} (from ${specPath})`);
+    } catch {
+      // A spec that will not load is `compile`'s finding, not this one's —
+      // reporting it here would double-report and blame the wrong command.
+      continue;
+    }
+  }
+  if (found.length > 0 && !silent) {
+    console.log("\nSpec reference check:\n");
+    for (const msg of found) {
+      console.log(`  ${sev === "error" ? "✗" : "⚠"} ${msg}`);
+      ghAnnotate(sev === "error" ? "error" : "warning", msg);
+    }
+  }
+  return { issues: found.length, errors: sev === "error" ? found.length : 0 };
+}
+
 async function runLint(
   restArgs: string[],
   flags: string[],
@@ -1993,6 +2061,10 @@ async function runLint(
   // 7b. Untested-surface check — skills/agents/hooks shipping without a test or
   // eval. Warning by default (a nudge, exit 0); set rules.untested-{skill,agent,
   // hook} to "error" to gate CI. See src/test-coverage.ts and docs/rules/.
+  // A compiled artifact's refs, re-derived from its spec — the hash says the file
+  // is unchanged, not that what it names still exists (#173).
+  const specRefs = await checkSpecRefs(config, silent, adapter.dialect);
+
   const untested = overBundles(
     checkUntestedSurfaces,
     config,
@@ -2291,6 +2363,8 @@ async function runLint(
     inlineRules,
     frontmatterErrors,
     frontmatterRules,
+    specRefIssues: specRefs.issues,
+    specRefErrors: specRefs.errors,
     duplicatePairs: dups.pairCount,
     duplicateSeverity:
       ruleSeverity(config?.rules?.["duplicate-rules"]) ?? "warn",

--- a/src/core/rule-meta.ts
+++ b/src/core/rule-meta.ts
@@ -55,7 +55,7 @@ export type RuleSurface =
 export type RuleDefaultSeverity = "error" | "warn" | "off";
 
 /** Every named rule: the `RulesConfig` keys plus the built-in `orphan-docs`. */
-export type RuleName = keyof RulesConfig | "orphan-docs";
+export type RuleName = keyof RulesConfig;
 
 /**
  * The declared shape of one rule — co-located metadata in the ESLint `meta`
@@ -362,6 +362,15 @@ export const RULE_META: Record<RuleName, RuleMeta> = {
   },
 
   // --- Docs hygiene ---------------------------------------------------------
+  "duplicate-rules": {
+    id: "duplicate-rules",
+    bucket: "heuristic-behavioral",
+    surface: ["instruction"],
+    defaultSeverity: "warn",
+    summary:
+      "Near-duplicate rules within one spec (NCD similarity) — two rules saying the same thing.",
+    detector: "findDuplicateRules",
+  },
   "orphan-docs": {
     id: "orphan-docs",
     bucket: "heuristic-behavioral",

--- a/src/core/rule-meta.ts
+++ b/src/core/rule-meta.ts
@@ -371,6 +371,15 @@ export const RULE_META: Record<RuleName, RuleMeta> = {
       "Near-duplicate rules within one spec (NCD similarity) — two rules saying the same thing.",
     detector: "findDuplicateRules",
   },
+  "spec-refs": {
+    id: "spec-refs",
+    bucket: "external-decidable",
+    surface: ["instruction"],
+    defaultSeverity: "error",
+    summary:
+      "A compiled instruction file whose spec references a file/script that no longer exists.",
+    detector: "compileClaude",
+  },
   "orphan-docs": {
     id: "orphan-docs",
     bucket: "heuristic-behavioral",

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -114,6 +114,25 @@ export interface TestCoverageConfig {
 
 export interface RulesConfig {
   /**
+   * Opt-in: a doc in a configured dir (default `docs/`) that no other `.md`
+   * references. The `orphans` block turns the SCAN on; this turns the FINDING
+   * into a warning or an error.
+   *
+   * It lived outside this interface until 2026-09 and therefore could not be
+   * set at all: `"warn"` and `"off"` were both ignored and the check always
+   * exited 1, so a repo's only choice was an always-blocking check or deleting
+   * the `orphans` block (#181). Default: "error", matching the old behaviour.
+   */
+  "orphan-docs"?: RuleSeverity;
+  /**
+   * Near-duplicate rules WITHIN one spec, by NCD similarity — spec bloat, two
+   * rules saying the same thing in different words.
+   *
+   * Also previously untierable, and worse: it had no rule id at all, so there
+   * was no name a config could even mention (#181). Default: "error".
+   */
+  "duplicate-rules"?: RuleSeverity;
+  /**
    * Require a `.spec.ts` behind each instruction file (CLAUDE.md / AGENTS.md) —
    * the file must be compiled from a typed spec, not hand-written. NARROW: only a
    * `.spec.ts` sibling (or an explicit `<!-- vigiles-disable
@@ -396,6 +415,20 @@ export interface VigilesConfig {
   /** Custom linter configs (rulesDir). */
   linters?: Record<string, { rulesDir?: string | string[] }>;
   /** Orphan-docs check configuration. Include/exclude globs, tsconfig-style. */
+  /**
+   * Which bundles `lint` scores: `"root"` (default) or `"all"`.
+   *
+   * A monorepo holding `skills/` plus `plugins/  * /skills/` had its nested skills
+   * silently uncounted — the counters looked complete while whole surfaces were
+   * never read (#185). `"all"` scores every discovered bundle in one pass, so a
+   * CI gate keeps ONE exit code over the whole repo.
+   *
+   * Root-only remains the default because descending unconditionally would score
+   * vendored third-party plugins (a repo may keep a pinned corpus on disk) as if
+   * they were the project's own. The default no longer hides the skip: `lint`
+   * names the bundles it did not score.
+   */
+  bundles?: "root" | "all";
   orphans?: OrphansConfig;
   /**
    * Glob patterns of instruction/skill files to EXCLUDE from `lint` discovery

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -125,6 +125,17 @@ export interface RulesConfig {
    */
   "orphan-docs"?: RuleSeverity;
   /**
+   * Re-derive a compiled instruction file's references from its `.spec.ts` and
+   * report the dead ones.
+   *
+   * The integrity hash answers "is this file still what the spec compiled to";
+   * it says nothing about whether the paths and scripts it NAMES still exist. So
+   * an artifact committed while its refs were live stayed green forever after
+   * the target was deleted — `compile` errored, `lint` said "hash valid" and
+   * exited 0 (#173). Default: "error", matching `compile`.
+   */
+  "spec-refs"?: RuleSeverity;
+  /**
    * Near-duplicate rules WITHIN one spec, by NCD similarity — spec bloat, two
    * rules saying the same thing in different words.
    *

--- a/src/core/validate.test.ts
+++ b/src/core/validate.test.ts
@@ -478,6 +478,7 @@ describe("loadConfig", () => {
       // Both were untierable until 2026-09 — they fed the exit code with no rule
       // id to address them (#181). Registered as real rules, they land at "warn"
       // like every other heuristic proxy.
+      "spec-refs": "error",
       "orphan-docs": "warn",
       "duplicate-rules": "warn",
       "require-instructions-spec": "warn",

--- a/src/core/validate.test.ts
+++ b/src/core/validate.test.ts
@@ -475,6 +475,11 @@ describe("loadConfig", () => {
     const config = loadConfig();
     assert.deepEqual(config.ruleMarkers, ["headings", "checkboxes"]);
     assert.deepEqual(config.rules, {
+      // Both were untierable until 2026-09 — they fed the exit code with no rule
+      // id to address them (#181). Registered as real rules, they land at "warn"
+      // like every other heuristic proxy.
+      "orphan-docs": "warn",
+      "duplicate-rules": "warn",
       "require-instructions-spec": "warn",
       // the consistent require-<surface>-spec parallel → default off
       "require-skill-spec": false,

--- a/src/core/validate.ts
+++ b/src/core/validate.ts
@@ -73,6 +73,9 @@ export const DEFAULT_RULES: Required<RulesConfig> = {
   // caught that disagreement the moment the rule was registered properly.
   //
   // Set either to `"error"` to keep the old blocking behaviour.
+  // Hard error, like `compile` itself: a dead reference is decidable from the
+  // filesystem, not a proxy — the calibration rule's `external-decidable` tier.
+  "spec-refs": "error",
   "orphan-docs": "warn",
   "duplicate-rules": "warn",
   "require-instructions-spec": "warn",

--- a/src/core/validate.ts
+++ b/src/core/validate.ts
@@ -60,6 +60,21 @@ const INSTRUCTION_FILES: readonly string[] = ["CLAUDE.md", "AGENTS.md"];
 const DEFAULT_FILES: string[] = [INSTRUCTION_FILES[0]];
 
 export const DEFAULT_RULES: Required<RulesConfig> = {
+  // 🔴 BOTH DROP TO "warn", and that is a deliberate behaviour change.
+  //
+  // They used to feed the exit code directly and could not be tiered at all
+  // (#181), so a single unreferenced doc turned a PR red with no way to say
+  // "report it, do not block". Naming them as rules made the contradiction
+  // visible: both are HEURISTIC-BEHAVIORAL (an NCD similarity proxy, an
+  // "unreferenced" guess that an OSS sweep measured at ~100% false positives on
+  // nav-managed doc sites), and this repo's own calibration rule is that a
+  // heuristic never defaults to `error` because it cries wolf. `orphan-docs`
+  // already DECLARED `warn` in its meta while behaving as `error` — the gate
+  // caught that disagreement the moment the rule was registered properly.
+  //
+  // Set either to `"error"` to keep the old blocking behaviour.
+  "orphan-docs": "warn",
+  "duplicate-rules": "warn",
   "require-instructions-spec": "warn",
   // Default OFF — the consistent `require-<surface>-spec` parallel. Skills are
   // legitimately hand-written, so requiring a .spec.ts per SKILL.md is the wrong

--- a/src/harness-resolve-hooks.mts
+++ b/src/harness-resolve-hooks.mts
@@ -1,0 +1,59 @@
+/**
+ * Module-resolution hook for HARNESS scripts: make a bare `vigiles` import
+ * resolve to the CLI's OWN installation.
+ *
+ * 🔴 WHY. A harness file does `import { runHook } from "vigiles"`, so the
+ * package has to sit in a `node_modules` Node can reach from that file. In a
+ * repo that already has a `package.json`, the obvious way to put it there is
+ * `npm install` in the root — which installs the whole dependency tree. Measured
+ * by an adopter (#184): **840 packages in 2 minutes** where vigiles alone is 42
+ * and about 90 MB; the other 798 were a model-eval framework and an agent SDK
+ * that the gate — `lint` and `test`, both deterministic reads — never touches.
+ * One run sat 11 minutes in that step before being cancelled. Their workaround
+ * was installing into a directory outside the workspace and symlinking the tree
+ * back in, which works and is not something every adopter should reinvent.
+ *
+ * ⚠️ `NODE_PATH` does NOT solve this, and that was measured rather than assumed:
+ * Node ignores it for ESM resolution, and a harness is ESM. So the only ways to
+ * resolve a bare specifier from elsewhere are a real `node_modules` entry (the
+ * symlink) or a resolver hook. This is the hook.
+ *
+ * Scope is deliberately narrow: ONLY the `vigiles` specifier and its subpaths,
+ * and only when the normal resolution fails. A harness that has vigiles
+ * installed locally keeps resolving to the local copy, so nothing changes for a
+ * repo that already worked — this only fills the hole where resolution would
+ * otherwise throw.
+ */
+import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
+
+type ResolveContext = { parentURL?: string; conditions: string[] };
+type Resolved = { url: string; format?: string | null; shortCircuit?: boolean };
+type NextResolve = (
+  specifier: string,
+  context: ResolveContext,
+) => Resolved | Promise<Resolved>;
+
+/** The CLI's own package root, handed in by the parent process. */
+const SELF = process.env.VIGILES_SELF_ROOT ?? "";
+
+export async function resolve(
+  specifier: string,
+  context: ResolveContext,
+  nextResolve: NextResolve,
+): Promise<Resolved> {
+  try {
+    return await nextResolve(specifier, context);
+  } catch (err) {
+    // Only rescue OUR specifier, and only after normal resolution failed, so a
+    // locally installed vigiles always wins and no other package is affected.
+    if (!SELF) throw err;
+    if (specifier !== "vigiles" && !specifier.startsWith("vigiles/")) throw err;
+    const require = createRequire(pathToFileURL(`${SELF}/package.json`));
+    // Resolve through the package's own `exports` map rather than guessing a
+    // file path, so a subpath like `vigiles/eval` obeys the same contract it
+    // would from a normal install.
+    const target = require.resolve(specifier, { paths: [SELF] });
+    return { url: pathToFileURL(target).href, shortCircuit: true };
+  }
+}

--- a/src/harness-resolve.test.ts
+++ b/src/harness-resolve.test.ts
@@ -1,0 +1,113 @@
+/**
+ * A harness resolves its bare `vigiles` import from the CLI's own install (#184).
+ *
+ * The report: a harness does `import { runHook } from "vigiles"`, so the package
+ * must sit in a `node_modules` Node can reach. In a repo that already has a
+ * `package.json`, the obvious way to put it there installs the WHOLE dependency
+ * tree — measured at 840 packages in 2 minutes where vigiles alone is 42, with
+ * one run sitting 11 minutes in that step before being cancelled. The reporter's
+ * workaround was installing to a directory outside the workspace and symlinking
+ * the tree back in.
+ *
+ * ⚠️ `NODE_PATH` is NOT the fix, and that was measured rather than assumed: Node
+ * ignores it for ESM resolution and a harness is ESM. A resolver hook is the only
+ * mechanism left short of a real `node_modules` entry.
+ */
+import { test, beforeEach, afterEach } from "vitest";
+import assert from "node:assert/strict";
+import { writeFileSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { execFileSync } from "node:child_process";
+
+import { makeTmpDir, cleanupTmpDir } from "./core/test-utils.js";
+
+const CLI = resolve(__dirname, "..", "dist", "cli.js");
+let dir: string;
+
+beforeEach(() => {
+  dir = makeTmpDir();
+});
+afterEach(() => {
+  cleanupTmpDir(dir);
+});
+
+function runTest(): { code: number; out: string } {
+  try {
+    return {
+      code: 0,
+      out: execFileSync("node", [CLI, "test"], {
+        cwd: dir,
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
+    };
+  } catch (e) {
+    const err = e as { status?: number; stdout?: string; stderr?: string };
+    return {
+      code: err.status ?? 1,
+      out: `${err.stdout ?? ""}${err.stderr ?? ""}`,
+    };
+  }
+}
+
+test("a harness importing `vigiles` runs with NO project install (#184)", () => {
+  // The load-bearing case: no package.json, no node_modules, nothing installed.
+  writeFileSync(
+    join(dir, "probe.harness.mjs"),
+    `import { runHook } from "vigiles";\n` +
+      `const r = runHook("exit 2", { hook_event_name: "PreToolUse", tool_name: "Bash" });\n` +
+      `if (!r.blocked) { console.error("guard did not block"); process.exit(1); }\n` +
+      `console.log("resolved and ran");\n`,
+  );
+  assert.equal(
+    existsSync(join(dir, "node_modules")),
+    false,
+    "nothing installed",
+  );
+
+  const r = runTest();
+  assert.equal(r.code, 0, r.out);
+  assert.match(r.out, /resolved and ran/);
+  assert.match(r.out, /1 passed/);
+});
+
+test("a subpath import resolves through the package's own exports map", () => {
+  // Not a guessed file path: `vigiles/spec` must obey the same `exports`
+  // contract it would from a normal install, or the rescue would work for the
+  // root specifier and quietly fail for every subpath.
+  writeFileSync(
+    join(dir, "sub.harness.mjs"),
+    `import { instructionFile } from "vigiles/spec";\n` +
+      `if (typeof instructionFile !== "function") process.exit(1);\n` +
+      `console.log("subpath ok");\n`,
+  );
+  const r = runTest();
+  assert.equal(r.code, 0, r.out);
+  assert.match(r.out, /subpath ok/);
+});
+
+test("an unrelated missing package is NOT rescued and NOT passed", () => {
+  // The other half. The hook rescues ONLY the vigiles specifier; if it swallowed
+  // or mis-resolved anything else, a harness with a real missing dependency would
+  // fail somewhere confusing instead of at its own import.
+  //
+  // ⚠️ The expectation here is a LOUD SKIP, not exit 1, and that is the runner's
+  // pre-existing documented contract rather than something this change relaxed:
+  // a module that cannot LOAD executed no assertion, so it is "did not run" (like
+  // a missing `claude`), and treating it as `fail` would retract yesterday's
+  // coverage because the machine broke. It still prints `⊘ SKIPPED`, never `✓`,
+  // and `--no-skip` — which this repo's own CI passes — turns it into a failure.
+  writeFileSync(
+    join(dir, "other.harness.mjs"),
+    `import "definitely-not-a-real-package-xyz";\nconsole.log("should not reach");\n`,
+  );
+  const r = runTest();
+  assert.match(
+    r.out,
+    /definitely-not-a-real-package-xyz/,
+    "the real error is shown",
+  );
+  assert.equal(r.out.includes("should not reach"), false, "the body never ran");
+  assert.match(r.out, /SKIPPED/, "loud, never folded into a pass");
+  assert.doesNotMatch(r.out, /1 passed/);
+});

--- a/src/harness-resolve.test.ts
+++ b/src/harness-resolve.test.ts
@@ -39,6 +39,9 @@ function runTest(): { code: number; out: string } {
         cwd: dir,
         encoding: "utf-8",
         stdio: ["ignore", "pipe", "pipe"],
+        // Same reason as lint-contract.test.ts: annotation mode duplicates
+        // message text and makes occurrence counts environment-dependent.
+        env: { ...process.env, GITHUB_ACTIONS: undefined } as NodeJS.ProcessEnv,
       }),
     };
   } catch (e) {

--- a/src/lint-contract.test.ts
+++ b/src/lint-contract.test.ts
@@ -17,7 +17,13 @@
  */
 import { test, beforeEach, afterEach } from "vitest";
 import assert from "node:assert/strict";
-import { writeFileSync, mkdirSync, readFileSync, existsSync } from "node:fs";
+import {
+  writeFileSync,
+  mkdirSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+} from "node:fs";
 import { join, resolve } from "node:path";
 import { execFileSync } from "node:child_process";
 
@@ -227,4 +233,77 @@ test("--json still replaces stdout, unchanged", () => {
   const out = run(["lint", ".", "--json"]).out;
   assert.doesNotMatch(out, /finding\(s\):/);
   JSON.parse(out); // throws if stdout is not pure JSON
+});
+
+// --- #173 (residual): a committed artifact whose refs went dead -----------
+
+test("lint catches a committed artifact whose spec refs died (#173 residual)", () => {
+  // The half deleting the write-on-error did not close. An artifact committed
+  // while its refs were live stays hash-valid forever; delete the target and
+  // `compile` errors while `lint` said "✓ hash valid — All compiled files
+  // intact" and exited 0. A hash is an integrity claim, not a reference claim.
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify({ name: "f", version: "0.0.0", scripts: {} }),
+  );
+  mkdirSync(join(dir, "docs"), { recursive: true });
+  writeFileSync(join(dir, "docs", "guide.md"), "# Guide\n");
+  const specEntry = resolve(__dirname, "..", "dist", "core", "spec.js");
+  writeFileSync(
+    join(dir, "CLAUDE.md.spec.ts"),
+    `import { instructionFile, file } from ${JSON.stringify(specEntry)};\n` +
+      `export default instructionFile({\n` +
+      `  sections: { Overview: \`x\`, Routing: [file("docs/guide.md")] },\n` +
+      `  rules: {},\n` +
+      `});\n`,
+  );
+
+  assert.equal(run(["compile", "CLAUDE.md.spec.ts"]).code, 0, "compiles clean");
+  assert.equal(
+    run(["lint", "."]).code,
+    0,
+    "and lints clean while the ref lives",
+  );
+
+  // The reference dies AFTER the artifact was committed.
+  rmSync(join(dir, "docs", "guide.md"));
+
+  const after = run(["lint", "."]);
+  assert.equal(after.code, 2, "a dead ref fails the gate");
+  assert.match(after.out, /docs\/guide\.md/, "…and names the reference");
+});
+
+test("spec-refs is tierable, and silent when every ref is alive", () => {
+  // Both halves: it must not fire on a healthy repo, and `warn` must report
+  // without failing — the property #181 was filed about, applied to a new rule
+  // so it does not repeat the untierable mistake.
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify({ name: "f", version: "0.0.0", scripts: {} }),
+  );
+  mkdirSync(join(dir, "docs"), { recursive: true });
+  writeFileSync(join(dir, "docs", "guide.md"), "# Guide\n");
+  const specEntry = resolve(__dirname, "..", "dist", "core", "spec.js");
+  writeFileSync(
+    join(dir, "CLAUDE.md.spec.ts"),
+    `import { instructionFile, file } from ${JSON.stringify(specEntry)};\n` +
+      `export default instructionFile({\n` +
+      `  sections: { Overview: \`x\`, Routing: [file("docs/guide.md")] },\n` +
+      `  rules: {},\n` +
+      `});\n`,
+  );
+  run(["compile", "CLAUDE.md.spec.ts"]);
+
+  const healthy = run(["lint", "."]);
+  assert.equal(healthy.code, 0);
+  assert.equal(healthy.out.includes("Spec reference check"), false);
+
+  rmSync(join(dir, "docs", "guide.md"));
+  writeFileSync(
+    join(dir, ".vigilesrc.json"),
+    JSON.stringify({ rules: { "spec-refs": "warn" } }),
+  );
+  const warned = run(["lint", "."]);
+  assert.equal(warned.code, 0, "warn does not fail the build");
+  assert.match(warned.out, /guide\.md/, "…but still reports");
 });

--- a/src/lint-contract.test.ts
+++ b/src/lint-contract.test.ts
@@ -33,6 +33,7 @@ function run(args: string[], cwd = dir): { code: number; out: string } {
       cwd,
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "pipe"],
+      env: childEnv(),
     });
     return { code: 0, out };
   } catch (e) {
@@ -42,6 +43,23 @@ function run(args: string[], cwd = dir): { code: number; out: string } {
       out: `${err.stdout ?? ""}${err.stderr ?? ""}`,
     };
   }
+}
+
+/**
+ * The child's env with GitHub's annotation mode OFF.
+ *
+ * 🔴 Found by CI, not locally: under `GITHUB_ACTIONS` every finding is ALSO
+ * emitted as a `::warning::` annotation carrying the same message, so counting
+ * occurrences of a finding's text in the output doubles it — this file asserted
+ * 2 and got 4 on the runner while passing on a laptop. The tests here are about
+ * the HUMAN-READABLE run, so the annotation stream is noise that must be off
+ * rather than a number to double.
+ */
+function childEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  delete env.GITHUB_ACTIONS;
+  delete env.GITHUB_STEP_SUMMARY;
+  return env;
 }
 
 /** A skill whose description is deliberately over the 500-char budget. */

--- a/src/lint-contract.test.ts
+++ b/src/lint-contract.test.ts
@@ -1,0 +1,212 @@
+/**
+ * The `lint` output contract, from four adopter reports (#181, #182, #183, #185).
+ *
+ * They arrived as separate issues and share one root: what `lint` REPORTS could
+ * not be trusted as a complete, tierable, machine-readable account of the run.
+ * Nested bundles were scored by nobody and announced by nobody; two findings fed
+ * the exit code with no rule id to address them; the log and the JSON gave
+ * different totals with nothing explaining the gap; and getting both artefacts
+ * meant scanning the repo twice.
+ *
+ * 🔴 EVERY CASE HAS BOTH HALVES — it fires on the defect AND stays silent next
+ * door. A reporting gate whose success looks like silence cannot be noticed
+ * broken.
+ *
+ * Driven through the REAL built CLI: every one of these is about what the
+ * command PRINTS, WRITES or RETURNS, which no unit test of the detectors sees.
+ */
+import { test, beforeEach, afterEach } from "vitest";
+import assert from "node:assert/strict";
+import { writeFileSync, mkdirSync, readFileSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { execFileSync } from "node:child_process";
+
+import { makeTmpDir, cleanupTmpDir } from "./core/test-utils.js";
+
+const CLI = resolve(__dirname, "..", "dist", "cli.js");
+
+let dir: string;
+
+function run(args: string[], cwd = dir): { code: number; out: string } {
+  try {
+    const out = execFileSync("node", [CLI, ...args], {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { code: 0, out };
+  } catch (e) {
+    const err = e as { status?: number; stdout?: string; stderr?: string };
+    return {
+      code: err.status ?? 1,
+      out: `${err.stdout ?? ""}${err.stderr ?? ""}`,
+    };
+  }
+}
+
+/** A skill whose description is deliberately over the 500-char budget. */
+function skill(root: string, name: string, long: boolean): void {
+  const d = join(root, "skills", name);
+  mkdirSync(d, { recursive: true });
+  const desc = long
+    ? "Use this when you need to do the thing and also the other thing in a very specific situation. ".repeat(
+        7,
+      )
+    : "Short and fine.";
+  writeFileSync(
+    join(d, "SKILL.md"),
+    `---\nname: ${name}\ndescription: ${desc}\n---\n\nBody.\n`,
+  );
+}
+
+/** A nested plugin bundle with its own manifest and skills. */
+function bundle(root: string, name: string, long: boolean): void {
+  const b = join(root, "plugins", name);
+  mkdirSync(join(b, ".claude-plugin"), { recursive: true });
+  writeFileSync(
+    join(b, ".claude-plugin", "plugin.json"),
+    JSON.stringify({ name, version: "0.0.0" }),
+  );
+  skill(b, `${name}-skill`, long);
+}
+
+beforeEach(() => {
+  dir = makeTmpDir();
+  writeFileSync(
+    join(dir, ".vigilesrc.json"),
+    JSON.stringify({ rules: { "skill-description-budget": "warn" } }),
+  );
+});
+afterEach(() => {
+  cleanupTmpDir(dir);
+});
+
+// --- #185: nested bundles ------------------------------------------------
+
+test("nested bundles are ANNOUNCED when they are not scored (#185)", () => {
+  // The defect was silence, not scope: the counters looked complete while whole
+  // surfaces were never read, so a repo reads green-with-N while more skills
+  // carry the same defect.
+  skill(dir, "root-a", true);
+  bundle(dir, "alpha", true);
+
+  const r = run(["lint", "."]);
+  assert.match(r.out, /nested bundle\(s\) discovered but NOT scored/);
+  assert.match(r.out, /plugins\/alpha/);
+});
+
+test("--bundles=all scores them, and the count reaches ground truth", () => {
+  skill(dir, "root-a", true);
+  skill(dir, "root-b", true);
+  bundle(dir, "alpha", true);
+  bundle(dir, "beta", true);
+
+  const rootOnly = (run(["lint", "."]).out.match(/budget 500/g) ?? []).length;
+  const all = (
+    run(["lint", ".", "--bundles=all"]).out.match(/budget 500/g) ?? []
+  ).length;
+
+  assert.equal(rootOnly, 2, "root run sees only the root bundle's skills");
+  assert.equal(all, 4, "every over-budget skill in the repo is scored");
+});
+
+test("a repo with NO nested bundle says nothing about bundles", () => {
+  // The other half: the announcement must not become permanent noise on the
+  // ordinary single-bundle repo, which is most of them.
+  skill(dir, "root-a", true);
+  const r = run(["lint", "."]);
+  assert.equal(r.out.includes("nested bundle"), false);
+});
+
+// --- #181: tierable orphan / duplicate findings ---------------------------
+
+test("orphan-docs honours its severity instead of always exiting 1 (#181)", () => {
+  mkdirSync(join(dir, "docs"), { recursive: true });
+  writeFileSync(
+    join(dir, "docs", "orphan.md"),
+    "# Orphan\n\nNothing links here.\n",
+  );
+  skill(dir, "demo", false);
+
+  const cfg = (rules: Record<string, unknown>): void => {
+    writeFileSync(
+      join(dir, ".vigilesrc.json"),
+      JSON.stringify({ orphans: { include: ["docs/**/*.md"] }, rules }),
+    );
+  };
+
+  cfg({ "orphan-docs": "error" });
+  assert.equal(run(["lint", "."]).code, 1, "error still blocks");
+
+  cfg({ "orphan-docs": "warn" });
+  const warned = run(["lint", "."]);
+  assert.equal(warned.code, 0, "warn reports without failing the build");
+  assert.match(warned.out, /orphan/i, "…and it is still REPORTED, not hidden");
+
+  cfg({ "orphan-docs": false });
+  assert.equal(run(["lint", "."]).code, 0, "off skips the check");
+});
+
+// --- #183: one total, and the JSON agrees --------------------------------
+
+test("the run ends with a total, and --json carries the same numbers (#183)", () => {
+  skill(dir, "root-a", true);
+  skill(dir, "root-b", true);
+
+  const human = run(["lint", "."]);
+  const m = /(\d+) finding\(s\): (\d+) error, (\d+) warning/.exec(human.out);
+  assert.ok(m, "the human-readable run states a total");
+
+  const parsed = JSON.parse(run(["lint", ".", "--json"]).out) as {
+    totals: { findings: number; errors: number; warnings: number };
+  };
+  assert.equal(
+    Number(m[1]),
+    parsed.totals.findings,
+    "the log and the JSON cannot disagree — they read one computed total",
+  );
+  assert.equal(Number(m[2]), parsed.totals.errors);
+  assert.equal(Number(m[3]), parsed.totals.warnings);
+});
+
+test("the total counts findings, not output lines", () => {
+  // The gap that made two right numbers look wrong: some checks print one line
+  // per finding, others one line carrying a count. 19 + 34 + 35 findings showed
+  // as 21 `⚠` lines on the reporter's repo.
+  skill(dir, "a", true);
+  skill(dir, "b", true);
+  skill(dir, "c", true);
+  const out = run(["lint", "."]).out;
+  const warnLines = (out.match(/⚠/g) ?? []).length;
+  const total = Number(/(\d+) finding\(s\)/.exec(out)?.[1] ?? "0");
+  assert.ok(total > 0);
+  assert.notEqual(
+    total,
+    warnLines,
+    "if these ever match by construction the test proves nothing — the point is that the total is computed, not counted",
+  );
+});
+
+// --- #182: one pass, both artefacts --------------------------------------
+
+test("--json-out writes JSON while stdout stays human-readable (#182)", () => {
+  skill(dir, "root-a", true);
+  const dest = join(dir, "out", "lint.json");
+
+  const r = run(["lint", ".", `--json-out=${dest}`]);
+
+  assert.match(r.out, /finding\(s\)/, "stdout is still the human-readable run");
+  assert.equal(existsSync(dest), true, "and the JSON landed on disk");
+  const parsed = JSON.parse(readFileSync(dest, "utf-8")) as {
+    totals: { findings: number };
+  };
+  assert.ok(parsed.totals.findings > 0, "the file is the real report");
+});
+
+test("--json still replaces stdout, unchanged", () => {
+  // The new flag must not alter the old one's contract.
+  skill(dir, "root-a", true);
+  const out = run(["lint", ".", "--json"]).out;
+  assert.doesNotMatch(out, /finding\(s\):/);
+  JSON.parse(out); // throws if stdout is not pure JSON
+});


### PR DESCRIPTION
## What and why

Closes #181, closes #182, closes #183, closes #184, closes #185 — and the residual half of #173.

Five issues that arrived separately and share one root: **what `lint` reports could not be trusted as a complete, tierable, machine-readable account of the run.** Every claim was reproduced against the source before anything changed.

**#185 — nested bundles were scored by nobody and announced by nobody.** Reproduced on a fixture: 4 skills over the description budget, `lint .` reported **2**, exit 0. Split in two, because the silence and the scope are different bugs — the default now names what it did not score, and `--bundles=all` scores everything in one pass with one exit code. Root-only stays the default because descending unconditionally would score **vendored third-party plugins** (this repo's own `test/dogfood/` holds pinned real ones) as if they were yours.

**#181 — two findings fed the exit code with no rule id to address them.** `orphan-docs` had a documented severity nothing read; the duplicate-rules check had no id at all. Both are real rules now and the exit code respects their severity.

**#183 — the log and the JSON disagreed.** 21 `⚠` lines against 88 findings, because some checks print one line per finding and others one line carrying a count. One computed total now, printed and carried in `--json` as `totals`.

**#182 — one scan, both artefacts.** `--json-out=<file>` writes the JSON while stdout stays human-readable.

**#184 — the harness tier no longer needs a project install.** `vigiles test` resolves a harness's bare `vigiles` import from the CLI's own installation, so `npx vigiles@<version> test` works with nothing installed.

**#173 residual — a committed artifact whose refs died.** Deleting compile's write-on-error stopped *new* poisoned artifacts and did nothing for one already committed. `lint` verified the integrity HASH — "is this still what the spec compiled to" — which says nothing about whether the things it NAMES still exist:

```
$ vigiles compile CLAUDE.md.spec.ts
✗ [stale-file] File not found: "docs/guide.md"
$ vigiles lint .
✓ CLAUDE.md — hash valid — All compiled files intact     # exit 0
```

The new `spec-refs` rule re-derives a compiled file's references from its spec and validates them exactly as `compile` does.

🔴 **It immediately found four real dead references in this repo.** `examples/CLAUDE.md.spec.ts` still pointed at `src/spec.ts`, `src/compile.ts`, `src/linters.ts` and `src/generate-types.ts` — all moved to `src/core/` in the hexagonal refactor, and the example's spec was never updated. Repointed; `lint .` is back to 0 errors.

## Safety impact

**Not "none" — two defaults get LOOSER and one new rule gets STRICTER, all deliberately.**

Registering `orphan-docs` and `duplicate-rules` surfaced a contradiction the repo's own gate caught the moment they became real rules: both are **heuristic-behavioral**, and the calibration rule is that a heuristic never defaults to `error` because it cries wolf. `orphan-docs` already *declared* `warn` while *behaving* as `error`.

- Both now default to `"warn"`; a repo relying on either to fail CI must set `"error"`. Hence the `!`.
- `spec-refs` defaults to `error`, matching `compile` and the `external-decidable` tier — a dead path is decidable from the filesystem, not a proxy. It will turn some repos red, and every one of those reds is an instruction file naming something the agent will not find.
- Nothing else gets stricter silently: `--bundles=all` is opt-in; the default run only gains an announcement.
- The resolver hook (#184) rescues **only** the `vigiles` specifier and **only** after normal resolution fails — a locally installed copy still wins, and an unrelated missing package still fails at its own import. Pinned by a test.
- Unchanged: the sandbox, `sandboxAvailable()`, `interceptTools`, and what any read-only path may execute.

## Checks

- [x] `npm test` passes locally, or CI is green
- [x] New behaviour has a test — or there's a note below saying why it doesn't
- [x] Docs updated if this changes a rule, a CLI surface, or a documented guarantee

**Gates, in order:** `npm run check` (**18/18 in 69s** — the repo's own list) · `npx vitest run --project unit` (**3427 passed, 21 skipped, 0 failed**).

**Docs:** `docs/rules/duplicate-rules.md` and `docs/rules/spec-refs.md` (new rules — the rule-meta test enforces an exact set match against `docs/rules/*.md`), plus a `lint`-in-a-monorepo section in `docs/cli.md`.

**Mutations** — seven, each verified to have landed and to fail on its own assertion: suppressing the bundle announcement · ignoring `--bundles=all` · ignoring orphan severity · suppressing the total line · making `--json-out` a no-op · disabling the resolver rescue · disabling the spec-refs check.

## Two things that were wrong on my side, not the code's

⚠️ **A test that passed locally and failed on the runner.** Under `GITHUB_ACTIONS` every finding is *also* emitted as a `::warning::` annotation carrying the same text, so counting occurrences doubled them — 2 asserted, 4 received. The child now runs with annotation mode off, verified by reproducing the failure locally with `GITHUB_ACTIONS=1`.

⚠️ **An existing test asserted the opposite of `spec-refs` and had to change.** `a failed compile leaves the LAST GOOD artifact alone` also claimed `lint` must be GREEN on that survivor — and that expectation *was* the hole. It now asserts exit 2 plus the named reference; the part about not destroying the file is still pinned by comparing bytes.

## What is deliberately NOT in this change

**The findings array from #182's second half** — per-finding `{rule, severity, path, message}` in `--json`. The reporter called it the more useful of his two options and he is right; it needs every check to *return* its messages instead of printing them, which is a larger refactor than this PR. Said here rather than letting the closure imply it shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrS34j2M8XR12P2QHaBer4

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Fixes**
- make the lint report complete, tierable and machine-readable
- the lint-contract counts were doubled by GitHub annotation mode
- catch a committed artifact whose spec references died
<!-- vigiles:pr-summary:end -->
