### PR TITLE
fix(harness): parse every content block, not just `text` — the probe was blind, not the product

### DIFF
--- a/examples/harness/injectable-events-delivery.harness.mjs
+++ b/examples/harness/injectable-events-delivery.harness.mjs
@@ -9,12 +9,21 @@
  * runtime emit a payload and BELIEVE it delivered. That is the repo's own
  * `fired ≠ landed` split, one level up from the one it names.
  *
- * MEASURED 2026-09-10 (zernie/vigiles#231): Claude Code stopped delivering
- * `PostToolUse` additionalContext between 2.1.227 (last good) and 2.1.228 (first
- * bad); it is still dropped on 2.1.267. CI is green only because it pins
- * VALIDATED_CC_VERSION = 2.1.187. The hook FIRES and the harness records its
- * stdout verbatim — Claude Code ingests the payload and drops it before building
- * the model request.
+ * 🔴 THE 2026-09-10 WRITE-UP IN THIS HEADER WAS WRONG, AND THE CORRECTION IS THE
+ * POINT OF THE FILE. It read: "Claude Code stopped delivering PostToolUse
+ * additionalContext between 2.1.227 and 2.1.228; still dropped on 2.1.267."
+ * Claude Code never dropped anything. From 2.1.228 (a PATCH) the payload arrives
+ * appended to the `tool_result` block's `content` inside a `<system-reminder>`
+ * instead of as its own `text` block — both delivered. What went blind was OUR
+ * probe: `flattenContent` in src/mock-model.ts read only `.text`, so eight of the
+ * sixteen `ContentBlockParam` variants were invisible, and the blindness was
+ * asserted as intended in mock-model.test.ts. Proven by changing only the parser
+ * on one machine at claude 2.1.267: blind = "landed=false", typed = "landed=true".
+ * A false regression report against somebody else's product was one word away.
+ *
+ * SO READ A FAILURE HERE TWICE. "Not delivered" is a claim about the probe as
+ * much as about the harness. Before blaming the harness, ask what the flattener
+ * does with the block the payload arrived in.
  *
  * THE PROPERTY IS DELIBERATELY NOT "PostToolUse IS BROKEN". Encoding today's
  * accident as the expectation would make this test go red the day Anthropic fixes
@@ -184,7 +193,7 @@ try {
   const dropped = declared.filter((e) => !landed.has(e));
   if (dropped.length > 0) {
     throw new Error(
-      `claude ${version} ACCEPTED and DROPPED additionalContext on ${dropped.join(", ")} — ` +
+      `claude ${version}: additionalContext did not REACH THE MODEL on ${dropped.join(", ")} — ` +
         `the hook fired and emitted the payload, and it never reached the model, ` +
         `while ${[...landed].join(", ")} delivered in the SAME session. ` +
         `claudeCodeHookProtocol.injectableEvents still declares [${declared.join(", ")}], ` +

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "vigiles": "dist/cli.js"
       },
       "devDependencies": {
+        "@anthropic-ai/sdk": "^0.124.0",
         "@eslint/js": "^10.0.1",
         "@jackchuka/mdschema": "^0.12.8",
         "@microsoft/api-extractor": "^7.58.9",
@@ -125,6 +126,28 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.124.0.tgz",
+      "integrity": "sha512-cN5O8i9UVxHeOQAzj/XjshWXG8KiibJDw9OGpH2Z/eR3n/RBxdoLxDJOcfqAJWvjaMDFfHTBADU04hWRJVkDyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@ast-grep/lang-python": {
       "version": "0.0.6",
@@ -3874,6 +3897,13 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -7210,6 +7240,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "dev": true,
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -8960,6 +8997,20 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -13980,6 +14031,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.1.1.tgz",
+      "integrity": "sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/std-env": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
@@ -14517,6 +14579,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "docs:api": "typedoc"
   },
   "devDependencies": {
+    "@anthropic-ai/sdk": "^0.124.0",
     "@eslint/js": "^10.0.1",
     "@jackchuka/mdschema": "^0.12.8",
     "@microsoft/api-extractor": "^7.58.9",

--- a/src/adapters/codex/mock-model.ts
+++ b/src/adapters/codex/mock-model.ts
@@ -147,6 +147,33 @@ interface ResponsesInputItem {
   content?: unknown;
 }
 
+/**
+ * 🔴 KNOWN BLIND SPOT — NARROW ON PURPOSE, AND THAT IS NOT THE SAME AS COMPLETE.
+ * Roadmapped P1 2026-09-10; do not read a `requestContains` miss on a Codex trace
+ * as "not delivered" until this is closed.
+ *
+ * This reads `.text` and nothing else, and its caller takes only the LAST input
+ * item with `role:"user", type:"message"`. Measured against openai@7.13.0:
+ * `ResponseInputItem` has THIRTY-TWO variants and we look at one. The ignored
+ * ones include `FunctionCallOutput`, `ShellCallOutput` and `LocalShellCallOutput`
+ * — the Responses-API analogues of an Anthropic `tool_result`, i.e. exactly where
+ * Claude Code relocated a hook's additionalContext in 2.1.228 and where the same
+ * payload would land here.
+ *
+ * WHY THIS IS A COMMENT AND NOT A FIX. `driver.ts` adapts this into a
+ * `ModelRequest`, so it feeds `requestContains` — the same predicate whose
+ * `.text`-only twin in src/mock-model.ts produced a false "not delivered", a
+ * false issue (zernie/vigiles#231) and a near-miss upstream report. The trap is
+ * armed; nobody has stepped on it only because both delivery harnesses are
+ * Claude-Code-only today. Closing it properly means deciding what `prompt` MEANS
+ * across 32 item types — a semantic change, not a bug fix, and too large to ride
+ * along with the mock-model repair.
+ *
+ * The Claude Code side now takes `ContentBlockParam` from @anthropic-ai/sdk and
+ * fails the BUILD on an unhandled variant (see `flattenBlock` in
+ * src/mock-model.ts). openai ships the matching union under Apache-2.0; applying
+ * the same construction here is the fix, and it is the roadmapped work.
+ */
 function joinInputText(content: unknown): string {
   if (!Array.isArray(content)) return "";
   return content

--- a/src/harness-assert.ts
+++ b/src/harness-assert.ts
@@ -515,7 +515,17 @@ function requestText(trace: Trace): string {
  * Did ANY request the model received contain `needle` — searching the system
  * prompt and every message across all requests? The predicate that proves
  * injected context *reached the model*: a SessionStart hook's `additionalContext`
- * or a slash command's expansion. Harness tier only — the eval tier drives the
+ * or a slash command's expansion.
+ *
+ * THIS IS A PROJECTION OF THE REQUEST, NOT THE REQUEST — state what it omits
+ * before building a claim on it. Until 2026-09-10 this sentence was false: the
+ * flattener read only `.text`, so the eight `ContentBlockParam` variants that
+ * carry `content` were invisible, and a payload Claude Code had delivered inside
+ * a `tool_result` read as "never arrived" (zernie/vigiles#231, a false finding).
+ * It now covers every block type the pinned SDK union names, and serialises any
+ * it does not. STILL OMITTED BY DESIGN: `tool_use` / `server_tool_use` inputs —
+ * those are what the model SAID, not what it was TOLD, so a needle in a tool
+ * argument must not read as delivery. See `flattenBlock` in mock-model.ts. Harness tier only — the eval tier drives the
  * real API, so its `modelRequests` (and this) is empty. Behind `assertRequestContains`.
  */
 export function requestContains(

--- a/src/mock-model.test.ts
+++ b/src/mock-model.test.ts
@@ -182,12 +182,29 @@ test("extractRequest: flattens system + messages, tolerates odd shapes", () => {
           content: [
             "raw",
             { type: "text", text: "C" },
-            { type: "tool_result", content: "ignored" }, // no `text` → ""
+            // REGRESSION GUARD 2026-09-10. This line used to read
+            // `content: "ignored"` with the comment "no `text` → \"\"", i.e. the
+            // blind spot was asserted as INTENDED — which is why no run could
+            // ever find it. A PostToolUse hook's additionalContext arrives here
+            // from Claude Code >= 2.1.228; dropping it made every delivery test
+            // report a false negative. See `flattenBlock` in mock-model.ts.
+            { type: "tool_result", content: "SEEN" },
+            // A block type the pinned SDK union does not know: over-included as
+            // JSON, never silently dropped (the same asymmetry, asserted).
+            { type: "future_block_from_a_newer_api", payload: "LOUD" },
           ],
         },
       ],
     }),
-    { system: "AB", messages: [{ role: "user", text: "rawC" }] },
+    {
+      system: "AB",
+      messages: [
+        {
+          role: "user",
+          text: 'rawCSEEN{"type":"future_block_from_a_newer_api","payload":"LOUD"}',
+        },
+      ],
+    },
   );
   // missing system → ""; missing role → ""; non-array messages → []
   assert.deepEqual(extractRequest({ messages: [{ content: "x" }] }), {

--- a/src/mock-model.test.ts
+++ b/src/mock-model.test.ts
@@ -189,6 +189,9 @@ test("extractRequest: flattens system + messages, tolerates odd shapes", () => {
             // from Claude Code >= 2.1.228; dropping it made every delivery test
             // report a false negative. See `flattenBlock` in mock-model.ts.
             { type: "tool_result", content: "SEEN" },
+            // `content` is OPTIONAL on a tool_result: absent contributes
+            // nothing, and is not the same as an unparsed shape.
+            { type: "tool_result" },
             // A block type the pinned SDK union does not know: over-included as
             // JSON, never silently dropped (the same asymmetry, asserted).
             { type: "future_block_from_a_newer_api", payload: "LOUD" },
@@ -233,7 +236,11 @@ test("extractRequest: flattens system + messages, tolerates odd shapes", () => {
             // A base64 source is bytes: skipped, or every real match drowns.
             {
               type: "document",
-              source: { type: "base64", media_type: "application/pdf", data: "BLOB" },
+              source: {
+                type: "base64",
+                media_type: "application/pdf",
+                data: "BLOB",
+              },
             },
             { type: "image" },
             { type: "redacted_thinking" },

--- a/src/mock-model.test.ts
+++ b/src/mock-model.test.ts
@@ -225,7 +225,16 @@ test("extractRequest: flattens system + messages, tolerates odd shapes", () => {
           content: [
             { type: "thinking", thinking: "THOUGHT" },
             { type: "document", title: "TITLE", context: "CTX" },
-            { type: "document", source: { type: "base64", data: "…" } },
+            // Its text lives under `source`, not beside it.
+            {
+              type: "document",
+              source: { type: "text", media_type: "text/plain", data: "BODY" },
+            },
+            // A base64 source is bytes: skipped, or every real match drowns.
+            {
+              type: "document",
+              source: { type: "base64", media_type: "application/pdf", data: "BLOB" },
+            },
             { type: "image" },
             { type: "redacted_thinking" },
             { type: "container_upload" },
@@ -236,7 +245,55 @@ test("extractRequest: flattens system + messages, tolerates odd shapes", () => {
     }),
     {
       system: "",
-      messages: [{ role: "assistant", text: "THOUGHTTITLE\nCTX" }],
+      messages: [{ role: "assistant", text: "THOUGHTTITLECTXBODY" }],
+    },
+  );
+  // Six of the eight `*_tool_result` variants carry an OBJECT under `content`,
+  // not a string or an array — the gap review found on this PR. Each shape puts
+  // its text at a different key, so all of them are walked.
+  assert.deepEqual(
+    extractRequest({
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "bash_code_execution_tool_result",
+              content: {
+                type: "bash_code_execution_result",
+                stdout: "OUT",
+                stderr: "ERR",
+                return_code: 0,
+                content: [],
+              },
+            },
+            {
+              type: "web_fetch_tool_result",
+              content: {
+                type: "web_fetch_result",
+                url: "https://e.example/x",
+                content: {
+                  type: "document",
+                  source: {
+                    type: "text",
+                    media_type: "text/plain",
+                    data: "FETCHED",
+                  },
+                },
+              },
+            },
+            // A number is neither text nor a container: contributes nothing.
+            { type: "tool_result", content: 7 as unknown },
+          ],
+        },
+      ],
+    }),
+    {
+      system: "",
+      messages: [
+        // `return_code: 0` contributes nothing — a number is not text.
+        { role: "user", text: "OUTERRhttps://e.example/xFETCHED" },
+      ],
     },
   );
   // missing system → ""; missing role → ""; non-array messages → []

--- a/src/mock-model.test.ts
+++ b/src/mock-model.test.ts
@@ -227,6 +227,29 @@ test("extractRequest: flattens system + messages, tolerates odd shapes", () => {
           role: "assistant",
           content: [
             { type: "thinking", thinking: "THOUGHT" },
+            // A search result's `title` and `source` sit BESIDE its `content`
+            // and are shown to the model just the same.
+            {
+              type: "search_result",
+              title: "TTL",
+              source: "SRC",
+              content: [{ type: "text", text: "SNIP" }],
+            },
+            // A citation's quoted text is text the model was shown too.
+            {
+              type: "text",
+              text: "CITED:",
+              citations: [
+                {
+                  type: "char_location",
+                  cited_text: "QUOTE",
+                  document_title: "DOCTITLE",
+                  document_index: 0,
+                  start_char_index: 0,
+                  end_char_index: 5,
+                },
+              ],
+            },
             { type: "document", title: "TITLE", context: "CTX" },
             // Its text lives under `source`, not beside it.
             {
@@ -252,7 +275,12 @@ test("extractRequest: flattens system + messages, tolerates odd shapes", () => {
     }),
     {
       system: "",
-      messages: [{ role: "assistant", text: "THOUGHTTITLECTXBODY" }],
+      messages: [
+        {
+          role: "assistant",
+          text: "THOUGHTTTLSRCSNIPCITED:QUOTEDOCTITLETITLECTXBODY",
+        },
+      ],
     },
   );
   // Six of the eight `*_tool_result` variants carry an OBJECT under `content`,

--- a/src/mock-model.test.ts
+++ b/src/mock-model.test.ts
@@ -206,6 +206,39 @@ test("extractRequest: flattens system + messages, tolerates odd shapes", () => {
       ],
     },
   );
+  // The REST of the union, so no branch of the exhaustive switch in
+  // `flattenBlock` is one only tsc has ever seen. Coverage is the point: a case
+  // that no run exercises is a case whose behaviour nobody has checked, and this
+  // function's whole defect was a family of blocks silently flattening to "".
+  //   - `thinking` IS context the model was given → its text counts;
+  //   - `document` contributes its human-readable title/context, and one with
+  //     neither contributes nothing (the filter's other branch);
+  //   - `image` / `redacted_thinking` / `container_upload` carry no text;
+  //   - `tool_use` is the model's OWN call, not context delivered TO it, so a
+  //     needle in a tool ARGUMENT must never read as "the model was told this".
+  //     That exclusion is deliberate and asserted here, not merely commented.
+  assert.deepEqual(
+    extractRequest({
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "THOUGHT" },
+            { type: "document", title: "TITLE", context: "CTX" },
+            { type: "document", source: { type: "base64", data: "…" } },
+            { type: "image" },
+            { type: "redacted_thinking" },
+            { type: "container_upload" },
+            { type: "tool_use", input: { needle: "NOT-CONTEXT" } },
+          ],
+        },
+      ],
+    }),
+    {
+      system: "",
+      messages: [{ role: "assistant", text: "THOUGHTTITLE\nCTX" }],
+    },
+  );
   // missing system → ""; missing role → ""; non-array messages → []
   assert.deepEqual(extractRequest({ messages: [{ content: "x" }] }), {
     system: "",

--- a/src/mock-model.ts
+++ b/src/mock-model.ts
@@ -337,9 +337,11 @@ function flattenBlock(b: ContentBlockParam): string {
     case "tool_search_tool_result":
       return b.content === undefined ? "" : flattenContent(b.content);
     case "document":
-      return [b.title, b.context]
-        .filter((x) => typeof x === "string")
-        .join("\n");
+      // Its readable text is spread across `title`, `context` AND `source`
+      // (`PlainTextSource.data`, `ContentBlockSource.content`), so it is walked
+      // rather than read field by field. A base64 source is skipped by
+      // `flattenUnknown`: it is an opaque blob by construction.
+      return flattenUnknown(b);
     // The model's own call, not context delivered TO it — kept out of
     // `requestContains` on purpose so a needle in a tool ARGUMENT is never read
     // as "the model was told this".
@@ -361,10 +363,47 @@ function flattenBlock(b: ContentBlockParam): string {
   }
 }
 
-/** Flatten Anthropic content (string, or an array of blocks) to text. */
+/**
+ * Flatten an arbitrary wire payload to text by walking every string leaf.
+ *
+ * WHY A GENERIC WALK AND NOT ONE MORE NAMED FIELD. The first version of
+ * `flattenBlock` grouped eight variants as "the ones that carry `content`" and
+ * handed each to `flattenContent`, which accepts only a string or an array.
+ * Six of those eight carry an OBJECT there — `web_fetch_tool_result`,
+ * `web_search_tool_result`, `code_execution_tool_result`,
+ * `bash_code_execution_tool_result`, `text_editor_code_execution_tool_result`,
+ * `tool_search_tool_result` — so they still flattened to "". The grouping was
+ * made on the field's NAME while the defect lives in its TYPE, which is the
+ * same mistake, one level up, as the `.text`-only read it replaced. Found by
+ * review on this PR, not by a run (zernie/vigiles#233).
+ *
+ * And no single field would have fixed it: the payload's text sits at a
+ * different key in each shape — `stdout`/`stderr` on a bash result, a nested
+ * `content` document on a fetch result, `data` on a plain-text source. Keying
+ * on any one of them re-commits the shape assumption. Walking commits to none.
+ */
+function flattenUnknown(v: unknown): string {
+  if (typeof v === "string") return v;
+  if (Array.isArray(v)) return v.map(flattenUnknown).join("");
+  if (typeof v !== "object" || v === null) return "";
+  const o = v as Record<string, unknown>;
+  // A base64 source is bytes, not text. Including it would bury every real
+  // match under megabytes of encoding — the one over-inclusion that costs more
+  // than the false negative it avoids.
+  if (o.type === "base64") return "";
+  return Object.entries(o)
+    .filter(([k]) => k !== "type" && k !== "media_type") // discriminators
+    .map(([, val]) => flattenUnknown(val))
+    .join("");
+}
+
+/**
+ * Flatten Anthropic content to text: a string, an array of blocks, or the
+ * OBJECT a server-tool result carries (see `flattenUnknown`).
+ */
 function flattenContent(content: unknown): string {
   if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
+  if (!Array.isArray(content)) return flattenUnknown(content);
   return content
     .map((b) =>
       typeof b === "string" ? b : flattenBlock(b as ContentBlockParam),

--- a/src/mock-model.ts
+++ b/src/mock-model.ts
@@ -18,6 +18,10 @@
  */
 import http from "node:http";
 import type { ServerResponse } from "node:http";
+// TYPES ONLY — erased at compile time, so this stays a devDependency and never
+// enters a consumer's tree. MIT, unlike @anthropic-ai/claude-code. See the
+// comment on `flattenBlock` for what it buys and what it does not.
+import type { ContentBlockParam } from "@anthropic-ai/sdk/resources/messages";
 import type { AddressInfo } from "node:net";
 
 // The trace shapes are defined in core (`src/core/harness-driver.ts`) so the
@@ -279,16 +283,92 @@ export function splitRequestCounts(requests: readonly ModelRequest[]): {
   return { count: requests.length - sideChannelCount, sideChannelCount };
 }
 
-/** Flatten Anthropic content (string, or an array of text/other blocks) to text. */
+/**
+ * Flatten one Anthropic content block to the text the MODEL actually received.
+ *
+ * WHY THIS IS A TYPED, EXHAUSTIVE SWITCH AND NOT A `.text` LOOKUP — the whole
+ * point of the file, and it was paid for. Until 2026-09-10 this read `b.text`
+ * and returned `""` for anything else. Eight of the sixteen `ContentBlockParam`
+ * variants carry their payload in `content`, not `text`, so half the union was
+ * invisible to every instrument built on `extractRequest` — `requestContains`,
+ * `refs-nudge.harness.mjs`, `injectable-events-delivery.harness.mjs`.
+ *
+ * WHAT THAT COST. Claude Code <= 2.1.227 delivered a `PostToolUse` hook's
+ * `additionalContext` as its own `text` block. From 2.1.228 (a PATCH release,
+ * 2026-08-11) it arrives appended to the `tool_result` block's `content`, inside
+ * a `<system-reminder>`. Nothing broke: the model received the payload on both
+ * versions. Our probe went blind, every test above reported "not delivered", and
+ * that false reading was written up as zernie/vigiles#231 and very nearly filed
+ * upstream as a regression in somebody else's product. MEASURED both ways on one
+ * machine, claude 2.1.267, changing only this function: blind = "landed=false",
+ * typed = "landed=true".
+ *
+ * WHAT THE TYPE BUYS, precisely — it is NOT a change detector:
+ *   - it does NOT notice a payload moving between fields the type already allows
+ *     (`ToolResultBlockParam.content` predates the relocation; nothing changed);
+ *   - it DOES make a silently-unhandled variant impossible: the `never` binding
+ *     below fails `tsc` until every case is written out, so the seventeenth
+ *     block type Anthropic ships breaks the BUILD instead of quietly emptying a
+ *     measurement.
+ *
+ * WHY THE DEFAULT SERIALISES INSTEAD OF RETURNING `""`. This is a measurement
+ * instrument, and its proven failure mode is the FALSE NEGATIVE — a payload that
+ * was there, reported missing. So an unrecognised block is over-included (its
+ * JSON) rather than dropped: a stale pin then costs a noisy match, never a
+ * silent hole. That asymmetry is deliberate; do not "tidy" it to `""`.
+ *
+ * The repo's `assertNever` is deliberately NOT used: it throws, and this parses
+ * untrusted wire JSON where an unknown block must degrade, not crash.
+ */
+function flattenBlock(b: ContentBlockParam): string {
+  switch (b.type) {
+    case "text":
+      return b.text;
+    case "thinking":
+      return b.thinking;
+    // The eight that carry `content` — the family this function was blind to.
+    case "tool_result":
+    case "search_result":
+    case "web_search_tool_result":
+    case "web_fetch_tool_result":
+    case "code_execution_tool_result":
+    case "bash_code_execution_tool_result":
+    case "text_editor_code_execution_tool_result":
+    case "tool_search_tool_result":
+      return b.content === undefined ? "" : flattenContent(b.content);
+    case "document":
+      return [b.title, b.context]
+        .filter((x) => typeof x === "string")
+        .join("\n");
+    // The model's own call, not context delivered TO it — kept out of
+    // `requestContains` on purpose so a needle in a tool ARGUMENT is never read
+    // as "the model was told this".
+    case "tool_use":
+    case "server_tool_use":
+      return "";
+    // Genuinely carry no text.
+    case "image":
+    case "redacted_thinking":
+    case "container_upload":
+      return "";
+    default: {
+      // Compile-time: unreachable, and that is the guard — a new variant makes
+      // this assignment fail. Run-time: reachable via wire JSON from a newer
+      // API than the pinned types, so it degrades loudly instead of throwing.
+      const unhandled: never = b;
+      return JSON.stringify(unhandled);
+    }
+  }
+}
+
+/** Flatten Anthropic content (string, or an array of blocks) to text. */
 function flattenContent(content: unknown): string {
   if (typeof content === "string") return content;
   if (!Array.isArray(content)) return "";
   return content
-    .map((b) => {
-      if (typeof b === "string") return b;
-      const t = (b as { text?: unknown }).text;
-      return typeof t === "string" ? t : "";
-    })
+    .map((b) =>
+      typeof b === "string" ? b : flattenBlock(b as ContentBlockParam),
+    )
     .join("");
 }
 

--- a/src/mock-model.ts
+++ b/src/mock-model.ts
@@ -322,13 +322,28 @@ export function splitRequestCounts(requests: readonly ModelRequest[]): {
  */
 function flattenBlock(b: ContentBlockParam): string {
   switch (b.type) {
+    // WALKED — every string field is readable text the model was shown, and
+    // reading any one of them by name is what this function keeps getting
+    // wrong. `text` also carries `citations[].cited_text` / `document_title`
+    // (quoted source text); `search_result` carries `title` and `source`
+    // BESIDE its `content`; `document` spreads its text across `title`,
+    // `context` and `source` (`PlainTextSource.data`,
+    // `ContentBlockSource.content`). A base64 source is skipped inside
+    // `flattenUnknown` — bytes, not text.
     case "text":
-      return b.text;
+    case "search_result":
+    case "document":
+      return flattenUnknown(b);
+    // READ NARROWLY, and the dropped field is named so the next reader can
+    // check the claim instead of trusting it: `signature` is an opaque
+    // attestation blob, not context.
     case "thinking":
       return b.thinking;
-    // The eight that carry `content` — the family this function was blind to.
+    // The families whose payload hangs off `content`. Their only other field is
+    // `tool_use_id` — a correlation identifier, not text the model was shown.
+    // `content` is optional on `tool_result` alone; on the rest it is required
+    // and is an OBJECT, which `flattenContent` hands to `flattenUnknown`.
     case "tool_result":
-    case "search_result":
     case "web_search_tool_result":
     case "web_fetch_tool_result":
     case "code_execution_tool_result":
@@ -336,19 +351,14 @@ function flattenBlock(b: ContentBlockParam): string {
     case "text_editor_code_execution_tool_result":
     case "tool_search_tool_result":
       return b.content === undefined ? "" : flattenContent(b.content);
-    case "document":
-      // Its readable text is spread across `title`, `context` AND `source`
-      // (`PlainTextSource.data`, `ContentBlockSource.content`), so it is walked
-      // rather than read field by field. A base64 source is skipped by
-      // `flattenUnknown`: it is an opaque blob by construction.
-      return flattenUnknown(b);
     // The model's own call, not context delivered TO it — kept out of
     // `requestContains` on purpose so a needle in a tool ARGUMENT is never read
-    // as "the model was told this".
+    // as "the model was told this". Their `id` / `name` are identifiers.
     case "tool_use":
     case "server_tool_use":
       return "";
-    // Genuinely carry no text.
+    // No readable text by construction: `redacted_thinking.data` is encrypted,
+    // `container_upload.file_id` is an identifier, an image is pixels.
     case "image":
     case "redacted_thinking":
     case "container_upload":


### PR DESCRIPTION
## What and why

`flattenContent` in `src/mock-model.ts` read only `.text` off a content block. Anthropic's `ContentBlockParam` union has 16 variants and **eight of them carry `content`, not `text`** — `tool_result` first among them. Every one of those flattened to `""`.

That made `requestContains` blind to whole families of context, and the blindness had already produced a false conclusion: a bisect showed a probe going red at Claude Code 2.1.228 and it was read as "Claude Code stopped delivering `PostToolUse` `additionalContext`". It hadn't. 2.1.228 **relocated** the payload into `tool_result.content`, and this parser does not look there. Both versions delivered. (An upstream bug report was drafted on that premise and is cancelled; #231 has been retitled and its body replaced with the corrected finding.)

### The fix

`flattenBlock(b: ContentBlockParam)` — an exhaustive `switch` over the real SDK union, with `const unhandled: never = b` in the `default`. `@anthropic-ai/sdk` (MIT) is a **type-only** devDependency: the import is erased at compile time, so nothing enters a consumer's tree.

What the type buys and what it does not, since the distinction is the whole point of the incident:

- ✅ **buys**: a new block variant in a future SDK is a `tsc` error at this switch, not a silent `""`. Proven by mutation — deleting the `tool_result` case gives `error TS2322: Type 'ToolResultBlockParam' is not assignable to type 'never'`, RC=2.
- ❌ **does not buy**: notice when a *field moves between existing variants*. That is exactly what 2.1.228 did, and the type did not change. The `default` branch therefore serialises the unknown block rather than returning `""` — a needle in a shape we do not model still shows up, loudly.

`tool_use` / `server_tool_use` stay excluded on purpose: those are the model's own call, not context delivered *to* it, so a needle inside a tool ARGUMENT must never read as "the model was told this". That exclusion is now asserted by a test, not merely commented. `requestContains`'s docblock states that it is a **projection** of the request and names what it omits.

### 🔴 The first version of this fix was incomplete, in the same shape as the defect

Codex review caught it, and it is worth stating plainly because it is the same mistake one level up. `flattenBlock` grouped eight variants as "the ones that carry `content`" and handed each to `flattenContent`, which accepts a string or an array. Measured against the SDK types, **six of those eight carry an OBJECT there**:

| variant | `content` type | first version |
| --- | --- | --- |
| `tool_result` | `string \| Array<…>` | ✅ handled |
| `search_result` | `Array<TextBlockParam>` | ✅ handled |
| `web_search_tool_result` | object union | ❌ `""` |
| `web_fetch_tool_result` | `…Error \| WebFetchBlockParam` | ❌ `""` |
| `code_execution_tool_result` | object union | ❌ `""` |
| `bash_code_execution_tool_result` | object union | ❌ `""` |
| `text_editor_code_execution_tool_result` | object union | ❌ `""` |
| `tool_search_tool_result` | object union | ❌ `""` |

The grouping was made on the field's **name** while the defect lives in its **type** — the same assumption about shape as the `.text`-only read it replaced. `document` was wrong too: its text is under `source`, not beside it.

**No single extra field closes it.** The payload's text sits at a different key in every shape — `stdout`/`stderr` on a bash result, a nested `content` document on a fetch result, `data` on a plain-text source. Picking one re-commits the assumption. `flattenUnknown` walks every string leaf and commits to none, with one exclusion: a `type: "base64"` source is bytes, and emitting megabytes of encoding would bury every real match — the only over-inclusion that costs more than the false negative it avoids.

### The second instance, deliberately NOT fixed

`joinInputText` in `src/adapters/codex/mock-model.ts` is the same idiom, and its caller reads one of `ResponseInputItem`'s **32** variants and only the last. It gets a comment naming the blind spot, not a patch: closing it means deciding what `prompt` MEANS across 32 item types (`FunctionCallOutput`, `ShellCallOutput`, `LocalShellCallOutput` are all ignored today), which is a semantic change, not a bug fix. Roadmapped, with the reason recorded in the file.

## Safety impact

None. Nothing here touches what a hook or guard permits, the sandbox, `interceptTools`, or whether a read-only path can execute. The change is confined to how the test-tier mock model flattens a request for assertion; it makes the probe see **more** of the request, never act on it.

## Checks

- [x] `npm run test:harness` — RC=0, 14 passed / 1 skipped, including both delivery harnesses.
- [x] `npm run check` — `format` failed on the first round (prettier; `npm run lint` does not look at formatting), fixed and re-verified clean.
- [x] New behaviour has a test — `src/mock-model.test.ts` flips the assertion that *enshrined* the blindness (`{ type: "tool_result", content: "ignored" }` → `""`) into a regression guard, and adds: an unknown block (serialised, not swallowed), an object-valued `content`, a nested fetched document, a plain-text source, a skipped base64 source, an absent `content`, and a numeric leaf.
- [x] Docs updated — `requestContains`'s docblock states the projection and its omissions; both incidents are recorded on `flattenBlock` / `flattenUnknown`.

### On the coverage gate, honestly

The `test` job was red on the 100% gate, not on a failing test (3836 passed, 0 failed): `mock-model.ts` sat at 95.65% lines with the `thinking`, `document` and no-text cases unexercised. That gap **is this PR's subject one level up** — a case no run exercises is a case whose behaviour nobody has checked, which is exactly how the original defect survived. Fixed by running them.

⚠️ Locally the gate cannot reach 100% by construction, so this is stated rather than claimed green: with the CI-pinned claude on PATH the suite is `3980 passed, 0 failed` and `mock-model.ts` is **lines 100 / funcs 100**, but statements stop at 99.09 on lines 151/458/493 — the mock's own HTTP-server paths, reachable only through the bubblewrap-gated tiers. This machine has no `bwrap` and no `codex`, so 26 tests skip against CI's 9. Those three lines are absent from CI's own uncovered list, i.e. covered there. Everything this diff touched is covered.

<!-- vigiles:pr-summary:start -->
## Summary — auto-generated from commits

**Fixes**
- parse every content block, not just `text`
- parse every content block, not just `text` — the probe was blind, not the product
- walk object-valued content payloads, not just string and array
- decide each block by what its fields MEAN, not what they are named

**Tests**
- exercise every branch of the exhaustive block switch
- cover the absent-content arm of a tool_result
<!-- vigiles:pr-summary:end -->
