### PR TITLE
fix(test): stop reading a site section that #219 deleted

### DIFF
--- a/src/core/linter-contract.test.ts
+++ b/src/core/linter-contract.test.ts
@@ -98,15 +98,17 @@ describe("LinterAdapter conformance", () => {
     // …not a reintroduced hand-typed string array of linter names.
     expect(lib).not.toMatch(/const LINTER_NAMES\s*=\s*\[\s*["']/);
 
-    // And both consumers actually read the derived lists rather than
+    // And the consumer actually reads the derived list rather than
     // reintroducing a local literal.
-    const wedge = readFileSync(
-      resolve(__dirname, "../../site/src/components/sections/Wedge.tsx"),
-      "utf8",
-    );
-    expect(wedge).toMatch(
-      /\bLINTER_NAMES\b[^;]*from\s*["']@\/lib\/linters["']/s,
-    );
+    //
+    // 🔴 THIS USED TO ASSERT TWO CONSUMERS. The second was `Wedge.tsx`, which
+    // rendered the linter strip; the 2026-09-09 landing rework (#219) deleted the
+    // section, and this test kept reading the file — so `main` went red on a
+    // deletion nothing connected back here. `LINTER_NAMES` is therefore exported
+    // and DERIVED but currently has no consumer on the site; it stays covered by
+    // `site/src/lib/linters.browser.test.ts` (the derivation itself), and this
+    // test now asserts only what a component still renders. Give the strip a home
+    // again and the assertion comes back with it.
     const hero = readFileSync(
       resolve(__dirname, "../../site/src/components/sections/Hero.tsx"),
       "utf8",


### PR DESCRIPTION
`main` is red. `src/core/linter-contract.test.ts` asserted that **two** site components read the `BUILTIN_LINTERS`-derived lists; one of them, `Wedge.tsx`, was deleted by the landing-page rework in #219, and the test kept `readFileSync`ing it.

```
Error: ENOENT: no such file or directory,
  open 'site/src/components/sections/Wedge.tsx'
  ❯ src/core/linter-contract.test.ts:103:19
```

**Measured, not assumed:** the file is absent from `origin/main`, `git log --diff-filter=D` names `40e74bf` (#219) as the deletion, and the failure reproduces on `main` untouched.

### Why it shipped green

`npm run check` covers one CI job and *prints* the four it does not — `test` (`npm run coverage`) among them. That job was not run before merging #219. The printed list is exactly the mechanism for this, and it only works if you read it.

### The fix

Drop the assertion about the deleted component; keep the `Hero` half, which still binds `LANGUAGES` to the derived source and is unchanged.

`LINTER_NAMES` is now exported with **no consumer on the site** — its derivation stays covered by `site/src/lib/linters.browser.test.ts`. The comment records that, so the missing assertion reads as deliberate rather than lost, and says to bring it back if the strip gets a home again.

### Gates

| gate | result |
| --- | --- |
| `npx vitest run src/core/linter-contract.test.ts` | ✅ 5 passed (was 1 failed) |
| `npm run check` | ✅ 18/18 |
| `npm run coverage` | ✅ green — see the follow-up PR, which runs it on top of this |

🤖 Generated with [Claude Code](https://claude.com/claude-code)