### PR TITLE
fix: strip YAML wrapper quotes on the salvage path before tokenizing

### DIFF
--- a/src/core/frontmatter-read.test.ts
+++ b/src/core/frontmatter-read.test.ts
@@ -98,17 +98,18 @@ test("a parenthesis INSIDE a quoted string is a character, not a bracket (#217)"
     'Bash(git commit -m "feat(api): x")',
     "Read",
   ]);
-  // 🔴 THE COUNTERWEIGHT, and why quotes gate ONLY the depth counter: if being
-  // inside quotes also suppressed SPLITTING, a quoted list would collapse back
-  // to one token — reintroducing the very bug #217 reports.
+  // A quoted list splits on BOTH paths, valid and salvaged.
   //
-  // It must be asserted on a MALFORMED block, and that is the whole point. On
-  // valid YAML js-yaml strips the quotes before `splitList` ever runs, so the
-  // value arrives as bare `Read Write Glob` and NO quote character is present —
-  // measured, after the first version of this assertion used a valid block and
-  // stayed green under the widening mutation, carrying zero information. Quotes
-  // reach the splitter only down the regex SALVAGE path, so that is where the
-  // property lives. (`desc:` below carries an unescaped `: ` — invalid YAML.)
+  // 🔴 THIS ROW NO LONGER CARRIES THE "quotes gate depth, not splitting"
+  // COUNTERWEIGHT, and the comment that claimed it did was left standing for one
+  // commit after it stopped being true. It was written when the salvage path
+  // handed `splitList` the YAML wrapper quotes; that WAS the regression the next
+  // commit fixed (`stripWrapperQuotes`), so no quote character reaches the
+  // splitter here any more and the widening mutation cannot bite on this input.
+  // The live counterweight is the UNBALANCED-quote row in the salvage test above,
+  // where a lone `"` genuinely does reach the tokenizer. Kept here as a
+  // both-paths-agree assertion, which is what it actually proves.
+  // (`desc:` below carries an unescaped `: ` — invalid YAML.)
   const salvaged = frontmatterList(
     readFrontmatter(
       '---\nname: a\ndesc: Use the foo: bar tool\ntools: "Read Write Glob"\n---\n',
@@ -118,6 +119,41 @@ test("a parenthesis INSIDE a quoted string is a character, not a bracket (#217)"
   assert.deepEqual(salvaged, ["Read", "Write", "Glob"]);
   // …and the same value on the valid-YAML path, where the quotes are gone by then.
   assert.deepEqual(read('"Read Write Glob"'), ["Read", "Write", "Glob"]);
+});
+
+test("the SALVAGE path strips YAML wrapper quotes before tokenizing (#217)", () => {
+  // A REGRESSION this suite did not catch, found by the Codex review bot after
+  // the quote-aware depth counter landed. On valid YAML js-yaml removes a
+  // scalar's surrounding quotes; only the regex salvage handed them through, so
+  // the opening YAML quote was read as a SHELL quote, the grant's parens stopped
+  // counting as structure, and its own spaces split it. Measured before the fix:
+  //
+  //   tools: "Bash(git status *), Read"  ->  ["Bash(git","status","*)","Read"]
+  //
+  // Three phantom tool names — the exact shape #217 argued against, and in the
+  // false-EXPOSED direction. The older comma-only parser got this input right,
+  // which is what makes it a regression rather than a gap.
+  const salvaged = (v: string): string[] | null =>
+    frontmatterList(
+      // The unescaped `: ` in `description` is what makes the block invalid YAML.
+      readFrontmatter(
+        `---\nname: a\ndescription: use foo: bar\ntools: ${v}\n---\n`,
+      ),
+      "tools",
+    );
+  assert.deepEqual(salvaged('"Bash(git status *), Read"'), [
+    "Bash(git status *)",
+    "Read",
+  ]);
+  // The two paths must agree — that is the property, not just "the grant survives".
+  const viaYaml = frontmatterList(
+    readFrontmatter('---\nname: a\ntools: "Bash(git status *), Read"\n---\n'),
+    "tools",
+  );
+  assert.deepEqual(salvaged('"Bash(git status *), Read"'), viaYaml);
+  // An UNBALANCED leading quote is left alone rather than guessed at; the value
+  // still tokenizes, and the stray quote comes off per token as it always did.
+  assert.deepEqual(salvaged('"Read Write'), ["Read", "Write"]);
 });
 
 test("absent list key → null (inherits all); present-but-empty → [] (no tools)", () => {

--- a/src/core/frontmatter-read.ts
+++ b/src/core/frontmatter-read.ts
@@ -139,11 +139,35 @@ function salvageField(block: string, key: string): string | undefined {
   );
 }
 
-/** Salvage a list field from the raw block (single-line key only). */
+/** Salvage a list field from the raw block (single-line key only).
+ *
+ *  THE WRAPPER QUOTES COME OFF HERE, not in `splitList`, so both paths hand the
+ *  tokenizer the SAME shape. On valid YAML js-yaml has already removed a scalar's
+ *  surrounding quotes; only this regex salvage hands them through, and leaving
+ *  that asymmetry in place made `tools: "Bash(git status *), Read"` tokenize as
+ *  `Bash(git` · `status` · `*)` · `Read` — the opening YAML quote read as a shell
+ *  quote, so the parens stopped counting as structure and the grant's own spaces
+ *  split it. That is the phantom-tool failure #217 warned about, in the
+ *  false-EXPOSED direction (`bashGrantIsUnbounded` answers "unbounded" when it
+ *  cannot recognise a grant), and it was a REGRESSION: the older comma-only
+ *  parser recovered this input correctly.
+ *
+ *  Only a MATCHED pair is stripped, and only when it wraps the whole value — an
+ *  unbalanced leading quote is left alone rather than guessed at. */
 function salvageList(block: string, key: string): string[] | null {
   const match = new RegExp(`^${key}:[ \\t]*(.*)$`, "m").exec(block);
   if (!match) return null;
-  return splitList(match[1]);
+  return splitList(stripWrapperQuotes(match[1]));
+}
+
+/** Remove ONE matched pair of quotes wrapping an entire scalar. */
+function stripWrapperQuotes(raw: string): string {
+  const v = raw.trim();
+  const q = v[0];
+  if ((q === '"' || q === "'") && v.length >= 2 && v[v.length - 1] === q) {
+    return v.slice(1, -1);
+  }
+  return v;
 }
 
 /**


### PR DESCRIPTION
**A regression shipped in #221**, found by the Codex review bot as that PR merged and reproduced on merged `main` before changing anything:

```
malformed block, tools: "Bash(git status *), Read"
  →  ["Bash(git", "status", "*)", "Read"]
```

Three phantom tool names. The opening **YAML** quote was read as a **shell** quote by #221's new quote-aware depth counter, so the grant's parentheses stopped counting as structure and its own spaces split it.

That is the exact shape #217 argued against, in the false-**exposed** direction — `bashGrantIsUnbounded()` answers *unbounded* when it can't recognise a grant. And the older comma-only parser handled this input correctly, which makes it a regression rather than a pre-existing gap.

### The cause is placement, not logic

On valid YAML, js-yaml removes a scalar's surrounding quotes before `splitList` ever runs. Only the regex salvage handed them through — so the two paths fed the tokenizer **different shapes**, and only one of them carried YAML syntax the tokenizer had no business interpreting.

So the fix is at the boundary, not in the tokenizer (parse-don't-validate): `salvageList` strips one **matched** wrapping pair, and both paths hand `splitList` the same thing. An unbalanced leading quote is left alone rather than guessed at, and still tokenizes.

| input (salvage path) | before | after |
| --- | --- | --- |
| `"Bash(git status *), Read"` | ❌ 4 tokens, 3 phantom | ✅ `Bash(git status *)`, `Read` |
| `"Read Write Glob"` | ✅ | ✅ |
| `Bash(printf '( %s' foo) Read` | ✅ | ✅ |
| `"Read Write` (unbalanced) | ✅ | ✅ |

The test also asserts the two paths **agree**, which is the actual property — not merely that the grant survives.

### Mutation-proven, patch verified landed each time

| mutation | result |
| --- | --- |
| remove the wrapper strip (the shipped regression) | new test fails ✅ |
| quotes suppress splitting too (the over-fix) | new test fails ✅ |

### ⚠️ A stale claim in the tests is corrected in the same pass

#221's counterweight comment said its quoted-list row proved *"quotes gate the depth counter, not the splitting."* That was true only while the salvage path leaked wrapper quotes. This fix removes them, so no quote reaches the splitter on that input and the widening mutation can no longer bite there. The live counterweight is now the unbalanced-quote row, where a lone `"` genuinely does reach the tokenizer.

A test whose comment outlives what it proves is the same defect class that let this regression through in the first place.

### Gates

| gate | result |
| --- | --- |
| `npm run check` | ✅ 18/18 |
| `npm run coverage` | 3959 passed, 0 failed; `frontmatter-read.ts` at 100%. The 99.94% statement gate fails locally on `src/mock-model.ts:147,339,374` — untouched here, and green on CI in #221 (25 tests skip locally and never reach those lines). |

🤖 Generated with [Claude Code](https://claude.com/claude-code)