### PR TITLE
fix(hook-runtime): name the thrown cause when a hook fails to load

### DIFF
--- a/src/hook-runtime.ts
+++ b/src/hook-runtime.ts
@@ -522,12 +522,19 @@ export async function runHookProgramCommand(
     // Everything else stays BLOCKED, and the escapes are whitelists of commands
     // that are WRITES — see `isLoadPathRepairEvent` for why no command is one.
     const conflicted = conflictedLoadPathFiles(file);
+    // 🔴 THE THROWN MESSAGE IS THE ONLY THING THAT NAMES THE REAL CAUSE when the
+    // merge-conflict heuristic above does not fire. Without it this said just
+    // "cannot be loaded" — a diagnosis that sends the reader looking in the wrong
+    // place, which is the defect this runtime has already shipped twice (the
+    // loader that advised `npm run build` when the answer was `npm install`).
+    // The comment above promises to name the cause; this is what keeps it.
+    const thrown = err instanceof Error ? err.message : String(err);
     const cause =
       conflicted.length > 0
         ? `cannot be loaded — ${conflicted.join(", ")} contains merge-conflict ` +
           `markers, so Node cannot resolve \`vigiles/hook\` from it (the hook itself ` +
           `may be fine)`
-        : "cannot be loaded";
+        : `cannot be loaded — ${thrown}`;
     if (
       isLoadPathRepairEvent(event, file, {
         // The root the REST of this runtime already uses: `hookStampPath` and


### PR DESCRIPTION
## `main` is red

`catch (err)` at `src/hook-runtime.ts:498` never uses `err`, so `@typescript-eslint/no-unused-vars` fails `lint` and takes the whole `check` job with it.

Arrived in `236615e` (*merge: fix inject hook resilience*). Reproduced on a clean checkout of `origin/main` before touching anything, so it is the base and not any one PR:

```
src/hook-runtime.ts
  498:12  error  'err' is defined but never used   @typescript-eslint/no-unused-vars
✖ 4 problems (1 error, 3 warnings)
```

## Considered and rejected: `catch {`

That silences the rule and keeps the defect.

Three lines above the catch, the comment promises the failure will **"name the real cause"**. Today it names one only when the merge-conflict heuristic fires; every other load failure — a missing dependency, a syntax error in the hook, a bad export — reads a bare `cannot be loaded`.

That is a diagnosis that sends the reader looking in the wrong place, and it is a defect this runtime has already shipped twice: the spec loader that advised `npm run build` when the answer was `npm install`.

`catch (err)` next to a comment about naming the cause reads as an author who meant to use it. So it is used.

## The message is appended, not substituted

```ts
: `cannot be loaded — ${thrown}`;
```

`src/hook.test.ts:405` asserts `/guard\.mjs cannot be loaded/` and still matches — as it should. `cannot be loaded` is the claim; the thrown text is the evidence for it.

## Gates

| gate | result |
| --- | --- |
| `npm run check` | ✅ 18/18 — `lint` 0 errors, was 1 |
| `npm run coverage` | ✅ 3972 passed, 0 failed |

The 99.94% statement gate fails locally on `src/mock-model.ts` — untouched here, green on CI (25 tests skip locally and never reach those lines).

Blocks #226, whose `check` job fails on this same error through the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Fixes**
- name the thrown cause when a hook fails to load
<!-- vigiles:pr-summary:end -->
