### PR TITLE
ci: grant the changes job the two permissions it uses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,23 @@ jobs:
   # here only ever means a merge into main, so the checkout is paid once per merge
   # and the job still rounds to the same single billable minute.
   #
+  # ── WHAT A PUSH COMPARES, because it reads like a regression and is not ─────
+  # `base` is deliberately UNSET, and that does NOT mean "only the last commit".
+  # Traced through the action's main.ts: with no `base` it defaults to the
+  # repository's `default_branch` (main), while `head` comes from `github.ref`
+  # (also main), so `isBaseSameAsHead` holds and `baseSha` becomes the push
+  # event's own `before` — i.e. `git diff <before>..<head>`, the WHOLE pushed
+  # range, exactly what the hand-written classifier did. The "changes will be
+  # detected from last commit" branch is reachable only when `before` is absent
+  # from the payload, which a push event never is.
+  #
+  # Confirmed in the first push run after the switch (run 34420710819):
+  #   Changes will be detected between 236615e97... and main
+  #   git diff --no-renames --name-status -z 236615e97...refs/remotes/origin/main
+  # where 236615e97 is that push's `before`. The same log shows it `git fetch
+  # --depth=1` that SHA on demand, which is why the shallow checkout above is
+  # enough.
+  #
   # 🔴 `predicate-quantifier: some-with-excludes` IS LOAD-BEARING, NOT DECORATION.
   # Under the default `some`, patterns are OR-ed (`patterns.some(...)` in the
   # action's own filter.ts), so `['**', '!site/**']` would match a file under site/
@@ -49,6 +66,26 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # BOTH lines are required, and the second is the one that is easy to get
+    # wrong. A job-level `permissions:` block REPLACES the default for this job
+    # rather than adding to it — everything unlisted becomes `none` — so naming
+    # only `pull-requests: read` would strip `contents: read` and break the
+    # `actions/checkout@v4` below, which the `push` path needs to diff with git.
+    #
+    # `pull-requests: read` is what the action's README requires for the
+    # `pull_request` path: with a token it calls `pulls.listFiles` (REST) instead
+    # of diffing, which is exactly why that path needs no checkout. Today this
+    # workflow declares no top-level `permissions:`, so the job inherits the
+    # repository default and the REST call happens to be allowed. That is luck,
+    # not a contract: the moment anyone adds a restrictive top-level block — the
+    # standard hardening step — the call 403s. The old classifier degraded to
+    # `gh api ... || true` and ran everything; the action raises, so the failure
+    # is loud rather than silent, but it blocks every PR until someone finds it.
+    # Declaring the two permissions the job actually uses costs nothing and
+    # removes the dependency on a default we do not control.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       root: ${{ steps.f.outputs.root }}
       site: ${{ steps.f.outputs.site }}

--- a/src/ci-path-filter.test.ts
+++ b/src/ci-path-filter.test.ts
@@ -65,6 +65,14 @@ function filterStep(): { version: string; with: Record<string, string> } {
   return { version: step.uses.split("@")[1], with: step.with };
 }
 
+/** The `permissions:` the `changes` job declares for itself. */
+function changesPermissions(): Record<string, string> {
+  const wf = yaml.load(readFileSync(CI, "utf8")) as {
+    jobs?: { changes?: { permissions?: Record<string, string> } };
+  };
+  return wf.jobs?.changes?.permissions ?? {};
+}
+
 /** The filters, parsed out of the step's YAML block scalar. */
 function filters(): Record<string, string[]> {
   return yaml.load(filterStep().with["filters"] ?? "") as Record<
@@ -125,6 +133,25 @@ describe("the changes job is wired to the action, not to a hand-rolled rule", ()
 
   it("declares both flags the dependent jobs read", () => {
     expect(Object.keys(filters()).sort()).toEqual(["root", "site"]);
+  });
+
+  it("grants itself BOTH permissions it uses, not one of them", () => {
+    // A job-level `permissions:` block REPLACES the default rather than adding
+    // to it, so this is a pair or it is a break, and each half fails a DIFFERENT
+    // way — which is why both are asserted rather than just the one the action's
+    // README names:
+    //
+    //   contents: read       the `push` path checks out and diffs with git
+    //   pull-requests: read  the `pull_request` path calls pulls.listFiles (REST)
+    //
+    // Without the block at all the job inherits the repository default, which
+    // supplies both today. That is a default we do not control: a top-level
+    // `permissions:` added later — the standard hardening step — would silently
+    // take one away, and the first sign would be every PR blocked on a 403.
+    expect(changesPermissions()).toMatchObject({
+      contents: "read",
+      "pull-requests": "read",
+    });
   });
 });
 


### PR DESCRIPTION
Two Codex findings on #226, both posted one minute before I merged it. One is real and fixed here; one is false and is recorded here so it is not re-raised.

## The real one — and the suggested fix would have broken the workflow

`dorny/paths-filter`'s README requires `pull-requests: read` for the `pull_request` path: with a token the action calls `pulls.listFiles` (REST) instead of diffing, which is exactly why that path needs no checkout. `ci.yml` declares no top-level `permissions:`, so `changes` inherits the repository default, which supplies it today.

That is a default we do not control. A restrictive top-level `permissions:` block added later — the standard hardening step — takes it away, and the first sign is every PR blocked on a 403.

🔴 **But a job-level `permissions:` block REPLACES the default rather than adding to it** — everything unlisted becomes `none`. So declaring only `pull-requests: read`, as the review suggested, strips `contents: read` and kills the `actions/checkout@v4` the `push` path needs to diff with git.

| permission | which path needs it | how its absence fails |
| --- | --- | --- |
| `contents: read` | `push` — checkout, then `git diff` | checkout fails, `changes` errors |
| `pull-requests: read` | `pull_request` — `pulls.listFiles` | REST 403, `changes` errors |

It is a pair or it is a break. Both are declared.

## Mutations

Each fails exactly its own assertion, patch shown to have landed:

| mutation | result |
| --- | --- |
| drop `contents: read` (the suggestion as written) | ✗ `grants itself BOTH permissions it uses, not one of them` |
| drop the block entirely (what `main` does today) | ✗ same assertion |
| restored | ✓ 25 passed |

## The false one, recorded rather than dropped

The second finding claimed an unset `base` makes a push inspect only the latest commit, so an earlier commit in a multi-commit push would be missed.

Traced through the action's own `main.ts`: with no `base` it defaults to the repository's `default_branch` (`main`), while `head` comes from `github.ref` (also `main`), so `isBaseSameAsHead` holds and `baseSha` becomes the push event's own `before`:

```ts
const isBaseSameAsHead = base === head
if (isBaseSha || isBaseSameAsHead) {
  const baseSha = isBaseSha ? base : beforeSha
  if (!baseSha) { … return await git.getChangesInLastCommit() }
  …
  return await git.getChanges(baseSha, head)
}
```

`git diff <before>..<head>` is the **whole pushed range** — exactly what the hand-written classifier did. The `getChangesInLastCommit()` branch the finding describes needs `beforeSha` to be falsy, which a `push` payload never is.

Confirmed empirically in the first push run after the switch ([34420710819](https://github.com/zernie/vigiles/actions/runs/34420710819)):

```
Changes will be detected between 236615e978db6d486efe2bcfd38720aa168ee519 and main
git diff --no-renames --name-status -z 236615e97…..refs/remotes/origin/main
Detected 5 changed files
```

where `236615e97` is that push's `before`. The same log shows it `git fetch --depth=1` that SHA on demand, which is why the shallow default checkout is enough.

The derivation is written into the workflow comment, not just this PR — the reasoning is what stops the next reader re-deriving it.

## Gates

| gate | result |
| --- | --- |
| `npm run check` | ✅ 18/18 |
| `npm run coverage` | ✅ 3976 passed, 0 failed |

The 99.94% statement gate fails locally on `src/mock-model.ts:147,339,374` — untouched here, green on CI (25 tests skip locally and never reach those lines).

`main` is green as of 34420710819.

🤖 Generated with [Claude Code](https://claude.com/claude-code)