### PR TITLE
feat(eval): pin --effort as a measurement input, hashed in lock and cache

### DIFF
--- a/.vigiles/generated.d.ts
+++ b/.vigiles/generated.d.ts
@@ -101,7 +101,7 @@ declare module "vigiles/generated" {
     | "internal:check"
     | "docs:api";
 
-  /** 405 project files. */
+  /** 406 project files. */
   export type ProjectFile = 
     | "src/CLAUDE.md"
     | "src/CLAUDE.md.spec.ts"
@@ -369,6 +369,7 @@ declare module "vigiles/generated" {
     | "src/eval-cost.ts"
     | "src/eval-define.test.ts"
     | "src/eval-define.ts"
+    | "src/eval-effort.test.ts"
     | "src/eval-entry.test.ts"
     | "src/eval-entry.ts"
     | "src/eval-file-shape.test.ts"
@@ -846,6 +847,7 @@ declare module "vigiles/spec" {
       | "src/eval-cost.ts"
       | "src/eval-define.test.ts"
       | "src/eval-define.ts"
+      | "src/eval-effort.test.ts"
       | "src/eval-entry.test.ts"
       | "src/eval-entry.ts"
       | "src/eval-file-shape.test.ts"

--- a/api-surface/vigiles-claude-code.api.md
+++ b/api-surface/vigiles-claude-code.api.md
@@ -210,6 +210,7 @@ export interface SelectionMatrixOptions extends SelectionOptions {
 // @public
 export interface SelectionOptions {
     readonly concurrency?: number;
+    readonly effort?: string | number;
     readonly harness?: ProbeHarness;
     readonly model?: string;
     readonly trials?: number;

--- a/api-surface/vigiles-codex.api.md
+++ b/api-surface/vigiles-codex.api.md
@@ -108,6 +108,9 @@ export function parseResponsesRequest(body: string): {
 };
 
 // @public
+export function refuseCodexEffort(effort: string | number | undefined): void;
+
+// @public
 export function renderResponsesSSE(text: string, opts?: {
     model?: string;
 }): string;

--- a/api-surface/vigiles-eval.api.md
+++ b/api-surface/vigiles-eval.api.md
@@ -8,6 +8,7 @@
 export interface AgentRunArgs {
     // (undocumented)
     readonly cwd: string;
+    readonly effort?: string | number;
     readonly env?: Record<string, string>;
     // (undocumented)
     readonly hasSettings: boolean;
@@ -49,6 +50,7 @@ export interface ArmsMeasureSpec {
     readonly arms: Record<string, EvalArm>;
     // (undocumented)
     readonly checks: readonly Check<RunContext>[];
+    readonly effort?: string | number;
     // (undocumented)
     readonly fixture?: Record<string, string>;
     // (undocumented)
@@ -117,6 +119,7 @@ export interface CheckResult {
 
 // @public
 export interface EvalArm {
+    readonly effort?: string | number;
     readonly files?: Record<string, string>;
     readonly interceptTools?: readonly ToolIntercept[];
     readonly model?: string;
@@ -156,6 +159,7 @@ export interface EvalSpec<M extends Metrics> {
     readonly cache?: CacheMode;
     readonly cacheDir?: string;
     readonly concurrency?: number;
+    readonly effort?: string | number;
     readonly ephemeralEnv?: boolean;
     readonly fixture?: Record<string, string>;
     readonly lock?: EvalLockOptions;
@@ -199,6 +203,7 @@ export type JudgeFn = (opts: {
 export interface MeasureSpec {
     readonly allowedTools?: readonly string[];
     readonly checks: readonly Check<RunContext>[];
+    readonly effort?: string | number;
     readonly fixture?: Record<string, string>;
     readonly interceptTools?: readonly ToolIntercept[];
     readonly model?: string;
@@ -350,6 +355,7 @@ export interface TriggerRateReport {
 export interface TriggerRateSpec {
     readonly allowedTools?: readonly string[];
     readonly concurrency?: number;
+    readonly effort?: string | number;
     readonly fired: (trace: Trace) => boolean;
     readonly fixture?: Record<string, string>;
     readonly installSet?: readonly string[];

--- a/api-surface/vigiles.api.md
+++ b/api-surface/vigiles.api.md
@@ -8,6 +8,7 @@
 export interface AgentRunArgs {
     // (undocumented)
     readonly cwd: string;
+    readonly effort?: string | number;
     readonly env?: Record<string, string>;
     // (undocumented)
     readonly hasSettings: boolean;
@@ -55,6 +56,7 @@ export interface ArmsMeasureSpec {
     readonly arms: Record<string, EvalArm>;
     // (undocumented)
     readonly checks: readonly Check<RunContext>[];
+    readonly effort?: string | number;
     // (undocumented)
     readonly fixture?: Record<string, string>;
     // (undocumented)
@@ -482,6 +484,7 @@ export interface EmitTrackSchema {
 
 // @public
 export interface EvalArm {
+    readonly effort?: string | number;
     readonly files?: Record<string, string>;
     readonly interceptTools?: readonly ToolIntercept[];
     readonly model?: string;
@@ -565,6 +568,7 @@ export interface EvalSpec<M extends Metrics> {
     readonly cache?: CacheMode;
     readonly cacheDir?: string;
     readonly concurrency?: number;
+    readonly effort?: string | number;
     readonly ephemeralEnv?: boolean;
     readonly fixture?: Record<string, string>;
     readonly lock?: EvalLockOptions;
@@ -811,6 +815,7 @@ export function mcp(server: string, toolName: string): Check<Trace>;
 export interface MeasureSpec {
     readonly allowedTools?: readonly string[];
     readonly checks: readonly Check<RunContext>[];
+    readonly effort?: string | number;
     readonly fixture?: Record<string, string>;
     readonly interceptTools?: readonly ToolIntercept[];
     readonly model?: string;
@@ -1235,6 +1240,7 @@ export interface TriggerRateReport {
 export interface TriggerRateSpec {
     readonly allowedTools?: readonly string[];
     readonly concurrency?: number;
+    readonly effort?: string | number;
     readonly fired: (trace: Trace) => boolean;
     readonly fixture?: Record<string, string>;
     readonly installSet?: readonly string[];

--- a/docs/testing-api.md
+++ b/docs/testing-api.md
@@ -312,6 +312,7 @@ const report = await measureTriggerRate({
   trials: 2,
   concurrency: 4, //              parallelize the prompts × trials grid
   minModel: "sonnet", //          fail before spending a token if pointed below
+  effort: "low", //               reasoning budget — pin it to reproduce a number
   minPrompts: 10, //              diversity-gate floor
 });
 assertTriggerRate(report, { min: 0.8, maxFalsePositive: 0.1 });
@@ -328,6 +329,26 @@ assertTriggerRate(report, { min: 0.8, maxFalsePositive: 0.1 });
 - **Model** — defaults to `"sonnet"` (the realistic selector; a weaker model
   under-selects — dogfooded 0.50 on haiku vs 0.90 on sonnet). The `minModel` floor
   fails a too-weak run up front. Model lives in the spec, not an env override.
+- **`effort`** — the reasoning budget the run is pinned to (`"low"`, `"high"`, an
+  integer — whatever your harness build accepts). Set it when you are reproducing
+  or publishing a number: a result measured at one budget is not a result at
+  another, so effort is hashed into both the eval lock and the local cache, and a
+  recorded report is **stale** for a run at a different budget. It is also an arm
+  in its own right — `arms: { cheap: { effort: "low" }, rich: { effort: "high" } }`
+  answers "does my harness still hold on the cheaper budget?" through the same
+  significance machinery, exactly as model-as-an-arm does.
+
+  Three things worth knowing before you rely on it:
+
+  |                                               |                                                                                                                                                                                                                                                                        |
+  | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | **It is pinned, not merely passed**           | The harness also reads `CLAUDE_CODE_EFFORT_LEVEL`, and that env var outranks the flag. vigiles sets it for the run — and **deletes an inherited one when you omit `effort`** — so an exported value in your shell can never silently become the budget a lock records. |
+  | **A value the harness rejects fails the run** | It does not fail on a bad level; it warns and quietly uses its default. vigiles turns that warning into an error, because a number produced by a configuration nobody asked for is the problem this field exists to avoid.                                             |
+  | **Omitting it means the harness default**     | Not a fixed level: the default is per-model and can move between builds. An effort-less lock is reproducible only modulo that — the same kind of caveat as the harness version.                                                                                        |
+
+  Not supported on Codex: no mapping has been measured, so a spec declaring
+  `effort` there **fails loudly** rather than recording a budget the run did not use.
+
 - **`fixture`** — each run defaults to an empty cwd (faithful for opening-move
   skills); pass `fixture` to seed the repo state a skill claims to fire on.
 - **`installSet`** — by default the skill competes against the other skills in the

--- a/src/adapters/codex/eval.ts
+++ b/src/adapters/codex/eval.ts
@@ -193,6 +193,33 @@ export function installCodexSkills(pluginDir: string, cwd: string): number {
   return n;
 }
 
+/**
+ * Refuse an `effort` this adapter cannot honour, LOUDLY.
+ *
+ * The Claude runner pins the reasoning budget through `--effort` plus the env var
+ * it sits under. Codex exposes no mapping we have measured — its config carries a
+ * `model_reasoning_effort` key, but nothing here has driven the real binary
+ * through it, so claiming support would assert something unverified.
+ *
+ * The alternative — forwarding `task`/`cwd`/`timeoutMs` and dropping `effort` on
+ * the floor, as this runner does today — is the silent CC-only path the
+ * harness-parity rule forbids: a spec would declare `effort: "low"`, the lock
+ * would RECORD `low`, and the run would happen at whatever Codex defaults to.
+ * A stale number is recoverable; a confidently mislabelled one is not.
+ *
+ * Pure so the deferral itself is tested rather than living inside the ignored
+ * subprocess region.
+ */
+export function refuseCodexEffort(effort: string | number | undefined): void {
+  if (effort === undefined) return;
+  throw new Error(
+    `effort (${JSON.stringify(effort)}) is not supported on the Codex adapter: ` +
+      `vigiles has not measured a mapping for it, so honouring the spec here ` +
+      `would record an effort the run did not use. Drop \`effort\` for this ` +
+      `harness, or run the eval on Claude Code.`,
+  );
+}
+
 /* v8 ignore start -- real codex subprocess; validated against the binary, not the unit gate */
 /**
  * The Codex eval-tier `AgentRunner`: install the run's skills into `.codex/skills`
@@ -201,6 +228,7 @@ export function installCodexSkills(pluginDir: string, cwd: string): number {
  * codexEvalDriver })` dispatches through.
  */
 export function codexEvalAgentRunner(args: AgentRunArgs): Promise<RunOut> {
+  refuseCodexEffort(args.effort);
   if (args.pluginDir) installCodexSkills(args.pluginDir, args.cwd);
   return Promise.resolve(
     codexEvalRunner({

--- a/src/eval-cache.ts
+++ b/src/eval-cache.ts
@@ -35,6 +35,13 @@ export type CacheMode = "off" | "read" | "readwrite";
 export interface CacheKeyInput {
   readonly task: string;
   readonly model: string;
+  /**
+   * Reasoning budget (`--effort`). Keyed for the same reason `model` is: it moves
+   * the output distribution, so a replay across effort levels would serve a result
+   * the caller did not ask for. `undefined` (the harness default) drops out of the
+   * hash via JSON, so entries recorded before effort existed stay valid.
+   */
+  readonly effort?: string | number;
   readonly tools: readonly string[];
   /** The resolved fixture + arm + plugin files written before the run. */
   readonly files: Record<string, string>;

--- a/src/eval-effort.test.ts
+++ b/src/eval-effort.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Tests for `--effort` support across the eval tier — the flag, the env pin, the
+ * fail-closed rejection guard, both hashes, and the Codex deferral. Model-free.
+ *
+ * The load-bearing case is the ENV PIN. Effort has three inputs (flag, settings
+ * key, `CLAUDE_CODE_EFFORT_LEVEL`) and the env var outranks the flag, while
+ * `EPHEMERAL_ALLOW_PREFIXES` passes `CLAUDE_*` through on purpose. Hashing effort
+ * WITHOUT pinning it would make the lock confidently wrong — recording `low` over
+ * a run that executed at the shell's `max` — which is the very defect this
+ * feature exists to prevent.
+ */
+import { test } from "vitest";
+import assert from "node:assert/strict";
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  buildAgentArgs,
+  runEvalWith,
+  resolveSpawnEnv,
+  pinEffortEnv,
+  effortRejection,
+  withEffortGuard,
+  EFFORT_ENV_VAR,
+  type AgentRunArgs,
+  type AgentRunner,
+  type RunOut,
+} from "./eval.js";
+import { cacheKey } from "./eval-cache.js";
+import { evalInputsHash, readLock } from "./eval-lock.js";
+import {
+  refuseCodexEffort,
+  codexEvalAgentRunner,
+} from "./adapters/codex/eval.js";
+
+const baseArgs: AgentRunArgs = {
+  task: "t",
+  cwd: "/tmp/x",
+  model: "claude-sonnet-5",
+  tools: ["Read"],
+  hasSettings: false,
+  pluginDir: undefined,
+  timeoutMs: 1000,
+};
+
+/* ---------------------------------------------------------------- the flag */
+
+test("buildAgentArgs passes --effort straight after the model when declared", () => {
+  const args = buildAgentArgs({ ...baseArgs, effort: "low" });
+  const i = args.indexOf("--effort");
+  assert.notEqual(i, -1, "the flag must reach the binary");
+  assert.equal(args[i + 1], "low");
+  assert.equal(args[i - 1], baseArgs.model, "sits with the other model knobs");
+});
+
+test("buildAgentArgs stringifies an integer budget", () => {
+  // Not a literal union on purpose: the binary documents "or an integer".
+  const args = buildAgentArgs({ ...baseArgs, effort: 4096 });
+  assert.equal(args[args.indexOf("--effort") + 1], "4096");
+});
+
+test("buildAgentArgs omits the flag entirely when effort is undefined", () => {
+  // Byte-identical to the pre-effort argv, so nothing existing changes.
+  assert.equal(buildAgentArgs(baseArgs).includes("--effort"), false);
+});
+
+/* ------------------------------------------------------------- the env pin */
+
+test("pinEffortEnv sets the var when effort is declared, beating the shell", () => {
+  const out = pinEffortEnv({ [EFFORT_ENV_VAR]: "max", PATH: "/bin" }, "low");
+  assert.equal(out[EFFORT_ENV_VAR], "low");
+  assert.equal(out.PATH, "/bin", "unrelated env is untouched");
+});
+
+test("pinEffortEnv DELETES an inherited var when effort is omitted", () => {
+  // "Omit" must mean the harness default, never "whatever this machine
+  // exported" — otherwise an omitted effort is a hidden, unhashed input.
+  const out = pinEffortEnv(
+    { [EFFORT_ENV_VAR]: "max", PATH: "/bin" },
+    undefined,
+  );
+  assert.equal(EFFORT_ENV_VAR in out, false);
+  assert.equal(out.PATH, "/bin");
+});
+
+test("pinEffortEnv does not mutate its input", () => {
+  const src = { [EFFORT_ENV_VAR]: "max" };
+  pinEffortEnv(src, "low");
+  assert.equal(src[EFFORT_ENV_VAR], "max");
+});
+
+test("resolveSpawnEnv pins effort over an ambient var on the OVERLAY path", () => {
+  const env = resolveSpawnEnv(
+    { effort: "low" },
+    {
+      [EFFORT_ENV_VAR]: "max",
+      SECRET: "s",
+    },
+  );
+  assert.equal(env[EFFORT_ENV_VAR], "low");
+  assert.equal(env.SECRET, "s", "overlay still inherits the base env");
+});
+
+test("resolveSpawnEnv pins effort on the SCRUBBED ephemeral path too", () => {
+  // The scrub does not save us here: CLAUDE_* is allow-listed by prefix, so an
+  // ambient effort survives into an ephemeral run unless it is pinned.
+  const env = resolveSpawnEnv(
+    { env: { [EFFORT_ENV_VAR]: "max" }, replaceEnv: true, effort: "low" },
+    { SECRET: "s" },
+  );
+  assert.equal(env[EFFORT_ENV_VAR], "low");
+  assert.equal(env.SECRET, undefined, "the scrub still drops the host env");
+});
+
+test("resolveSpawnEnv strips an ambient effort when the spec declares none", () => {
+  const env = resolveSpawnEnv({}, { [EFFORT_ENV_VAR]: "max", PATH: "/bin" });
+  assert.equal(EFFORT_ENV_VAR in env, false);
+  assert.equal(env.PATH, "/bin");
+});
+
+/* ------------------------------------------------------- the rejection guard */
+
+const REJECTION =
+  "Unknown --effort value 'bogus' — ignoring it and using the default effort. " +
+  "Valid values: low, medium, high, xhigh, max.";
+
+test("effortRejection reads the harness's own refusal off stderr", () => {
+  const got = effortRejection({ code: 0, stdout: "", stderr: REJECTION });
+  assert.match(String(got), /Unknown --effort value 'bogus'/);
+});
+
+test("effortRejection is null on a clean run", () => {
+  assert.equal(
+    effortRejection({ code: 0, stdout: "all good", stderr: "" }),
+    null,
+  );
+});
+
+test("withEffortGuard THROWS on a rejected effort instead of sampling it", async () => {
+  // The harness exits 0 and silently runs at its default, so without this the
+  // run would produce a number from a configuration nobody asked for.
+  const runner = (): Promise<RunOut> =>
+    Promise.resolve({ code: 0, stdout: "", stderr: REJECTION });
+  await assert.rejects(
+    withEffortGuard(runner)({ ...baseArgs, effort: "bogus" }),
+    /the harness rejected effort "bogus"/,
+  );
+});
+
+test("withEffortGuard passes a clean run through untouched", async () => {
+  const out: RunOut = { code: 0, stdout: "fine", stderr: "" };
+  assert.deepEqual(
+    await withEffortGuard(() => Promise.resolve(out))(baseArgs),
+    out,
+  );
+});
+
+/* ------------------------------------------------------------- both hashes */
+
+const keyBase = {
+  task: "t",
+  model: "m",
+  tools: ["Read"],
+  files: {},
+  settings: undefined,
+  trialIndex: 0,
+};
+
+test("the CACHE key changes with effort", () => {
+  assert.notEqual(
+    cacheKey({ ...keyBase, effort: "low" }),
+    cacheKey({ ...keyBase, effort: "max" }),
+  );
+});
+
+test("an absent effort leaves the CACHE key byte-identical to today's", () => {
+  // Entries recorded before effort existed must stay valid, not silently miss.
+  assert.equal(cacheKey({ ...keyBase, effort: undefined }), cacheKey(keyBase));
+});
+
+const lockBase = { model: "m", evalApiVersion: 1, inputs: { a: 1 } };
+
+test("the LOCK hash changes with effort", () => {
+  assert.notEqual(
+    evalInputsHash({ ...lockBase, effort: "low" }),
+    evalInputsHash({ ...lockBase, effort: "max" }),
+  );
+});
+
+test("an absent effort leaves the LOCK hash byte-identical — old locks replay", () => {
+  // The additive claim, asserted rather than assumed: a lock committed before
+  // effort existed must not read as STALE and demand a paid re-run.
+  assert.equal(
+    evalInputsHash({ ...lockBase, effort: undefined }),
+    evalInputsHash(lockBase),
+  );
+});
+
+/* ------------------------------------------------------- the Codex deferral */
+
+test("Codex REFUSES a declared effort loudly rather than dropping it", () => {
+  assert.throws(() => {
+    refuseCodexEffort("low");
+  }, /not supported on the Codex adapter/);
+});
+
+test("Codex is silent when no effort is declared", () => {
+  assert.doesNotThrow(() => {
+    refuseCodexEffort(undefined);
+  });
+});
+
+/* ------------------------------------------------------------- the WIRING */
+/*
+ * The unit tests above assert the INTERFACES. They cannot see the fills — delete
+ * `effort: runArgs.effort` from the cache key or the lock inputs and every one of
+ * them stays green. These drive the real entry point with a fake runner, so the
+ * spec → runArgs → hash path is asserted end to end.
+ */
+
+const MODEL = "claude-sonnet-4-6-20260101";
+
+/** A fake runner that records the args it was handed. */
+function recordingRunner(): {
+  run: (a: AgentRunArgs) => Promise<RunOut>;
+  seen: AgentRunArgs[];
+} {
+  const seen: AgentRunArgs[] = [];
+  return {
+    seen,
+    run: (a) => {
+      seen.push(a);
+      return Promise.resolve({
+        code: 0,
+        stdout: JSON.stringify({ type: "result", result: "ok", num_turns: 1 }),
+        stderr: "",
+      });
+    },
+  };
+}
+
+function evalSpec(dir: string, extra: Record<string, unknown> = {}) {
+  return {
+    name: "effort wiring",
+    arms: { run: {} },
+    task: "do it",
+    trials: 1,
+    model: MODEL,
+    spacingSec: 0,
+    measure: (ctx: { turns: number }) => ({ turns: ctx.turns }),
+    lock: { mode: "off", dir, evalApiVersion: 1 } as const,
+    ...extra,
+  };
+}
+
+test("a spec-level effort reaches the runner's args", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "vig-effort-"));
+  try {
+    const r = recordingRunner();
+    await runEvalWith(evalSpec(dir, { effort: "low" }), r.run);
+    assert.ok(r.seen.length > 0);
+    assert.equal(r.seen[0].effort, "low");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("an ARM-level effort overrides the eval-level one", async () => {
+  // Effort-as-an-arm is the whole point for an A/B: "does my harness still hold
+  // at the cheaper budget?" is the same question model-as-an-arm already answers.
+  const dir = mkdtempSync(join(tmpdir(), "vig-effort-"));
+  try {
+    const r = recordingRunner();
+    await runEvalWith(
+      evalSpec(dir, {
+        effort: "low",
+        arms: { cheap: {}, rich: { effort: "max" } },
+      }),
+      r.run,
+    );
+    const byEffort = r.seen.map((a) => a.effort).sort();
+    assert.deepEqual(byEffort, ["low", "max"]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/*
+ * MEASURED LIMIT of the test below, stated rather than papered over. Effort
+ * reaches the lock hash through TWO fills — the `withEvalLock` chokepoint and the
+ * per-arm lock inputs — so a mutation removing EITHER ONE leaves this green.
+ * Verified 2026-09-01 with the patch proven landed; removing BOTH fails here.
+ * That is overlap (two populations: any seam vs. a per-arm override), not a dead
+ * line, and neither fill is individually pinned by behaviour. Do not "fix" this
+ * by deleting one of them.
+ */
+test("changing effort makes a committed lock STALE (the hash fill is wired)", async () => {
+  // The assertion the whole feature turns on: without effort in the lock inputs,
+  // `--check` would happily replay a report recorded at a different budget.
+  const dir = mkdtempSync(join(tmpdir(), "vig-effort-"));
+  try {
+    const r = recordingRunner();
+    const lock = (mode: "update" | "check") => ({
+      mode,
+      dir,
+      evalApiVersion: 1,
+    });
+    await runEvalWith(
+      { ...evalSpec(dir, { effort: "low" }), lock: lock("update") },
+      r.run,
+    );
+    const recorded = readLock(dir, "effort wiring");
+    assert.equal(recorded?.effort, "low", "the lock records WHICH effort ran");
+
+    // Same spec, different budget → must refuse to replay.
+    await assert.rejects(
+      runEvalWith(
+        { ...evalSpec(dir, { effort: "max" }), lock: lock("check") },
+        r.run,
+      ),
+      /stale/i,
+    );
+    // And the unchanged one still replays, so the gate is not simply always-stale.
+    await assert.doesNotReject(
+      runEvalWith(
+        { ...evalSpec(dir, { effort: "low" }), lock: lock("check") },
+        r.run,
+      ),
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("the CACHE fill is wired: same effort replays, a different one re-runs", async () => {
+  // `cache` defaults to "off", so nothing above ever executes the cache-key fill.
+  // Without this, deleting `effort: runArgs.effort` from it stays green.
+  const dir = mkdtempSync(join(tmpdir(), "vig-effort-"));
+  try {
+    const r = recordingRunner();
+    const cached = (effort: string) => ({
+      ...evalSpec(dir, { effort }),
+      cache: "readwrite" as const,
+      cacheDir: dir,
+    });
+    await runEvalWith(cached("low"), r.run);
+    const afterFirst = r.seen.length;
+    await runEvalWith(cached("low"), r.run);
+    assert.equal(r.seen.length, afterFirst, "same effort → served from cache");
+    await runEvalWith(cached("max"), r.run);
+    assert.ok(
+      r.seen.length > afterFirst,
+      "a different effort must NOT replay another budget's result",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("the Codex runner refuses BEFORE it spawns anything", async () => {
+  // Asserts the CALL site, not just `refuseCodexEffort` itself — the refusal is
+  // the first statement, so this throws without reaching the binary.
+  await assert.rejects(
+    Promise.resolve().then(() =>
+      codexEvalAgentRunner({ ...baseArgs, effort: "low" }),
+    ),
+    /not supported on the Codex adapter/,
+  );
+});
+
+test("withEffortGuard preserves a SYNCHRONOUS throw from the wrapped runner", () => {
+  // The regression this pins: an `async` wrapper converts a synchronous refusal
+  // into a rejected promise. The real runner refuses synchronously so a paid eval
+  // collected by a foreign test runner cannot bill — a downgrade to "rejects
+  // later" is invisible to `assert.throws` and to any caller that does not await.
+  const refusing: AgentRunner = () => {
+    throw new Error("refused before spending anything");
+  };
+  assert.throws(
+    () => withEffortGuard(refusing)(baseArgs),
+    /refused before spending anything/,
+  );
+});

--- a/src/eval-lock.ts
+++ b/src/eval-lock.ts
@@ -87,6 +87,18 @@ export interface EvalLockInputs {
   /** Model id used (folded in; a floating alias can't detect weight drift — warned). */
   readonly model: string;
   /**
+   * Reasoning budget (`--effort`) the run was pinned to, or undefined for the
+   * harness default. Hashed because it steers the model — the criterion this
+   * interface already states — so a committed report recorded at one effort is
+   * STALE for a run at another. `undefined` is dropped by `JSON.stringify`, so
+   * locks committed before effort existed keep their hash and still replay.
+   *
+   * Caveat kept honest: "omitted" means the harness's own default, which is
+   * per-model and can move between builds — reproducible only modulo that, the
+   * same class of provenance caveat as `harnessVersion` below.
+   */
+  readonly effort?: string | number;
+  /**
    * A hand-bumped behavior epoch the project owns (`.vigilesrc.json`
    * `eval.apiVersion`), bumped when a harness-side change YOU made (a CLAUDE.md
    * edit, a global hook) would shift eval outputs but isn't otherwise in the
@@ -129,6 +141,13 @@ export interface EvalLock {
   readonly inputsHash: string;
   /** The model id the report was produced against (for the drift warning). */
   readonly model: string;
+  /**
+   * The effort the report was produced at, or undefined for the harness default
+   * (provenance; already in the hash). Recorded because the complaint that
+   * motivated effort support was not only that it could not be SET — it was that
+   * nothing in the run record said which effort produced the numbers.
+   */
+  readonly effort?: string | number;
   /** The harness version token at record time (provenance; already in the hash). */
   readonly harnessVersionKey: string;
   /** The behavior epoch at record time (provenance; already in the hash). */
@@ -269,6 +288,7 @@ export function buildLock(args: {
   readonly name: string;
   readonly inputsHash: string;
   readonly model: string;
+  readonly effort?: string | number;
   readonly harnessVersionKey: string;
   readonly evalApiVersion: number;
   readonly builtAt: string;

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -131,6 +131,13 @@ export interface EvalArm {
    * use the eval-level model. See `research/eval-architecture.md` (model strategy).
    */
   readonly model?: string;
+  /**
+   * Reasoning budget for the run (`claude --effort`, e.g. `"low"` or an integer).
+   * Lives here beside `model` because it is part of the MEASUREMENT — it moves the
+   * output distribution, not the sample size — so it is hashed into the lock and
+   * the cache, and never read from an env var. Omit for the harness default.
+   */
+  readonly effort?: string | number;
 }
 
 /** Per-run resource use, parsed from the terminal `result` event (0 when absent). */
@@ -184,6 +191,13 @@ export interface EvalSpec<M extends Metrics> {
   readonly trials?: number;
   /** Model alias. Default "haiku". */
   readonly model?: string;
+  /**
+   * Reasoning budget for the run (`claude --effort`, e.g. `"low"` or an integer).
+   * Lives here beside `model` because it is part of the MEASUREMENT — it moves the
+   * output distribution, not the sample size — so it is hashed into the lock and
+   * the cache, and never read from an env var. Omit for the harness default.
+   */
+  readonly effort?: string | number;
   /** Tools the agent may use. Default: Read Edit Write Bash. */
   readonly allowedTools?: readonly string[];
   /** Per-run timeout ms. Default 240000. */
@@ -332,6 +346,19 @@ export interface AgentRunArgs {
   readonly task: string;
   readonly cwd: string;
   readonly model: string;
+  /**
+   * Reasoning-budget level for the run (`claude --effort`). Part of the
+   * MEASUREMENT, not a run knob: it changes the model's output distribution, not
+   * the sample size — so it lives on the spec next to `model` (never an env),
+   * and it is hashed into both the cache key and the eval lock. Deliberately
+   * `string | number` rather than a literal union: the binary accepts an alias
+   * map, is case-insensitive, and takes an integer budget, and its own valid set
+   * MOVED between builds (2.1.42 had no `xhigh`, 2.1.257 does) — a hard-coded
+   * union would reject a valid level after any upstream addition. A wrong value
+   * is caught at RUNTIME instead, by {@link effortRejection}, which is what the
+   * binary actually tells us. Omit for the harness default.
+   */
+  readonly effort?: string | number;
   readonly tools: readonly string[];
   readonly hasSettings: boolean;
   readonly pluginDir: string | undefined;
@@ -366,39 +393,151 @@ export type AgentRunner = (args: AgentRunArgs) => Promise<RunOut>;
  * leak the host environment into an untrusted, model-driven run.
  */
 export function resolveSpawnEnv(
-  a: Pick<AgentRunArgs, "env" | "replaceEnv">,
+  a: Pick<AgentRunArgs, "env" | "replaceEnv" | "effort">,
   base: NodeJS.ProcessEnv = process.env,
 ): NodeJS.ProcessEnv {
-  return a.replaceEnv ? (a.env ?? {}) : { ...base, ...a.env };
+  const resolved = a.replaceEnv ? (a.env ?? {}) : { ...base, ...a.env };
+  return pinEffortEnv(resolved, a.effort);
 }
 
+/**
+ * The env var name the harness reads for the reasoning budget. It sits ABOVE the
+ * `--effort` flag in the CLI's own precedence chain, so passing the flag alone
+ * does NOT pin the level.
+ */
+export const EFFORT_ENV_VAR = "CLAUDE_CODE_EFFORT_LEVEL";
+
+/**
+ * Pin the effort the run actually gets, so the recorded effort is the effort
+ * that ran.
+ *
+ * WHY THIS EXISTS AND WHY IT IS NOT OPTIONAL. Effort has THREE inputs — the
+ * `--effort` flag, the `effortLevel` settings key, and `CLAUDE_CODE_EFFORT_LEVEL`
+ * — and the env var wins over the flag. `EPHEMERAL_ALLOW_PREFIXES` passes
+ * `CLAUDE_*` through by design (the CLI reads several such knobs and dropping one
+ * is the failure mode), so an ambient `CLAUDE_CODE_EFFORT_LEVEL=max` in the
+ * author's shell survives even the SCRUBBED ephemeral env. Without this pin,
+ * hashing effort into the lock would make the lock CONFIDENTLY WRONG: it would
+ * record `low` over a run that executed at `max` — the exact defect the feature
+ * exists to prevent, reintroduced by the fix for it.
+ *
+ * Both directions matter, so both are handled:
+ *  - effort DECLARED  → set the var, overriding whatever the shell had.
+ *  - effort OMITTED   → DELETE an inherited var, so "omit" means the harness
+ *                       default rather than "whatever this machine happened to
+ *                       export". An omitted effort must not be a hidden input.
+ */
+export function pinEffortEnv(
+  env: NodeJS.ProcessEnv,
+  effort: string | number | undefined,
+): NodeJS.ProcessEnv {
+  // Rebuilt WITHOUT the key rather than deleting or assigning `undefined`:
+  // omission has to be provable here, and whether a spawn drops an
+  // `undefined`-valued env entry is a Node-version detail we should not lean on.
+  const { [EFFORT_ENV_VAR]: _inherited, ...rest } = env;
+  return effort === undefined
+    ? rest
+    : { ...rest, [EFFORT_ENV_VAR]: String(effort) };
+}
+
+/**
+ * The harness's own rejection of an `--effort` value, or null. Pure.
+ *
+ * The CLI does NOT fail on a bad level — it prints this to stderr and silently
+ * runs at its default. That silent substitution is precisely the bug class this
+ * feature addresses (a number produced by a configuration nobody asked for), so
+ * a rejected value must never become a sample. Matched on the binary's own
+ * wording, the same shape as {@link isRateLimited}.
+ */
+export function effortRejection(out: RunOut): string | null {
+  const text = `${out.stderr ?? ""}\n${out.stdout}`;
+  const m = /Unknown --effort value[^\n]*/.exec(text);
+  return m ? m[0].trim() : null;
+}
+
+/**
+ * Wrap a runner so a run the harness rejected on `--effort` FAILS LOUDLY.
+ *
+ * Applied ONCE, around the real runner, rather than as a guard repeated at each
+ * of the five `runner(...)` call sites — a guard per call site is the shape that
+ * left four of five compilers unprotected in #173.
+ *
+ * It THROWS rather than counting the trial as `runError`. A `runError` trial is
+ * dropped from the denominator, which is right for a transient (a rate limit) and
+ * wrong here: an unusable effort value is deterministic and repeatable, so every
+ * trial fails it and the run would report a rate computed over ZERO samples. A
+ * configuration mistake should stop the run and name itself.
+ */
+export function withEffortGuard(runner: AgentRunner): AgentRunner {
+  // 🔴 DELIBERATELY NOT `async`. An `async` wrapper turns the wrapped runner's
+  // SYNCHRONOUS throws into rejected promises, and the real runner refuses
+  // synchronously on purpose — `refuseDuringEvalLoad` / `refuseUnderForeignRunner`
+  // stop a paid eval from billing when a foreign test runner collects it. Making
+  // this `async` silently downgraded those refusals from "throws at the call" to
+  // "returns a promise that rejects", which `assert.throws` cannot see and an
+  // un-awaited caller would not notice. Caught by the full suite, not by the
+  // targeted one; pinned below by `withEffortGuard preserves a SYNCHRONOUS throw`.
+  return (a) => {
+    const pending = runner(a);
+    return pending.then((out) => {
+      const rejection = effortRejection(out);
+      if (rejection !== null) {
+        throw new Error(
+          `the harness rejected effort ${JSON.stringify(a.effort)}: ${rejection}`,
+        );
+      }
+      return out;
+    });
+  };
+}
+
+/**
+ * Build the real runner's argv. Pure and exported so the FLAGS are provable —
+ * `spawnAgentRaw` is `v8 ignore`d (it spawns a subprocess), so an argv assembled
+ * inline there could not be asserted at all. Mirrors `buildCodexArgs`.
+ */
+export function buildAgentArgs(a: AgentRunArgs): string[] {
+  return [
+    "-p",
+    a.task,
+    // stream-json (+ --verbose, required with -p) so the per-turn tool_use
+    // events survive into `ctx.toolCalls` — the unified Trace, same as the
+    // harness tier. The terminal `result` event still carries num_turns/output.
+    "--output-format",
+    "stream-json",
+    "--verbose",
+    "--model",
+    a.model,
+    ...(a.effort !== undefined ? ["--effort", String(a.effort)] : []),
+    "--permission-mode",
+    "acceptEdits",
+    ...(a.pluginDir !== undefined
+      ? ["--plugin-dir", resolve(a.pluginDir)]
+      : []),
+    ...(a.hasSettings ? ["--settings", "settings.json"] : []),
+    "--allowedTools",
+    ...a.tools,
+  ];
+}
+
+/**
+ * The real `claude`-spawning runner (composition root). Exported so other
+ * real-model entries (e.g. the `audit` trigger tier) bind the same runner.
+ *
+ * The effort guard is composed in HERE, at the single definition, rather than at
+ * each of the places that bind this runner — so every consumer, including ones
+ * not yet written, is covered by construction. Guarding each call site instead is
+ * the shape that left four of five compilers unprotected in #173.
+ */
+export const spawnAgent: AgentRunner = withEffortGuard(spawnAgentRaw);
+
 /* v8 ignore start -- real claude subprocess; exercised by bench/, not the unit gate */
-/** The real `claude`-spawning runner (composition root). Exported so other
- *  real-model entries (e.g. the `audit` trigger tier) bind the same runner. */
-export function spawnAgent(a: AgentRunArgs): Promise<RunOut> {
+/** The unguarded spawn itself; wrapped by {@link spawnAgent}, never bound raw. */
+function spawnAgentRaw(a: AgentRunArgs): Promise<RunOut> {
   refuseDuringEvalLoad("spawning `claude`");
   refuseUnderForeignRunner("spawning `claude`");
   return new Promise((resolvePromise) => {
-    const args = [
-      "-p",
-      a.task,
-      // stream-json (+ --verbose, required with -p) so the per-turn tool_use
-      // events survive into `ctx.toolCalls` — the unified Trace, same as the
-      // harness tier. The terminal `result` event still carries num_turns/output.
-      "--output-format",
-      "stream-json",
-      "--verbose",
-      "--model",
-      a.model,
-      "--permission-mode",
-      "acceptEdits",
-      ...(a.pluginDir !== undefined
-        ? ["--plugin-dir", resolve(a.pluginDir)]
-        : []),
-      ...(a.hasSettings ? ["--settings", "settings.json"] : []),
-      "--allowedTools",
-      ...a.tools,
-    ];
+    const args = buildAgentArgs(a);
     const child = spawn(claudeCodeRuntime.agentBinary, args, {
       cwd: a.cwd,
       // The security-critical env resolution (overlay vs. scrubbed replacement)
@@ -521,6 +660,13 @@ export interface MeasureSpec {
   readonly trials?: number;
   /** Model alias. Default "sonnet" — measure on the model your users run. */
   readonly model?: string;
+  /**
+   * Reasoning budget for the run (`claude --effort`, e.g. `"low"` or an integer).
+   * Lives here beside `model` because it is part of the MEASUREMENT — it moves the
+   * output distribution, not the sample size — so it is hashed into the lock and
+   * the cache, and never read from an env var. Omit for the harness default.
+   */
+  readonly effort?: string | number;
   /** Tools the agent may use. */
   readonly allowedTools?: readonly string[];
   /** Per-run timeout ms. */
@@ -594,6 +740,7 @@ export async function measureWith(
         task: spec.task,
         trials: spec.trials ?? 5,
         model: spec.model ?? "sonnet",
+        effort: spec.effort,
         allowedTools: spec.allowedTools,
         timeoutMs: spec.timeoutMs,
         spacingSec: spec.spacingSec,
@@ -658,6 +805,13 @@ export interface ArmsMeasureSpec {
   readonly model?: string;
   readonly allowedTools?: readonly string[];
   readonly timeoutMs?: number;
+  /**
+   * Reasoning budget for the run (`claude --effort`, e.g. `"low"` or an integer).
+   * Lives here beside `model` because it is part of the MEASUREMENT — it moves the
+   * output distribution, not the sample size — so it is hashed into the lock and
+   * the cache, and never read from an env var. Omit for the harness default.
+   */
+  readonly effort?: string | number;
   readonly spacingSec?: number;
 }
 
@@ -683,6 +837,7 @@ export async function measureArmsWith(
         task: spec.task,
         trials: spec.trials ?? 5,
         model: spec.model ?? "sonnet",
+        effort: spec.effort,
         allowedTools: spec.allowedTools,
         timeoutMs: spec.timeoutMs,
         spacingSec: spec.spacingSec,
@@ -1037,6 +1192,7 @@ export async function runSkillSelectionTrial(args: {
   readonly runner: AgentRunner;
   readonly parse?: ModelOutputParser;
   readonly model: string;
+  readonly effort?: string | number;
   readonly tools?: readonly string[];
   readonly timeoutMs?: number;
   readonly fixture?: Record<string, string>;
@@ -1049,6 +1205,7 @@ export async function runSkillSelectionTrial(args: {
       task: args.prompt,
       cwd,
       model: args.model,
+      effort: args.effort,
       tools: args.tools ?? ["Read", "Edit", "Write", "Bash", "Skill"],
       hasSettings: false,
       pluginDir: args.pluginDir,
@@ -1126,6 +1283,7 @@ export function aggregateUsage(usages: readonly EvalUsage[]): ArmUsage {
 /** Resolved per-run settings shared across an eval's trials. */
 interface RunConfig {
   readonly model: string;
+  readonly effort?: string | number;
   readonly tools: readonly string[];
   readonly timeoutMs: number;
   readonly cache: CacheMode;
@@ -1152,6 +1310,7 @@ async function runWithCache(
   const key = cacheKey({
     task: runArgs.task,
     model: runArgs.model,
+    effort: runArgs.effort,
     tools: runArgs.tools,
     files: keyParts.files,
     settings: keyParts.settings,
@@ -1513,6 +1672,7 @@ async function executeTrial<M extends Metrics>(
         cwd,
         // A model comparison is a harness A/B: an arm may override the model.
         model: arm.model ?? cfg.model,
+        effort: arm.effort ?? cfg.effort,
         tools: cfg.tools,
         hasSettings,
         pluginDir: arm.pluginDir,
@@ -1692,6 +1852,7 @@ async function withEvalLock<R>(
     readonly name: string | undefined;
     readonly inputs: unknown;
     readonly model: string;
+    readonly effort?: string | number;
     readonly lock: ResolvedLock;
   },
   produce: () => Promise<R>,
@@ -1718,8 +1879,16 @@ async function withEvalLock<R>(
     return produce();
   }
   if (!isDatedModel(args.model)) warnFloatingModel(args.model);
+  // OVERLAP, DELIBERATE — do not delete this as dead. Effort reaches the hash
+  // twice: here (the CHOKEPOINT every seam passes through, so a future seam that
+  // forgets to fold effort into its own `inputs` is still covered) and inside
+  // each seam's `inputs` (which alone can see a PER-ARM override this line
+  // cannot). Measured 2026-09-01: removing either one alone leaves the suite
+  // green; removing BOTH fails `changing effort makes a committed lock STALE`.
+  // That is two populations covered, not one line duplicated.
   const inputsHash = evalInputsHash({
     model: args.model,
+    effort: args.effort,
     evalApiVersion: lock.evalApiVersion,
     inputs: args.inputs,
   });
@@ -1732,6 +1901,7 @@ async function withEvalLock<R>(
     name: args.name,
     inputsHash,
     model: args.model,
+    effort: args.effort,
     harnessVersionKey: harnessVersion(),
     evalApiVersion: lock.evalApiVersion,
     builtAt: new Date().toISOString(),
@@ -1788,6 +1958,10 @@ function evalArmsInputs<M extends Metrics>(
     const absRoot = arm.plugin ? resolve(process.cwd(), arm.plugin) : "";
     arms[name] = {
       model: arm.model ?? cfg.model,
+      // The per-ARM half of the overlap documented at `inputsHash` — the
+      // chokepoint sees only the eval-level effort, so an arm that overrides it
+      // would otherwise hash identically to its sibling.
+      effort: arm.effort ?? cfg.effort,
       tools: [...cfg.tools].sort(),
       files: stripPluginRoot(resolved.files, absRoot),
       settings: stripPluginRoot(resolved.settings, absRoot),
@@ -1831,6 +2005,7 @@ export async function runEvalWith<M extends Metrics>(
   const backoffMs = spec.retryBackoffMs ?? 1000;
   const cfg: RunConfig = {
     model: spec.model ?? "haiku",
+    effort: spec.effort,
     tools: spec.allowedTools ?? ["Read", "Edit", "Write", "Bash"],
     timeoutMs: spec.timeoutMs ?? 240000,
     cache: spec.cache ?? "off",
@@ -1868,7 +2043,7 @@ export async function runEvalWith<M extends Metrics>(
   // without ever entering the run pool — so no model is driven in CI.
   const inputs = lock.mode === "off" ? undefined : evalArmsInputs(spec, cfg);
   return withEvalLock(
-    { name: spec.name, inputs, model: cfg.model, lock },
+    { name: spec.name, inputs, model: cfg.model, effort: cfg.effort, lock },
     async () => {
       const results = await runPool(units, concurrency, worker);
       const { arms, totalCostUsd } = aggregateArms<M>(
@@ -2020,6 +2195,13 @@ export interface TriggerRateSpec {
    * 0.50 on haiku vs 0.90 on Sonnet). Override for a cheaper-but-pessimistic run.
    */
   readonly model?: string;
+  /**
+   * Reasoning budget for the run (`claude --effort`, e.g. `"low"` or an integer).
+   * Lives here beside `model` because it is part of the MEASUREMENT — it moves the
+   * output distribution, not the sample size — so it is hashed into the lock and
+   * the cache, and never read from an env var. Omit for the harness default.
+   */
+  readonly effort?: string | number;
   /**
    * Minimum model tier this eval may run on (haiku<sonnet<opus by family). The
    * run **fails** if the resolved `model` is weaker — trigger-rate under-measures
@@ -2523,6 +2705,7 @@ function resolveTriggerPluginDir(spec: TriggerRateSpec): {
 interface TriggerRunConfig {
   readonly trials: number;
   readonly model: string;
+  readonly effort?: string | number;
   readonly tools: readonly string[];
   readonly timeoutMs: number;
   readonly spacing: number;
@@ -2552,6 +2735,7 @@ async function runTriggerTrial(
       task: prompt,
       cwd,
       model: cfg.model,
+      effort: cfg.effort,
       tools: cfg.tools,
       hasSettings: false,
       pluginDir: cfg.pluginDir,
@@ -2681,6 +2865,7 @@ export async function measureTriggerRateWith(
     // Sonnet, not haiku: trigger-rate is a selection measurement and haiku
     // under-selects, producing false-negative recall (see TriggerRateSpec.model).
     model,
+    effort: spec.effort,
     tools: spec.allowedTools ?? ["Read", "Edit", "Write", "Bash", "Skill"],
     timeoutMs: spec.timeoutMs ?? 240000,
     spacing: (spec.spacingSec ?? 4) * 1000,
@@ -2708,6 +2893,7 @@ export async function measureTriggerRateWith(
               ? [...spec.irrelevantPrompts]
               : undefined,
             model: cfg.model,
+            effort: cfg.effort,
             tools: [...cfg.tools].sort(),
             fixture: spec.fixture,
             competitors,
@@ -2717,7 +2903,13 @@ export async function measureTriggerRateWith(
             harness,
           };
     return await withEvalLock(
-      { name: spec.name, inputs: triggerInputs, model: cfg.model, lock },
+      {
+        name: spec.name,
+        inputs: triggerInputs,
+        model: cfg.model,
+        effort: cfg.effort,
+        lock,
+      },
       async () => {
         const relevant = await runTriggerSet(spec.prompts, cfg, runner);
         const base: TriggerRateReport = {

--- a/src/scan-behavioral.ts
+++ b/src/scan-behavioral.ts
@@ -340,6 +340,16 @@ export interface SelectionOptions {
   readonly trials?: number;
   /** Selector model — defaults to Sonnet (a weaker model under-selects). */
   readonly model?: string;
+  /**
+   * Reasoning budget (`claude --effort`) for the selector, or undefined for the
+   * harness default. Present for {@link measureSelectionMatrix}, the ASSERTABLE
+   * test primitive, where the configuration a number came from has to be pinnable.
+   *
+   * Deliberately NOT exposed as an `audit` CLI flag: `audit` is a local report,
+   * not a reproducibility surface, and a flag nobody can act on is surface without
+   * a use. The audit probe therefore leaves this unset and runs at the default.
+   */
+  readonly effort?: string | number;
   /** Parallel runs across the prompts × trials grid (default 1). */
   readonly concurrency?: number;
   /** Which harness drives it (default `"claude-code"`; others report n/a). */
@@ -534,6 +544,7 @@ export async function measurePluginSelectionWith(
           parse: d.parse,
           runError: d.runError,
           model: opts.model ?? "sonnet",
+          effort: opts.effort,
         }),
     );
     const runs: SelectionRun[] = [];


### PR DESCRIPTION
Closes #189.

## What and why

`claude --effort` sets the reasoning budget per turn. vigiles could not set it, so an A/B could not reproduce a benchmark that pins one — the arm you ran was not the arm the author measured. The reporter's case is concrete: a skill whose published results pin *"effort low"*, which he could only approach through a `claude` shim first on `PATH`.

Effort is a **measurement**, not a run knob — it moves the output distribution, not the sample size. So it sits on the spec beside `model` (never an env), it is an arm in its own right, and it is hashed into the eval lock **and** the local cache.

### Three things that are not in the reported shape

**The env pin — without it this change would recreate the bug it fixes.** Effort has *three* inputs: the flag, the `effortLevel` settings key, and `CLAUDE_CODE_EFFORT_LEVEL`. The env var outranks the flag, and `EPHEMERAL_ALLOW_PREFIXES` passes `CLAUDE_*` through by design, so an ambient value survives even the *scrubbed* ephemeral env. Hashing effort without pinning it would make the lock confidently wrong: `low` recorded over a run that executed at the shell's `max`. Declared → the var is set; **omitted → an inherited one is deleted**, so "omit" means the harness default rather than whatever the machine exported.

**Not a literal union.** The binary is case-insensitive, keeps an alias map, accepts an integer budget, and its valid set already *moved* between builds (2.1.42 had no `xhigh`). A hard-coded union would reject a valid level after any upstream addition. And the silent fallback a union was meant to prevent is not silent — the binary warns on stderr, which is already captured — so a bad value is caught at runtime by `effortRejection` and **throws** rather than counting as `runError`: an unusable value is deterministic, so every trial fails it and the report would be a rate over zero samples.

**`harness-test.ts` is not a site.** The issue names it, but that tier runs a scripted mock against a hard-coded model; effort has no observable effect there. Adding the flag would have been dead argv.

Also: the reporter named the lock; `eval-cache`'s key carried `model` without effort in exactly the same way, so fixing one would have left half the hole. Codex **refuses** a declared effort loudly — no mapping has been measured, and silently recording a budget the run did not use is worse than refusing. `audit` deliberately gets no CLI flag: it is a local report, not a reproducibility surface.

`buildAgentArgs` is extracted so the flag is provable at all — the argv was assembled inside the `v8 ignore`d spawn, where nothing could assert it.

## Safety impact

**One narrowing, one widening, both stated.**

- **Narrowing:** an omitted `effort` now *deletes* an inherited `CLAUDE_CODE_EFFORT_LEVEL` from the spawn env. A run that previously inherited the shell's budget now uses the harness default. That is the point — an unhashed hidden input is what makes a lock lie — but it is a behaviour change for anyone who was relying on the ambient var.
- **Widening:** a spec can now set `--effort` on the real binary. It changes reasoning budget only; it does not touch what tools a model may call.
- **Regression found and fixed here, in a guard:** `withEffortGuard` was first written `async`, which converts the wrapped runner's *synchronous* refusals into rejected promises — downgrading `refuseUnderForeignRunner`, the guard that stops a paid eval from billing when a foreign test runner collects it, from "throws at the call" to "rejects later". Caught by the full suite (`node --test` reported it as an `unhandledRejection`), not by my targeted run. The wrapper is no longer `async`, and a test pins the synchronous throw.
- Unchanged: the sandbox, `sandboxAvailable()`, `interceptTools`, and what any read-only path may execute.

**API surface: +16 lines, 0 removals** — purely additive, hence `feat:` and not `feat!`.

## Checks

- [x] `npm test` passes locally, or CI is green
- [x] New behaviour has a test — or there's a note below saying why it doesn't
- [x] Docs updated if this changes a rule, a CLI surface, or a documented guarantee — `docs/testing-api.md` gains the `effort` row plus the env-precedence caveat

**Gates, in order:** `npm run check` (**18/18 in 73s** — the repo's own list, not a hand-picked subset) · `npx vitest run --project unit` (**200 files, 3462 passed, 21 skipped, 0 failed**).

**Mutations — eight, each verified to have LANDED:**

| mutation | fails on |
|---|---|
| drop `--effort` from argv | `buildAgentArgs passes --effort straight after the model` |
| `pinEffortEnv` stops deleting on omit | `pinEffortEnv DELETES an inherited var when effort is omitted` |
| `resolveSpawnEnv` skips the pin | `resolveSpawnEnv pins effort over an ambient var` |
| guard stops throwing | `withEffortGuard THROWS on a rejected effort` |
| drop effort from the CACHE key fill | `the CACHE fill is wired` |
| arm effort stops overriding | `an ARM-level effort overrides the eval-level one` |
| Codex drops effort silently | `the Codex runner refuses BEFORE it spawns` |
| drop effort from the LOCK inputs fill | 🔴 **stays green — see below** |

🔴 **The eighth stayed green with the patch proven landed, and that is a finding about the TEST, recorded in place rather than papered over.** Effort reaches the lock hash through *two* fills — the `withEvalLock` chokepoint and the per-arm inputs — so removing either alone is green; removing **both** fails `changing effort makes a committed lock STALE`. That is overlap across two populations (any seam vs. a per-arm override), not a dead line, and neither fill is individually pinned by behaviour. Both sites now carry a comment saying so, so the next reader does not delete one as redundant.

Two coverage gaps I found the same way and closed: the cache-key fill was never *executed* (`cache` defaults to `off`) and the Codex refusal's call site was untested — mutations on both would have passed green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrS34j2M8XR12P2QHaBer4

---
_Generated by [Claude Code](https://claude.ai/code/session_01PrS34j2M8XR12P2QHaBer4)_

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Features**
- pin --effort as a measurement input, hashed in lock and cache
<!-- vigiles:pr-summary:end -->
