### PR TITLE
fix(compile)!: a failed compile has no stamp to write — in all five compilers

### DIFF
--- a/.vigiles/generated.d.ts
+++ b/.vigiles/generated.d.ts
@@ -101,7 +101,7 @@ declare module "vigiles/generated" {
     | "internal:check"
     | "docs:api";
 
-  /** 403 project files. */
+  /** 405 project files. */
   export type ProjectFile = 
     | "src/CLAUDE.md"
     | "src/CLAUDE.md.spec.ts"
@@ -308,6 +308,8 @@ declare module "vigiles/generated" {
     | "src/core/railway.test.ts"
     | "src/core/refs.test.ts"
     | "src/core/refs.ts"
+    | "src/core/repo-path.test.ts"
+    | "src/core/repo-path.ts"
     | "src/core/rule-catalog.test.ts"
     | "src/core/rule-catalog.ts"
     | "src/core/rule-meta.test.ts"
@@ -783,6 +785,8 @@ declare module "vigiles/spec" {
       | "src/core/railway.test.ts"
       | "src/core/refs.test.ts"
       | "src/core/refs.ts"
+      | "src/core/repo-path.test.ts"
+      | "src/core/repo-path.ts"
       | "src/core/rule-catalog.test.ts"
       | "src/core/rule-catalog.ts"
       | "src/core/rule-meta.test.ts"

--- a/api-surface/vigiles-linting.api.md
+++ b/api-surface/vigiles-linting.api.md
@@ -88,6 +88,7 @@ export function compileAgent(spec: AgentSpec, options: {
 
 // @public (undocumented)
 export interface CompileAgentResult {
+    artifact: StampedMarkdown | null;
     // (undocumented)
     errors: CompileError[];
     // (undocumented)
@@ -150,6 +151,7 @@ export interface CompileRailwayOptions {
 
 // @public (undocumented)
 export interface CompileRailwayResult {
+    artifact: StampedMarkdown | null;
     // (undocumented)
     errors: CompileError[];
     // (undocumented)
@@ -165,6 +167,7 @@ export function compileSkill(spec: SkillSpec, options?: {
 
 // @public (undocumented)
 export interface CompileSkillResult {
+    artifact: StampedMarkdown | null;
     // (undocumented)
     errors: CompileError[];
     // (undocumented)

--- a/api-surface/vigiles.api.md
+++ b/api-surface/vigiles.api.md
@@ -245,6 +245,9 @@ export interface BaselineFile {
 export function blocked(): Check<HookRunResult>;
 
 // @public
+export type BlockMechanism = "exit-code" | "deny-decision" | "halt-field";
+
+// @public
 export function cacheTokens(opts: {
     maxCreation?: number;
     maxRead?: number;
@@ -362,6 +365,7 @@ export function decideHook(exitCode: number, json: HookOutput | null, protocol?:
     blocked: boolean;
     decision: HookRunResult["decision"];
     haltsTurn: boolean;
+    blockedBy: readonly BlockMechanism[];
 };
 
 // @public
@@ -767,6 +771,7 @@ export interface HookPropertyResult<E> {
 // @public (undocumented)
 export interface HookRunResult extends ScriptRunResult {
     readonly blocked: boolean;
+    readonly blockedBy: readonly BlockMechanism[];
     readonly decision: HookOutput["decision"] | "allow" | "deny" | "ask" | undefined;
     readonly haltsTurn: boolean;
     readonly json: HookOutput | null;

--- a/src/check.test.ts
+++ b/src/check.test.ts
@@ -72,6 +72,7 @@ function hookResult(over: Partial<HookRunResult> = {}): HookRunResult {
     json: null,
     blocked: false,
     haltsTurn: false,
+    blockedBy: [],
     egress: [],
     filesWritten: [],
     decision: undefined,

--- a/src/cli-compile-gate.test.ts
+++ b/src/cli-compile-gate.test.ts
@@ -14,7 +14,7 @@
  */
 import { test, beforeEach, afterEach } from "vitest";
 import assert from "node:assert/strict";
-import { writeFileSync, existsSync, readFileSync } from "node:fs";
+import { writeFileSync, existsSync, readFileSync, mkdirSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { execFileSync } from "node:child_process";
 
@@ -133,5 +133,65 @@ test("lint no longer goes green over an artifact compile refused to write", () =
     linted.out.includes("hash valid"),
     false,
     "there is no artifact to call intact, so lint cannot report one",
+  );
+});
+
+// --- the same hole in the SIBLING compilers (found red-teaming #186) --------
+
+test("a SKILL spec with a dead ref writes nothing either", () => {
+  // #173 was fixed in `compileClaudeToFile` only. The identical three lines —
+  // write, THEN check errors — sat unchanged in the skill, subagent, railway and
+  // generator compilers, and all four stamped unconditionally. Worse than the
+  // original: `spec-refs` skips non-`claude` specs, so there was no lint-side
+  // backstop at all. Reproduced on the built CLI before the fix: a stamped
+  // SKILL.md on disk and `lint` reporting `✓ hash valid`, exit 0.
+  //
+  // Guarding four call sites would have left the fifth writable, so the write
+  // takes a `StampedMarkdown` that an erroring compile never mints.
+  const specEntry = resolve(__dirname, "..", "dist", "core", "spec.js");
+  mkdirSync(join(dir, "skills", "demo"), { recursive: true });
+  writeFileSync(
+    join(dir, "skills", "demo", "SKILL.md.spec.ts"),
+    `import { experimental_skill, file } from ${JSON.stringify(specEntry)};\n` +
+      `export default experimental_skill({\n` +
+      `  name: "demo",\n` +
+      `  description: "A demo skill whose body references a file that is gone.",\n` +
+      `  tools: ["Read"],\n` +
+      `  body: ["Read the guide: ", file("docs/never-existed.md")],\n` +
+      `});\n`,
+  );
+
+  const r = run("compile", "skills/demo/SKILL.md.spec.ts");
+  assert.notEqual(r.code, 0, "a dead ref fails the compile");
+  assert.match(r.out, /never-existed/);
+  assert.equal(
+    existsSync(join(dir, "skills", "demo", "SKILL.md")),
+    false,
+    "no stamped artifact: `lint` would have called it hash-valid",
+  );
+});
+
+test("a CLEAN skill spec still compiles and writes", () => {
+  // The other half — refusing to write must not become refusing to work.
+  const specEntry = resolve(__dirname, "..", "dist", "core", "spec.js");
+  mkdirSync(join(dir, "skills", "ok"), { recursive: true });
+  writeFileSync(
+    join(dir, "skills", "ok", "SKILL.md.spec.ts"),
+    `import { experimental_skill } from ${JSON.stringify(specEntry)};\n` +
+      `export default experimental_skill({\n` +
+      `  name: "ok",\n` +
+      `  description: "A skill with no references at all, so nothing can be stale.",\n` +
+      `  tools: ["Read"],\n` +
+      `  body: "Do the thing.",\n` +
+      `});\n`,
+  );
+
+  assert.equal(run("compile", "skills/ok/SKILL.md.spec.ts").code, 0);
+  const out = join(dir, "skills", "ok", "SKILL.md");
+  assert.equal(existsSync(out), true);
+  assert.match(
+    readFileSync(out, "utf-8"),
+    /vigiles:sha256/,
+    "and it is stamped",
   );
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,6 +34,7 @@ import {
   join,
 } from "node:path";
 import { minimatch } from "minimatch";
+import { repoRelative, type RepoRelativePath } from "./core/repo-path.js";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { globSync } from "glob";
 import { generateTypes } from "./core/generate-types.js";
@@ -201,6 +202,7 @@ import {
   addHash,
   validateFileRef,
   validateCommandRef,
+  type StampedMarkdown,
 } from "./core/compile.js";
 import type { CompileError } from "./core/compile.js";
 import type { ClaudeSpec, SkillSpec, AgentSpec, Railway } from "./core/spec.js";
@@ -615,11 +617,13 @@ function compileGeneratorSkillToFile(
   source: string,
 ): boolean {
   const outputPath = specPath.replace(/\.spec\.ts$/, "");
-  const { markdown, errors } = compileGeneratorSkill(source, {
+  const { artifact, errors } = compileGeneratorSkill(source, {
     basePath: process.cwd(),
     specFile: specPath,
   });
-  writeFileSync(resolve(process.cwd(), outputPath), markdown);
+  // Written only when the compile is clean: `artifact` is null otherwise, and
+  // `writeArtifact` takes nothing else.
+  if (artifact) writeArtifact(outputPath, artifact);
   if (errors.length === 0) {
     console.log(`\n✓ ${specPath} → ${outputPath} (generator skill)`);
     return true;
@@ -732,14 +736,16 @@ function compileSkillToFile(
   dialect: HarnessDialect,
 ): boolean {
   const outputPath = specPath.replace(/\.spec\.ts$/, "");
-  const { markdown, errors, warnings } = compileSkill(spec, {
+  const { artifact, errors, warnings } = compileSkill(spec, {
     basePath: process.cwd(),
     specFile: specPath,
     // The SKILL.md frontmatter profile comes from the resolved harness — a Codex
     // repo gets a minimal (name + description) SKILL.md; CC gets the full set.
     dialect,
   });
-  writeFileSync(resolve(process.cwd(), outputPath), markdown);
+  // Written only when the compile is clean: `artifact` is null otherwise, and
+  // `writeArtifact` takes nothing else.
+  if (artifact) writeArtifact(outputPath, artifact);
   if (errors.length === 0) {
     console.log(`\n✓ ${specPath} → ${outputPath}`);
     printWarnings(specPath, warnings);
@@ -758,12 +764,14 @@ function compileAgentToFile(
   dialect: HarnessDialect,
 ): boolean {
   const outputPath = specPath.replace(/\.spec\.ts$/, "");
-  const { markdown, errors, warnings } = compileAgent(spec, {
+  const { artifact, errors, warnings } = compileAgent(spec, {
     basePath: process.cwd(),
     specFile: specPath,
     dialect,
   });
-  writeFileSync(resolve(process.cwd(), outputPath), markdown);
+  // Written only when the compile is clean: `artifact` is null otherwise, and
+  // `writeArtifact` takes nothing else.
+  if (artifact) writeArtifact(outputPath, artifact);
   if (errors.length === 0) {
     console.log(`\n✓ ${specPath} → ${outputPath}`);
     printWarnings(specPath, warnings);
@@ -786,11 +794,13 @@ function compileRailwayToFile(
   knownAgents: readonly string[],
 ): boolean {
   const outputPath = specPath.replace(/\.spec\.ts$/, "");
-  const { markdown, errors } = compileRailway(spec, {
+  const { artifact, errors } = compileRailway(spec, {
     specFile: specPath,
     knownAgents,
   });
-  writeFileSync(resolve(process.cwd(), outputPath), markdown);
+  // Written only when the compile is clean: `artifact` is null otherwise, and
+  // `writeArtifact` takes nothing else.
+  if (artifact) writeArtifact(outputPath, artifact);
   if (errors.length === 0) {
     console.log(`\n✓ ${specPath} → ${outputPath}`);
     return true;
@@ -1883,6 +1893,19 @@ async function checkSpecRefs(
     }
   }
   return { issues: found.length, errors: sev === "error" ? found.length : 0 };
+}
+
+/**
+ * Write a compiled artifact. Accepts ONLY a {@link StampedMarkdown}, so a body
+ * that failed to compile cannot reach the disk — there is no stamp to pass.
+ *
+ * This replaces four copies of `writeFileSync(path, markdown)` that ran BEFORE
+ * their error check (#173, reproduced in the skill/subagent/railway/generator
+ * compilers after the CLAUDE.md one was fixed). Guarding four call sites would
+ * have left the fifth writable; the type leaves nothing to remember.
+ */
+function writeArtifact(outputPath: string, artifact: StampedMarkdown): void {
+  writeFileSync(resolve(process.cwd(), outputPath), artifact);
 }
 
 async function runLint(
@@ -7902,15 +7925,17 @@ async function runHookProgramCommand(file: string | undefined): Promise<void> {
  * one-line nudge rather than creating one silently. Best-effort — a failure here
  * never breaks the audit. `entries` are paths relative to the git root (cwd).
  */
-function ensureReportGitignored(cwd: string, entries: readonly string[]): void {
+function ensureReportGitignored(
+  cwd: string,
+  entries: readonly RepoRelativePath[],
+): void {
   if (entries.length === 0) return;
-  // An `--out` outside the repo produced entries like
-  // `../../../../private/tmp/x/vigiles-report.json`, which ignore NOTHING —
-  // .gitignore does not reach outside its own tree — and accumulate one dead
-  // block per output path. Worse in principle than in practice: `audit` is
-  // documented as a read-only report, and this made it edit a tracked file for
-  // no benefit at all. Inside the repo the write is expected and documented.
-  if (entries.some((e) => e.startsWith("..") || isAbsolute(e))) return;
+  // 🔴 THE GUARD THAT USED TO BE HERE IS GONE, and its absence is the point.
+  // It checked at the write site that no entry escaped the repo (#176.8) — which
+  // worked, and left the bug writable: the next caller to build an entry list
+  // still got a bare `string[]`. `RepoRelativePath` moves the check into the
+  // TYPE, so an escaping path cannot be handed to this function at all. One
+  // place mints them (`repoRelative`), and it returns null instead.
   const gi = resolve(cwd, ".gitignore");
   try {
     if (!existsSync(gi)) {
@@ -8965,10 +8990,19 @@ async function main(): Promise<void> {
         // backslashes (`relative()` yields `reports\x` on Windows, which would
         // never match `reports/x`).
         if (wroteReports.length > 0) {
-          const rel = wroteReports.map((f) => {
-            const r = relative(process.cwd(), resolve(outDir, f)) || f;
-            return pathSep === "/" ? r : r.split(pathSep).join("/");
-          });
+          // Only paths that PROVABLY sit inside the repo can be minted, so an
+          // `--out` pointing elsewhere yields nothing to write rather than a
+          // dead `../../..` entry.
+          const rel = wroteReports
+            .map((f) =>
+              repoRelative(process.cwd(), resolve(outDir, f), {
+                relative,
+                resolve,
+                isAbsolute,
+                sep: pathSep,
+              }),
+            )
+            .filter((p): p is RepoRelativePath => p !== null);
           ensureReportGitignored(process.cwd(), rel);
         }
         // A shareable deep-link for a public GitHub repo: the in-browser demo

--- a/src/core/compile-generator.ts
+++ b/src/core/compile-generator.ts
@@ -30,7 +30,7 @@ import ts from "typescript";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 
-import { readPackageScripts, addHash } from "./compile.js";
+import { readPackageScripts, seal, type StampedMarkdown } from "./compile.js";
 
 export interface GeneratorError {
   type: "stale-file" | "stale-command";
@@ -288,6 +288,11 @@ function extractMeta(obj: ts.ObjectLiteralExpression): SkillMeta {
 }
 
 export interface CompileGeneratorSkillResult {
+  /**
+   * The stamped artifact — present ONLY when `errors` is empty. `null` is what
+   * makes a failed compile unwritable: `writeArtifact` accepts nothing else.
+   */
+  artifact: StampedMarkdown | null;
   markdown: string;
   errors: GeneratorError[];
 }
@@ -317,6 +322,9 @@ export function compileGeneratorSkill(
   ) {
     return {
       markdown: "",
+      // No stamp for a spec that did not compile — the error branch has nothing
+      // to write, which is the whole point of the field.
+      artifact: null,
       errors: [
         {
           type: "stale-command",
@@ -340,7 +348,7 @@ export function compileGeneratorSkill(
   }
   fm.push("", "---");
   const content = `${fm.join("\n")}\n\n${body.trim()}\n`;
-  return { markdown: addHash(content, specFile), errors };
+  return { ...seal(content, errors, specFile), errors };
 }
 
 /**

--- a/src/core/compile.ts
+++ b/src/core/compile.ts
@@ -62,7 +62,29 @@ export function computeHash(content: string): string {
 }
 
 /** @internal Prepend a hash comment to compiled content. */
-export function addHash(content: string, specFile: string): string {
+/**
+ * A compiled body that carries a valid integrity stamp — mintable ONLY by
+ * {@link addHash}, and by construction only handed out for a CLEAN compile.
+ *
+ * 🔴 WHY A BRAND AND NOT A CHECK AT THE WRITE SITE. #173 was a `CLAUDE.md`
+ * written while its refs were known-dead: `compile` printed the errors, exited
+ * 1, and wrote the file anyway, stamped. `lint` then verified the stamp and
+ * exited 0 over an artifact that names files which do not exist. The fix that
+ * shipped moved the write behind an error check in ONE compiler — and the same
+ * three lines sat unchanged in four siblings (skill, subagent, railway,
+ * generator), where the lint-side backstop does not even reach because
+ * `spec-refs` only inspects `claude` specs. Reproduced end to end after that
+ * fix: a skill spec with a stale ref still produced a stamped `SKILL.md` and a
+ * green `lint`.
+ *
+ * Fixing five write sites leaves the class writable — the sixth compiler would
+ * be written the same way. Branding the STAMP moves the guarantee to where it is
+ * produced: `writeArtifact` accepts nothing else, and an erroring compile has no
+ * stamp to give it.
+ */
+export type StampedMarkdown = string & { readonly __stamped: unique symbol };
+
+export function addHash(content: string, specFile: string): StampedMarkdown {
   // 🔴 THE LAST GATE BEFORE A COMPILED FILE IS WRITTEN. Every compile path returns through here
   // (four call sites), which makes it the one place a whole class of defect can be stopped.
   //
@@ -82,7 +104,32 @@ export function addHash(content: string, specFile: string): string {
         `input()/file()/cmd() and friends: they take strings, not option objects.`,
     );
   }
-  return placeIntegrityHeader(content, computeHash(content), specFile);
+  // The ONE mint. Every stamped artifact in the codebase originates here, which
+  // is what makes the brand meaningful rather than decorative.
+  return placeIntegrityHeader(
+    content,
+    computeHash(content),
+    specFile,
+  ) as StampedMarkdown;
+}
+
+/**
+ * How every compiler finishes: the rendered body, plus a STAMPED artifact that
+ * exists only when the compile is clean.
+ *
+ * `markdown` stays a plain string because callers legitimately want the draft
+ * even when it is wrong — `adoptDiff` diffs "what the spec WOULD produce"
+ * against the file on disk, and a stale ref must not stop that. `artifact` is
+ * what a writer needs, and it is `null` the moment there is an error, so the
+ * write cannot happen without narrowing.
+ */
+export function seal(
+  body: string,
+  errors: readonly CompileError[],
+  specFile: string,
+): { markdown: string; artifact: StampedMarkdown | null } {
+  const stamped = addHash(body, specFile);
+  return { markdown: stamped, artifact: errors.length === 0 ? stamped : null };
 }
 
 /** @internal Check if a file's hash matches its content. Returns null if no hash found. */
@@ -956,6 +1003,11 @@ function checkInlineCode(markdown: string, max: number): CompileError[] {
 }
 
 export interface CompileSkillResult {
+  /**
+   * The stamped artifact — present ONLY when `errors` is empty. `null` is what
+   * makes a failed compile unwritable: `writeArtifact` accepts nothing else.
+   */
+  artifact: StampedMarkdown | null;
   markdown: string;
   errors: CompileError[];
   /** Non-blocking advisories (e.g. an over-long inline code block). */
@@ -1086,7 +1138,7 @@ export function compileSkill(
     (marker ? marker + "\n\n" : "") +
     sections.trim() +
     "\n";
-  return { markdown: addHash(content, specFile), errors, warnings };
+  return { ...seal(content, errors, specFile), errors, warnings };
 }
 
 // ---------------------------------------------------------------------------
@@ -1237,6 +1289,11 @@ function renderAgentRules(rules: Record<string, Rule>): string {
 }
 
 export interface CompileAgentResult {
+  /**
+   * The stamped artifact — present ONLY when `errors` is empty. `null` is what
+   * makes a failed compile unwritable: `writeArtifact` accepts nothing else.
+   */
+  artifact: StampedMarkdown | null;
   markdown: string;
   errors: CompileError[];
   /** Non-blocking advisories (e.g. an over-long inline code block). */
@@ -1321,7 +1378,7 @@ export function compileAgent(
     (marker ? marker + "\n\n" : "") +
     body.trim() +
     "\n";
-  return { markdown: addHash(content, specFile), errors, warnings };
+  return { ...seal(content, errors, specFile), errors, warnings };
 }
 
 // ---------------------------------------------------------------------------
@@ -1342,6 +1399,11 @@ export interface CompileRailwayOptions {
 }
 
 export interface CompileRailwayResult {
+  /**
+   * The stamped artifact — present ONLY when `errors` is empty. `null` is what
+   * makes a failed compile unwritable: `writeArtifact` accepts nothing else.
+   */
+  artifact: StampedMarkdown | null;
   markdown: string;
   errors: CompileError[];
 }
@@ -1428,7 +1490,7 @@ export function compileRailway(
   const errors = validateRailway(rw, options.knownAgents);
   const specFile = options.specFile ?? `${rw.name}.railway.spec.ts`;
   const content = renderRailwayMarkdown(rw) + "\n";
-  return { markdown: addHash(content, specFile), errors };
+  return { ...seal(content, errors, specFile), errors };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/repo-path.test.ts
+++ b/src/core/repo-path.test.ts
@@ -1,0 +1,56 @@
+/**
+ * `repoRelative` — the smart constructor that makes an out-of-repo `.gitignore`
+ * entry unwritable (#176.8).
+ *
+ * 🔴 EVERY CASE HAS BOTH HALVES: it refuses what escapes AND mints what belongs.
+ * A constructor that returned null for everything would pass a refusal-only
+ * suite while silently disabling the feature it guards.
+ */
+import { describe, it, expect } from "vitest";
+import { relative, resolve, isAbsolute, sep } from "node:path";
+
+import { repoRelative } from "./repo-path.js";
+
+const io = { relative, resolve, isAbsolute, sep };
+const ROOT = resolve("/repo");
+
+describe("repoRelative", () => {
+  it("mints a path inside the repo", () => {
+    expect(repoRelative(ROOT, resolve(ROOT, "reports/x.json"), io)).toBe(
+      "reports/x.json",
+    );
+  });
+
+  it("refuses a path that escapes the root", () => {
+    // The measured shape: `--out=/tmp/...` produced
+    // `../../../../private/tmp/x/vigiles-report.json`, an entry that ignores
+    // nothing because .gitignore does not reach outside its own tree.
+    expect(repoRelative(ROOT, "/tmp/elsewhere/x.json", io)).toBeNull();
+    expect(
+      repoRelative(ROOT, resolve(ROOT, "../sibling/x.json"), io),
+    ).toBeNull();
+  });
+
+  it("refuses the root itself — there is nothing to ignore", () => {
+    expect(repoRelative(ROOT, ROOT, io)).toBeNull();
+  });
+
+  it("normalizes to POSIX separators", () => {
+    // .gitignore patterns are POSIX. A Windows `reports\x` would never match
+    // `reports/x` — a second silent miss that lived beside the first.
+    const win = {
+      ...io,
+      sep: "\\",
+      relative: () => "reports\\x.json",
+      resolve: () => "C:\\repo\\reports\\x.json",
+      isAbsolute: () => false,
+    };
+    expect(repoRelative("C:\\repo", "whatever", win)).toBe("reports/x.json");
+  });
+
+  it("a deep path inside the repo is still minted", () => {
+    expect(
+      repoRelative(ROOT, resolve(ROOT, "a/b/c/vigiles-report.html"), io),
+    ).toBe("a/b/c/vigiles-report.html");
+  });
+});

--- a/src/core/repo-path.ts
+++ b/src/core/repo-path.ts
@@ -1,0 +1,48 @@
+/**
+ * `RepoRelativePath` — a path that is provably INSIDE the repository.
+ *
+ * 🔴 WHY A TYPE AND NOT A CHECK. `audit --out=/tmp/x` appended entries like
+ * `../../../../private/tmp/x/vigiles-report.json` to the user's `.gitignore`
+ * (#176.8). Those ignore nothing — `.gitignore` does not reach outside its own
+ * tree — and accumulate one dead block per output path, in a file the tool is
+ * documented as never writing. The fix that shipped was a guard at the write
+ * site, which works and leaves the bug WRITABLE: the next caller to build an
+ * entry list gets a `string[]` and no reason to think twice.
+ *
+ * This makes it unwritable instead. `ensureReportGitignored` accepts only
+ * `RepoRelativePath[]`, and the only way to obtain one is `repoRelative()`,
+ * which returns `null` for anything that escapes the root. There is no cast at
+ * the call site and no second guard to keep in sync — a path that leaves the
+ * repo cannot reach the writer, because it cannot be given the type.
+ *
+ * The brand is the pattern this codebase already uses for `VerifiedPath` and
+ * friends: a nominal marker on `string` that only a smart constructor mints.
+ */
+declare const REPO_RELATIVE: unique symbol;
+
+/** A POSIX-separated path known to resolve inside the repository root. */
+export type RepoRelativePath = string & { readonly [REPO_RELATIVE]: true };
+
+/**
+ * Mint a {@link RepoRelativePath}, or `null` when the target escapes `root`.
+ *
+ * Rejects an absolute path and anything whose relative form starts with `..`.
+ * Normalizes to POSIX separators, because `.gitignore` patterns are POSIX and a
+ * Windows `reports\x` would never match `reports/x` — a second silent-miss that
+ * lived next to the first.
+ */
+export function repoRelative(
+  root: string,
+  target: string,
+  io: {
+    relative: (from: string, to: string) => string;
+    resolve: (...parts: string[]) => string;
+    isAbsolute: (p: string) => boolean;
+    sep: string;
+  },
+): RepoRelativePath | null {
+  const rel = io.relative(root, io.resolve(root, target));
+  if (rel === "" || rel.startsWith("..") || io.isAbsolute(rel)) return null;
+  const posix = io.sep === "/" ? rel : rel.split(io.sep).join("/");
+  return posix as RepoRelativePath;
+}

--- a/src/core/rule-meta.test.ts
+++ b/src/core/rule-meta.test.ts
@@ -22,7 +22,12 @@ describe("RULE_META registry", () => {
 
   it("each meta's defaultSeverity matches the real DEFAULT_RULES", () => {
     for (const meta of allRuleMeta()) {
-      if (meta.id === "orphan-docs") continue; // built-in, not in RulesConfig
+      // 🔴 A `continue` for `orphan-docs` used to sit here ("built-in, not in
+      // RulesConfig"). It was true when written and stale by the time it was
+      // found: the rule was moved into `RulesConfig` and the exemption kept
+      // excusing it from the one comparison that would have flagged the drift.
+      // An escape hatch that outlives its reason is the defect this file exists
+      // to catch, wearing the file's own clothes.
       const actual = DEFAULT_RULES[meta.id as keyof typeof DEFAULT_RULES];
       const normalized =
         actual === false ? "off" : Array.isArray(actual) ? actual[0] : actual;
@@ -63,3 +68,43 @@ describe("RULE_META registry", () => {
     expect(RULE_META[id].bucket).toBe("structural-closed");
   });
 });
+
+// ---------------------------------------------------------------------------
+// The direction this registry does NOT close, and why there is no test for it
+// ---------------------------------------------------------------------------
+//
+// 🔴 `Record<RuleName, RuleMeta>` closes one direction: a rule without a meta is
+// a tsc error. The other — that a declared rule is REACHABLE, i.e. some code
+// actually reads its severity — is exactly what #181 was. `orphan-docs` had a
+// meta, a doc and a documented default while `"warn"` and `"off"` were both
+// silently ignored, because nothing looked it up.
+//
+// A textual check for it was written here and then REMOVED, because it was
+// measured and it did not work. Five iterations, each fixing what the last one
+// missed:
+//
+//   1. matched `rules["id"]` only  → `integrity`/`coverage`, read via dot access,
+//      reported as unreachable
+//   2. added dot access            → `require-instructions-spec`, read off a
+//      local, still missed
+//   3. matched `["id"]` anywhere   → GREEN with every real read of `orphan-docs`
+//      deleted, kept alive by an unrelated `new Set([...])` in linters.ts
+//   4. required an object before the bracket → its own comment-stripper ate real
+//      code, because cli.ts holds glob strings whose slash-star opens a comment
+//      that closes somewhere else entirely
+//   5. stripped comments with the real TS scanner → still wrong on three rules
+//
+// Step 3 settles it: the check was green-and-dead for the very rule that
+// motivated it. A gate that cannot fail for its own case is decoration reading
+// as enforcement — the defect it was written to prevent, wearing its clothes.
+//
+// THE FIX IS STRUCTURAL, not a better matcher. The ~30 `check*` functions in
+// cli.ts already share one signature; they are a registry nobody wrote down.
+// Written down as `Record<RuleName, RuleRunner>`, `runLint` reads each severity
+// once by id in one loop, a rule without a runner becomes a tsc error, and
+// `lintExitCode`'s hand-maintained 31-line `||` list collapses into a fold over
+// the same table. That also closes a hole no textual check can see: a rule can
+// be READ, COUNTED, and still not gate, because the exit list is separate.
+//
+// Not bolted on here: it touches `LintReport`, a wire format bumped with `!` in
+// #187, so it earns its own PR and its own breaking-change note.

--- a/src/harness-assert.test.ts
+++ b/src/harness-assert.test.ts
@@ -83,6 +83,7 @@ function fakeHook(blocked: boolean): HookRunResult {
     json: null,
     blocked,
     haltsTurn: false,
+    blockedBy: blocked ? ["exit-code"] : [],
     egress: [],
     filesWritten: [],
     decision: blocked ? "deny" : undefined,

--- a/src/run-hook.test.ts
+++ b/src/run-hook.test.ts
@@ -959,3 +959,32 @@ test("fileToolEvents: the two spellings are never the same string", () => {
     assert.notEqual(p(rel), p(a), `root ${String(root)} collapsed the pair`);
   }
 });
+
+// --- the closed block-mechanism table -------------------------------------
+
+test("decideHook reports WHICH mechanisms fired, not just that one did", () => {
+  // The shape that stops #174 repeating: a hook can block several ways at once,
+  // and each new mechanism reports itself instead of needing a fresh boolean.
+  const both = decideHook(2, { continue: false });
+  assert.deepEqual([...both.blockedBy].sort(), ["exit-code", "halt-field"]);
+  assert.equal(both.blocked, true);
+  assert.equal(both.haltsTurn, true);
+});
+
+test("haltsTurn is DERIVED from the table, not computed twice", () => {
+  // Order-independent: evaluating only the first match would make `haltsTurn`
+  // depend on where `halt-field` sits in the table.
+  const exitOnly = decideHook(2, null);
+  assert.deepEqual(exitOnly.blockedBy, ["exit-code"]);
+  assert.equal(exitOnly.haltsTurn, false);
+
+  const haltOnly = decideHook(0, { continue: false });
+  assert.deepEqual(haltOnly.blockedBy, ["halt-field"]);
+  assert.equal(haltOnly.haltsTurn, true);
+});
+
+test("a clean run fires no mechanism at all", () => {
+  const clean = decideHook(0, null);
+  assert.deepEqual(clean.blockedBy, []);
+  assert.equal(clean.blocked, false);
+});

--- a/src/run-hook.ts
+++ b/src/run-hook.ts
@@ -296,6 +296,13 @@ export interface HookRunResult extends ScriptRunResult {
    */
   readonly haltsTurn: boolean;
   /**
+   * Every block mechanism that fired, from the closed {@link BlockMechanism}
+   * set. Reported so the next mechanism needs no new boolean on this interface —
+   * `haltsTurn` exists because the halt case was added as a one-off, and this is
+   * the shape that stops the pattern repeating.
+   */
+  readonly blockedBy: readonly BlockMechanism[];
+  /**
    * The decision the hook expressed, preferring the structured
    * `permissionDecision` ("allow"|"deny"|"ask") then legacy `decision`
    * ("approve"|"block"), else undefined.
@@ -320,8 +327,54 @@ export function parseHookOutput(stdout: string): HookOutput | null {
 }
 
 /**
+ * The ways a hook can stop an action — a CLOSED set, listed once.
+ *
+ * 🔴 WHY A TABLE AND NOT THREE `||` TERMS. `decideHook` used to be a boolean
+ * expression over three mechanisms while `HookOutput` declared a fourth,
+ * `continue`, that nothing read (#174). The consequence was not a missed
+ * detection but an INVERTED verdict in the flagship feature: a real guard that
+ * stopped every command in the disaster battery was reported by
+ * `assertBlocksDisasters` as blocking none of them.
+ *
+ * A `||` chain has no shape that can be incomplete — every term is optional by
+ * construction, so nothing can say "you declared a mechanism and did not handle
+ * it". `Record<BlockMechanism, …>` can: adding a member to the union without
+ * adding its row is a tsc error, the same device that keeps `RULE_META` honest.
+ */
+export type BlockMechanism = "exit-code" | "deny-decision" | "halt-field";
+
+interface BlockContext {
+  readonly exitCode: number;
+  readonly json: HookOutput | null;
+  readonly protocol: HookProtocol;
+}
+
+const BLOCK_MECHANISMS: Record<BlockMechanism, (ctx: BlockContext) => boolean> =
+  {
+    "exit-code": ({ exitCode, protocol }) =>
+      exitCode === protocol.blockExitCode,
+    "deny-decision": ({ json, protocol }) => {
+      const decision =
+        json?.hookSpecificOutput?.permissionDecision ?? json?.decision;
+      return (
+        decision !== undefined && protocol.denyDecisionValues.includes(decision)
+      );
+    },
+    // Read from the PORT, never hard-coded: `"continue"` is a documented Claude
+    // Code fact and unverified for Codex, so the harness that has it declares it
+    // (core ⊄ adapter). `=== false` and not falsy — an absent field is not a halt.
+    "halt-field": ({ json, protocol }) => {
+      const field = protocol.haltsTurnField;
+      return field !== undefined && json?.[field] === false;
+    },
+  };
+
+/**
  * Decide whether a hook result blocked, and the normalized decision. Pure, so
  * the policy is unit-testable independent of spawning anything.
+ *
+ * Folds the closed {@link BLOCK_MECHANISMS} table rather than testing three
+ * conditions inline, so a mechanism cannot be declared and left unhandled.
  */
 export function decideHook(
   exitCode: number,
@@ -331,20 +384,24 @@ export function decideHook(
   blocked: boolean;
   decision: HookRunResult["decision"];
   haltsTurn: boolean;
+  blockedBy: readonly BlockMechanism[];
 } {
   const permission = json?.hookSpecificOutput?.permissionDecision;
   const decision = permission ?? json?.decision;
-  // The halt field is read from the PORT, never hard-coded: `"continue"` is a
-  // documented Claude Code fact and an unverified one for Codex, so the harness
-  // that has it declares it (core ⊄ adapter). `=== false` and not falsy —
-  // an absent field must not read as a halt.
-  const haltField = protocol.haltsTurnField;
-  const haltsTurn = haltField !== undefined && json?.[haltField] === false;
-  const blocked =
-    exitCode === protocol.blockExitCode ||
-    haltsTurn ||
-    (decision !== undefined && protocol.denyDecisionValues.includes(decision));
-  return { blocked, decision, haltsTurn };
+  const ctx: BlockContext = { exitCode, json, protocol };
+  // EVERY mechanism is evaluated, not the first match: a hook may both exit 2
+  // and halt the turn, and reporting only the first would make `haltsTurn`
+  // depend on the table's order.
+  const blockedBy = (Object.keys(BLOCK_MECHANISMS) as BlockMechanism[]).filter(
+    (kind) => BLOCK_MECHANISMS[kind](ctx),
+  );
+  return {
+    blocked: blockedBy.length > 0,
+    decision,
+    // Derived, not computed twice — the next mechanism needs no new boolean.
+    haltsTurn: blockedBy.includes("halt-field"),
+    blockedBy,
+  };
 }
 
 /**
@@ -361,8 +418,11 @@ export function runHookWith(
 ): HookRunResult {
   const res = runScriptWith(command, JSON.stringify(input), opts, deps);
   const json = parseHookOutput(res.stdout);
-  const { blocked, decision, haltsTurn } = decideHook(res.exitCode, json);
-  return { ...res, json, blocked, decision, haltsTurn };
+  const { blocked, decision, haltsTurn, blockedBy } = decideHook(
+    res.exitCode,
+    json,
+  );
+  return { ...res, json, blocked, decision, haltsTurn, blockedBy };
 }
 
 /**

--- a/src/test.ts
+++ b/src/test.ts
@@ -76,6 +76,10 @@ export {
 } from "./run-hook.js";
 export type {
   HookRunResult,
+  // Named in HookRunResult.blockedBy, so a consumer must be able to name it too
+  // — a type that appears in a public signature and cannot be imported is a
+  // surface you can read but not write against.
+  BlockMechanism,
   RunHookOptions,
   HookInput,
   HookOutput,


### PR DESCRIPTION
## What and why

Started as "make the bug classes we just fixed unwritable". A red-team of #186/#187 turned up something more urgent: **#173 was fixed in one compiler out of five.**

### The live bug

`compileClaudeToFile` stopped writing on error. The identical three lines — write, **then** check errors — sat unchanged in the skill, subagent, railway and generator compilers, and all four stamped unconditionally. Worse than the original: `spec-refs` skips non-`claude` specs, so there was no lint-side backstop either.

Reproduced on the built CLI:

```
$ vigiles compile skills/demo/SKILL.md.spec.ts
✗ [stale-file] File not found: "docs/never-existed.md"
skills/demo/SKILL.md — 256 bytes, stamped

$ vigiles lint .
✓ skills/demo/SKILL.md — hash valid (from skills/demo/SKILL.md.spec.ts)
0 finding(s) — exit 0
```

So my comment closing #173 was right about `CLAUDE.md` and **wrong about scope**.

Guarding four more write sites would leave the class writable — the sixth compiler gets written the same way. `addHash` now mints a branded `StampedMarkdown`; `seal()` hands it out only when `errors` is empty; `writeArtifact` accepts nothing else. `markdown` stays a plain string, because `adoptDiff` legitimately wants the draft to diff against even when a ref is stale. **An erroring compile has no stamp to give the writer.**

### Two constructions kept

**`RepoRelativePath`** — an out-of-repo `.gitignore` entry (#176.8) cannot be constructed, so the write-site guard is *deleted* rather than duplicated.

**`Record<BlockMechanism, …>`** — the block mechanisms are a closed table. `decideHook` was three `||` terms while `HookOutput` declared a fourth that nothing read (#174); a `||` chain has no shape that can be incomplete. `blockedBy` reports what fired and `haltsTurn` derives from it, so the next mechanism needs no new boolean.

Also removed a stale `continue` in `rule-meta.test.ts` — `orphan-docs` was exempted as "built-in, not in RulesConfig", true when written and false since it moved into `RulesConfig`, and it was excusing the rule from the severity comparison.

### A third construction was written, measured, and removed

A textual check for "every declared rule's severity is read somewhere" — the #181 class. Five iterations, each fixing what the last missed, and **the third is why it is gone**: with every real read of `orphan-docs` deleted, the suite stayed **green**, kept alive by an unrelated `new Set(["orphan-docs"])` in `linters.ts`. It was green-and-dead for the very rule that motivated it. The fourth iteration's own comment-stripper then ate real code, because `cli.ts` holds glob strings whose `/*` opens a comment that closes somewhere else entirely.

The reasoning stays in the file, with the structural fix that belongs in its own PR: the ~30 `check*` functions already share one signature and are a registry nobody wrote down. `Record<RuleName, RuleRunner>` makes a rule without a runner a tsc error and collapses `lintExitCode`'s hand-maintained 31-line `||` list — a hole no textual check can see, since a rule can be read, counted, and still not gate.

**Not attempted:** the discriminated `CompileClaudeResult`. The union would force `adoptDiff` onto an `ok:false` branch with nothing to diff, and it only covers one of the five compilers — branding the stamp covers all of them at the point they are produced.

## Safety impact

**Narrowing in the direction that matters; one loosening, stated.**

- A failed compile can no longer write **anything**, in any of the five compilers. That is strictly less writing than before.
- `repoRelative` can only refuse *more* than the deleted guard did.
- The mechanism table is behaviour-preserving: every mechanism is evaluated, not first-match, so `blocked` and `haltsTurn` compute exactly as before — pinned by a test that fails if only the first match is taken.
- ⚠️ The **loosening** is the removed reachability check: this PR ships no detector for "declared but unread". That is deliberate — the alternative was keeping one that cannot fail for its own case.
- Unchanged: the sandbox, `sandboxAvailable()`, `interceptTools`, and what any read-only path may execute.

**API surface:** `StampedMarkdown` and `BlockMechanism` (new exported types), `HookRunResult.blockedBy`, and a required `artifact` on the four compile results. `addHash` returns `StampedMarkdown` instead of `string`. Reading a result is unaffected; constructing one must supply `artifact` — hence the `!`.

## Checks

- [x] `npm test` passes locally, or CI is green
- [x] New behaviour has a test — or there's a note below saying why it doesn't
- [x] Docs updated if this changes a rule, a CLI surface, or a documented guarantee — n/a, no rule or CLI surface changes

**Gates, in order:** `npm run check` (**18/18 in 72s**) · `npx vitest run --project unit` (**3437 passed, 21 skipped, 0 failed**).

**Mutations** — four, each verified to have landed and to fail on its own assertion:

| mutation | fails |
|---|---|
| restore write-before-check in the skill compiler | `a SKILL spec with a dead ref writes nothing either` |
| `seal` hands out a stamp on errors | same |
| `repoRelative` stops refusing escapes | `refuses a path that escapes the root` |
| drop a mechanism from the table | `decideHook: continue:false halts the turn` |

⚠️ **The first came back green on its first run** — it landed on the first of four identical blocks rather than the skill compiler. Third time this session that "prove the patch landed" earned its keep, and the reason the mutation table says *landed and failed* rather than just *failed*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrS34j2M8XR12P2QHaBer4